### PR TITLE
Bugfix ktps 1929 train val split

### DIFF
--- a/openstef/model/objective.py
+++ b/openstef/model/objective.py
@@ -79,8 +79,6 @@ class RegressorObjective:
         else:
             stratification_min_max = True
         (
-            peaks,
-            peaks_val_train,
             self.train_data,
             self.validation_data,
             self.test_data,

--- a/openstef/model_selection/model_selection.py
+++ b/openstef/model_selection/model_selection.py
@@ -179,7 +179,7 @@ def split_data_train_validation_test(
         # Let's consider the 15% lowest or highest days, with a minimum
         # of two dates in the min and max list
         train_val_dates = list(set(train_val_data.index.date))
-        n_days_per_subset = int(max(0.15 * len(train_val_dates), 2))
+        n_days_per_subset = int(max(0.15 * len(set(data_.index.date)), 2))
         # Find max_dates
         max_dates = (
             train_val_data[["load"]]

--- a/openstef/model_selection/model_selection.py
+++ b/openstef/model_selection/model_selection.py
@@ -220,7 +220,9 @@ def split_data_train_validation_test(
         train_dates = []
         for date_set in [max_dates, min_dates, other_dates]:
             n_days_val = max(1, int(validation_fraction * len(date_set)))
-            val_dates += np.random.choice(list(date_set), n_days_val)
+            val_dates += list(
+                np.random.choice(list(date_set), n_days_val, replace=False)
+            )
             train_dates += [x for x in date_set if x not in val_dates]
 
         validation_data = train_val_data[np.isin(train_val_data.index.date, val_dates)]

--- a/openstef/model_selection/model_selection.py
+++ b/openstef/model_selection/model_selection.py
@@ -139,9 +139,6 @@ def split_data_train_validation_test(
             ensuring the validation set to be representative of the train set.
 
     Returns:
-        min_max_dates (List[pd.DatetimeIndex]),
-        peaks_val_train (List[List: 'peak dates in validation',
-                              List: 'peak dates in train'])
         train_data (pandas.DataFrame): Train data.
         validation_data (pandas.DataFrame): Validation data.
         test_data (pandas.DataFrame): Test data.
@@ -243,8 +240,6 @@ def split_data_train_validation_test(
     test_data = test_data.sort_index()
 
     return (
-        None,  # min_max_dates, TODO: check if this is required or we can remove this
-        None,  # peaks_val_train,
         train_data,
         validation_data,
         test_data,

--- a/openstef/model_selection/model_selection.py
+++ b/openstef/model_selection/model_selection.py
@@ -139,7 +139,9 @@ def split_data_train_validation_test(
             ensuring the validation set to be representative of the train set.
 
     Returns:
-        peak_all_days (lint:int):
+        min_max_dates (List[pd.DatetimeIndex]),
+        peaks_val_train (List[List: 'peak dates in validation',
+                              List: 'peak dates in train'])
         train_data (pandas.DataFrame): Train data.
         validation_data (pandas.DataFrame): Validation data.
         test_data (pandas.DataFrame): Test data.
@@ -175,54 +177,47 @@ def split_data_train_validation_test(
         test_data = data_[:start_date_val]
         train_val_data = data_[start_date_val:]
 
-    # For determining the min and max values for the validation and train data
-    max_per_day = (
-        train_val_data[["load"]]
-        .resample("1D")
-        .max()
-        .sort_values(by="load", ascending=True)
-        .dropna()
-    )
-    min_per_day = (
-        train_val_data[["load"]]
-        .resample("1D")
-        .min()
-        .sort_values(by="load", ascending=True)
-        .dropna()
-    )
-    # Keep the top PEAK_FRACTION (upper and lower 15%)
-    max_dates = max_per_day.iloc[int((1 - PEAK_FRACTION) * len(max_per_day)) :, :]
-    min_dates = min_per_day.iloc[: int(PEAK_FRACTION * len(min_per_day)), :]
-    # Combine the max_dates and min_dates, and make sure no duplicate indices are present
-    min_max_dates = max_dates.append(
-        min_dates[min_dates.index.isin(max_dates.index) == False]
-    )
-
-    peak_n_days = len(min_max_dates)
-
-    if peak_n_days < 3:
-        stratification_min_max = (
-            False  # stratification is not adding value in this case
+    if stratification_min_max and (len(set(train_val_data.index.date)) >= 4):
+        # First determine the dates with min and max values
+        # Let's consider the 15% lowest or highest days, with a minimum
+        # of two dates in the min and max list
+        train_val_dates = list(set(train_val_data.index.date))
+        n_days_per_subset = int(max(0.15 * len(train_val_dates), 2))
+        # Find max_dates
+        max_dates = (
+            train_val_data[["load"]]
+            .resample("1D")
+            .max()
+            .sort_values(by="load", ascending=False)
+            .dropna()
+            .index[:n_days_per_subset]
         )
-
-    peaks_val_train = [[], []]
-
-    # Sample periods in the training part as the validation set using stratification (peaks).
-    if stratification_min_max:
-        split_val = int((peak_n_days * validation_fraction) / PERIOD_TIMEDELTA)
-        # Always have at least one validation split
-        split_val = max(split_val, 1)
-        peaks_val, idx_val_split = sample_indices_train_val(
-            data_,
-            random_sample(np.array(min_max_dates.index.date), k=split_val),
+        # Find min_dates, but do not consider the max_dates
+        min_dates_subset = train_val_data.loc[
+            ~np.isin(train_val_data.index.date, max_dates), ["load"]
+        ]
+        min_dates = (
+            min_dates_subset[["load"]]
+            .resample("1D")
+            .min()
+            .sort_values(by="load", ascending=True)
+            .dropna()
+            .index[:n_days_per_subset]
         )
-        peaks_train = list(set(min_max_dates.index.date) - set(peaks_val))
-        peaks_val_train[0].append(peaks_val)
-        peaks_val_train[1].append(peaks_train)
+        other_dates = [
+            x for x in train_val_dates if x not in min_dates and x not in max_dates
+        ]
 
-        idx_train_split = list(set(train_val_data.index) - set(idx_val_split))
-        validation_data = data_[data_.index.isin(idx_val_split)]
-        train_data = data_[data_.index.isin(idx_train_split)]
+        # Divide min, max and other dates fairly over validation and train set, with at least 1 min and max in train and validation
+        val_dates = []
+        train_dates = []
+        for date_set in [max_dates, min_dates, other_dates]:
+            n_days_val = max(1, int(validation_fraction * len(date_set)))
+            val_dates += random.sample(list(date_set), n_days_val)
+            train_dates += [x for x in date_set if x not in val_dates]
+
+        validation_data = train_val_data[np.isin(train_val_data.index.date, val_dates)]
+        train_data = train_val_data[np.isin(train_val_data.index.date, train_dates)]
 
     # Default sampling, take a one single validation set.
     else:
@@ -248,8 +243,8 @@ def split_data_train_validation_test(
     test_data = test_data.sort_index()
 
     return (
-        min_max_dates,
-        peaks_val_train,
+        None,  # min_max_dates, TODO: check if this is required or we can remove this
+        None,  # peaks_val_train,
         train_data,
         validation_data,
         test_data,

--- a/openstef/model_selection/model_selection.py
+++ b/openstef/model_selection/model_selection.py
@@ -180,7 +180,9 @@ def split_data_train_validation_test(
         test_data = data_[:start_date_val]
         train_val_data = data_[start_date_val:]
 
-    if stratification_min_max and (len(set(train_val_data.index.date)) >= 4):
+    if stratification_min_max and (
+        len(set(train_val_data.index.date)) >= min_days_for_stratification
+    ):
         # First how many dates are considers min or max.
         # Note that this should be at least to, so one can go to the train set
         # and another to the testset

--- a/openstef/pipeline/train_model.py
+++ b/openstef/pipeline/train_model.py
@@ -244,13 +244,7 @@ def train_pipeline_common(
         ].sort_index()
 
     # Split data
-    (
-        peaks,
-        peaks_val_train,
-        train_data,
-        validation_data,
-        test_data,
-    ) = split_data_train_validation_test(
+    (train_data, validation_data, test_data,) = split_data_train_validation_test(
         data_with_features,
         test_fraction=test_fraction,
         stratification_min_max=stratification_min_max,

--- a/test/unit/model/test_model_selection.py
+++ b/test/unit/model/test_model_selection.py
@@ -6,6 +6,9 @@ from test.unit.utils.base import BaseTestCase
 from test.unit.utils.data import TestData
 
 import numpy as np
+import pandas as pd
+import random
+
 
 from openstef.model_selection import model_selection
 
@@ -50,15 +53,13 @@ class TestTrain(BaseTestCase):
         sampled_random = model_selection.random_sample(complete_list, n_random_samples)
         self.assertEqual(len(sampled_random), n_random_samples)
 
-    def test_split_data_train_validation_test_stratification(self):
-
-        """Test spliting data with stratification.
+    def test_split_data_train_validation(self):
+        """Test spliting data
             Test the `split_data_stratification` function and compare the proportion of the split
             of data into training, test, and validation subsets with the fractions.
 
         Raises:
             AssertionError: -
-
         """
 
         data = TestData.load("input_data_train.pickle")
@@ -79,21 +80,72 @@ class TestTrain(BaseTestCase):
         # delta = 4, when looking at the test data, can differ 1 hr (4x15min)
 
         self.assertAlmostEqual(
-            len(peaks_val_train[0][0]),
-            len(peaks) * SPLIT_PARAMS["validation_fraction"],
-            delta=1,
-        )
-        self.assertAlmostEqual(
-            len(peaks_val_train[1][0]),
-            len(peaks) * (1 - SPLIT_PARAMS["validation_fraction"]),
-            delta=1,
-        )
+            len(valid_set),
+            len(data) * SPLIT_PARAMS["validation_fraction"],
+            delta=2 * 96,
+        )  # two days is allowed
 
         self.assertAlmostEqual(
             len(test_set),
             len(data.index) * SPLIT_PARAMS["test_fraction"],
             delta=4,
         )
+
+    def test_split_data_train_validation_test_stratification(self):
+        """
+        Test that the train/validation split is stratified,
+        meaning min/max days are equally distributed in train and validation set
+        """
+        df = pd.DataFrame(
+            index=pd.date_range(
+                start="2021-01-01 00:00:00Z", freq="15T", periods=20 * 96
+            )
+        )
+        # Make dates high/low
+        # note that if this number does not match the validation_fraction,
+        # the test results are not clearly defined (other dates can be recognized as min/max dates)
+        n_days_high = 3
+        n_days_low = 3
+
+        # Specify load profile (each day is identical)
+        df["load"] = np.sin(df.reset_index().index / 96 / 2 / np.pi * 20 * 2)
+        # Randomly set max and min days
+        max_days = random.sample(list(df.index.day.unique()), n_days_high)
+        min_days = random.sample(
+            [x for x in set(df.index.day) if x not in max_days], n_days_low
+        )
+        # Either increase or decrease load on those days
+        for day in max_days:
+            df.loc[df.index.day == day, "load"] += 5
+        for day in min_days:
+            df.loc[df.index.day == day, "load"] -= 5
+
+        # Split using default arguments. Should result in stratified split
+        (
+            peaks,
+            peaks_val_train,
+            train,
+            val,
+            test,
+        ) = model_selection.split_data_train_validation_test(
+            df, test_fraction=0, stratification_min_max=True
+        )
+        # test that max and min days are both in train and val sets
+        for dayset in [max_days, min_days]:
+            for d in [train, val]:
+                n_days_in = len([date for date in set(d.index.day) if date in dayset])
+
+                # Add checkpoint, useful for debugging when things go wrong
+                if n_days_in == 0:
+                    print("Investigate this!")
+
+                assert n_days_in >= 1
+
+    def test_split_data_train_validation_test_stratification_repeat_20_times(self):
+        """Repeat the stratification test 20 times,
+        since the test using random selection and should work every time"""
+        for _ in range(20):
+            self.test_split_data_train_validation_test_stratification()
 
 
 if __name__ == "__main__":

--- a/test/unit/model/test_model_selection.py
+++ b/test/unit/model/test_model_selection.py
@@ -65,8 +65,6 @@ class TestTrain(BaseTestCase):
         data = TestData.load("input_data_train.pickle")
 
         (
-            peaks,
-            peaks_val_train,
             train_set,
             valid_set,
             test_set,
@@ -121,13 +119,7 @@ class TestTrain(BaseTestCase):
             df.loc[df.index.day == day, "load"] -= 5
 
         # Split using default arguments. Should result in stratified split
-        (
-            peaks,
-            peaks_val_train,
-            train,
-            val,
-            test,
-        ) = model_selection.split_data_train_validation_test(
+        (train, val, test,) = model_selection.split_data_train_validation_test(
             df, test_fraction=0, stratification_min_max=True
         )
         # test that max and min days are both in train and val sets

--- a/test/unit/model/test_model_selection.py
+++ b/test/unit/model/test_model_selection.py
@@ -94,6 +94,7 @@ class TestTrain(BaseTestCase):
         Test that the train/validation split is stratified,
         meaning min/max days are equally distributed in train and validation set
         """
+        # Arrange: prep inputs
         df = pd.DataFrame(
             index=pd.date_range(
                 start="2021-01-01 00:00:00Z", freq="15T", periods=20 * 96
@@ -104,7 +105,6 @@ class TestTrain(BaseTestCase):
         # the test results are not clearly defined (other dates can be recognized as min/max dates)
         n_days_high = 3
         n_days_low = 3
-
         # Specify load profile (each day is identical)
         df["load"] = np.sin(df.reset_index().index / 96 / 2 / np.pi * 20 * 2)
         # Randomly set max and min days
@@ -118,11 +118,12 @@ class TestTrain(BaseTestCase):
         for day in min_days:
             df.loc[df.index.day == day, "load"] -= 5
 
-        # Split using default arguments. Should result in stratified split
+        # Act: Split using default arguments. Should result in stratified split
         (train, val, test,) = model_selection.split_data_train_validation_test(
             df, test_fraction=0, stratification_min_max=True
         )
-        # test that max and min days are both in train and val sets
+
+        # Assert: test that max and min days are both in train and val sets
         for dayset in [max_days, min_days]:
             for d in [train, val]:
                 n_days_in = len([date for date in set(d.index.day) if date in dayset])

--- a/test/unit/model/test_model_selection.py
+++ b/test/unit/model/test_model_selection.py
@@ -21,6 +21,10 @@ SPLIT_PARAMS = {
 
 
 class TestTrain(BaseTestCase):
+    def setUp(self) -> None:
+        # seed random number generator so repeated tests yield same results
+        np.random.seed(0)
+
     def test_sample_indices_train_val(self):
         """
         Test for sampling indices from a dataset.

--- a/test/unit/pipeline/test_pipeline_train_model.py
+++ b/test/unit/pipeline/test_pipeline_train_model.py
@@ -161,8 +161,6 @@ class TestTrainModelPipeline(BaseTestCase):
 
                 # Split data
                 (
-                    _,
-                    _,
                     train_data,
                     validation_data,
                     test_data,

--- a/test/unit/pipeline/test_train.py
+++ b/test/unit/pipeline/test_train.py
@@ -50,11 +50,6 @@ class TestTrain(BaseTestCase):
 
         # delta = 1, number of the peaks the two amounts may differ for the train and validation data
         # delta = 4, when looking at the test data, can differ 1 hr (4x15min)
-
-        # Add checkpoint, useful for debugging when things go wrong
-        # if np.abs(len(valid_set) - (len(self.data_table)*SPLIT_PARAMS['validation_fraction'])) >192:
-        #     print("Investigate this!")
-
         self.assertAlmostEqual(
             len(set(valid_set.index.date)),
             len(set(self.data_table.index.date)) * SPLIT_PARAMS["validation_fraction"],

--- a/test/unit/pipeline/test_train.py
+++ b/test/unit/pipeline/test_train.py
@@ -39,13 +39,7 @@ class TestTrain(BaseTestCase):
 
         """
 
-        (
-            peaks,
-            peaks_val_train,
-            train_set,
-            valid_set,
-            test_set,
-        ) = split_data_train_validation_test(
+        (train_set, valid_set, test_set,) = split_data_train_validation_test(
             self.data_table,
             test_fraction=SPLIT_PARAMS["test_fraction"],
             validation_fraction=SPLIT_PARAMS["validation_fraction"],
@@ -57,14 +51,9 @@ class TestTrain(BaseTestCase):
         # delta = 4, when looking at the test data, can differ 1 hr (4x15min)
 
         self.assertAlmostEqual(
-            len(peaks_val_train[0][0]),
-            len(peaks) * SPLIT_PARAMS["validation_fraction"],
-            delta=1,
-        )
-        self.assertAlmostEqual(
-            len(peaks_val_train[1][0]),
-            len(peaks) * (1 - SPLIT_PARAMS["validation_fraction"]),
-            delta=1,
+            len(valid_set),
+            len(self.data_table) * SPLIT_PARAMS["validation_fraction"],
+            delta=2 * 96,
         )
 
         self.assertAlmostEqual(
@@ -83,13 +72,7 @@ class TestTrain(BaseTestCase):
 
         """
 
-        (
-            peaks,
-            peaks_val_train,
-            train_set,
-            valid_set,
-            test_set,
-        ) = split_data_train_validation_test(
+        (train_set, valid_set, test_set,) = split_data_train_validation_test(
             self.data_table,
             test_fraction=SPLIT_PARAMS["test_fraction"],
             validation_fraction=SPLIT_PARAMS["validation_fraction"],
@@ -101,14 +84,9 @@ class TestTrain(BaseTestCase):
         # delta = 4, when looking at the test data, can differ 1 hr (4x15min)
 
         self.assertAlmostEqual(
-            len(peaks_val_train[0][0]),
-            len(peaks) * SPLIT_PARAMS["validation_fraction"],
-            delta=1,
-        )
-        self.assertAlmostEqual(
-            len(peaks_val_train[1][0]),
-            len(peaks) * (1 - SPLIT_PARAMS["validation_fraction"]),
-            delta=1,
+            len(valid_set),
+            len(self.data_table) * SPLIT_PARAMS["validation_fraction"],
+            delta=2 * 96,
         )
 
         self.assertAlmostEqual(
@@ -131,13 +109,7 @@ class TestTrain(BaseTestCase):
             SPLIT_PARAMS["test_fraction"] + SPLIT_PARAMS["validation_fraction"]
         )
 
-        (
-            peaks,
-            peaks_val_train,
-            train_set,
-            valid_set,
-            test_set,
-        ) = split_data_train_validation_test(
+        (train_set, valid_set, test_set,) = split_data_train_validation_test(
             self.data_table,
             test_fraction=SPLIT_PARAMS["test_fraction"],
             validation_fraction=SPLIT_PARAMS["validation_fraction"],
@@ -177,13 +149,7 @@ class TestTrain(BaseTestCase):
             SPLIT_PARAMS["test_fraction"] + SPLIT_PARAMS["validation_fraction"]
         )
 
-        (
-            peaks,
-            peaks_val_train,
-            train_set,
-            valid_set,
-            test_set,
-        ) = split_data_train_validation_test(
+        (train_set, valid_set, test_set,) = split_data_train_validation_test(
             self.data_table,
             test_fraction=SPLIT_PARAMS["test_fraction"],
             validation_fraction=SPLIT_PARAMS["validation_fraction"],

--- a/test/unit/pipeline/test_train.py
+++ b/test/unit/pipeline/test_train.py
@@ -29,6 +29,8 @@ class TestTrain(BaseTestCase):
         self.data = pd.DataFrame(
             index=pd.date_range(datetime_start, datetime_end, freq="15T")
         )
+        # seed random number generator so repeated tests yield same results
+        np.random.seed(0)
 
     def test_split_data_train_validation_test_stratification_no_backtest(self):
         """Test spliting data with stratification.

--- a/test/unit/pipeline/test_train.py
+++ b/test/unit/pipeline/test_train.py
@@ -7,6 +7,7 @@ from test.unit.utils.base import BaseTestCase
 from test.unit.utils.data import TestData
 
 import pandas as pd
+import numpy as np
 
 from openstef.pipeline.train_model import split_data_train_validation_test
 
@@ -50,10 +51,14 @@ class TestTrain(BaseTestCase):
         # delta = 1, number of the peaks the two amounts may differ for the train and validation data
         # delta = 4, when looking at the test data, can differ 1 hr (4x15min)
 
+        # Add checkpoint, useful for debugging when things go wrong
+        # if np.abs(len(valid_set) - (len(self.data_table)*SPLIT_PARAMS['validation_fraction'])) >192:
+        #     print("Investigate this!")
+
         self.assertAlmostEqual(
-            len(valid_set),
-            len(self.data_table) * SPLIT_PARAMS["validation_fraction"],
-            delta=2 * 96,
+            len(set(valid_set.index.date)),
+            len(set(self.data_table.index.date)) * SPLIT_PARAMS["validation_fraction"],
+            delta=2,
         )
 
         self.assertAlmostEqual(
@@ -84,9 +89,9 @@ class TestTrain(BaseTestCase):
         # delta = 4, when looking at the test data, can differ 1 hr (4x15min)
 
         self.assertAlmostEqual(
-            len(valid_set),
-            len(self.data_table) * SPLIT_PARAMS["validation_fraction"],
-            delta=2 * 96,
+            len(set(valid_set.index.date)),
+            len(set(self.data_table.index.date)) * SPLIT_PARAMS["validation_fraction"],
+            delta=2,
         )
 
         self.assertAlmostEqual(
@@ -125,9 +130,9 @@ class TestTrain(BaseTestCase):
             delta=4,
         )
         self.assertAlmostEqual(
-            len(valid_set),
-            len(self.data_table.index) * SPLIT_PARAMS["validation_fraction"],
-            delta=4,
+            len(set(valid_set.index.date)),
+            len(set(self.data_table.index.date)) * SPLIT_PARAMS["validation_fraction"],
+            delta=2,
         )
         self.assertAlmostEqual(
             len(train_set),
@@ -165,9 +170,9 @@ class TestTrain(BaseTestCase):
             delta=4,
         )
         self.assertAlmostEqual(
-            len(valid_set),
-            len(self.data_table.index) * SPLIT_PARAMS["validation_fraction"],
-            delta=4,
+            len(set(valid_set.index.date)),
+            len(set(self.data_table.index.date)) * SPLIT_PARAMS["validation_fraction"],
+            delta=2,
         )
         self.assertAlmostEqual(
             len(train_set),


### PR DESCRIPTION
Improves stratification of train and validation set.
Before: [min_peaks+max_peaks]  are equally divided, now they are divided separately.

Additionally, I removed two returns of the function, which were only used for testing.