### PR TITLE
Add the property indicating if a model can predict quantiles

### DIFF
--- a/openstef/model/basecase.py
+++ b/openstef/model/basecase.py
@@ -70,3 +70,7 @@ class BaseCaseModel(BaseEstimator, RegressorMixin):
         ]
 
         return basecase_forecast.sort_index()
+
+    @property
+    def can_predict_quantiles(self):
+        return False

--- a/openstef/model/confidence_interval_applicator.py
+++ b/openstef/model/confidence_interval_applicator.py
@@ -59,7 +59,7 @@ class ConfidenceIntervalApplicator:
         """
         temp_forecast = self._add_standard_deviation_to_forecast(forecast)
 
-        if "quantile" in pj["model"] and quantile_confidence_interval:
+        if self.model.can_predict_quantiles:
             return self._add_quantiles_to_forecast_quantile_regression(
                 temp_forecast, pj["quantiles"]
             )

--- a/openstef/model/regressors/lgbm.py
+++ b/openstef/model/regressors/lgbm.py
@@ -17,6 +17,10 @@ class LGBMOpenstfRegressor(LGBMRegressor, OpenstfRegressor):
     def feature_names(self):
         return self._Booster.feature_name()
 
+    @property
+    def can_predict_quantiles(self):
+        return False
+
     @staticmethod
     def _get_importance_names():
         return {

--- a/openstef/model/regressors/linear.py
+++ b/openstef/model/regressors/linear.py
@@ -79,3 +79,7 @@ class LinearOpenstfRegressor(LinearRegressor, OpenstfRegressor):
     @property
     def feature_names(self):
         return self.feature_in_names_
+
+    @property
+    def can_predict_quantiles(self):
+        return False

--- a/openstef/model/regressors/proloaf.py
+++ b/openstef/model/regressors/proloaf.py
@@ -156,6 +156,10 @@ class OpenstfProloafRegressor(OpenstfRegressor, ModelWrapper):
             ["load"] + self.encoder_features + self.decoder_features
         )  # TODO: gehele range, of een enkele feature
 
+    @property
+    def can_predict_quantiles(self):
+        return False
+
     def predict(self, x: pd.DataFrame) -> np.ndarray:
         x = x[list(self.feature_names)[1:]]
         # Apply scaling and interpolation for NaN values

--- a/openstef/model/regressors/regressor_interface.py
+++ b/openstef/model/regressors/regressor_interface.py
@@ -54,6 +54,11 @@ class OpenstfRegressorInterface(BaseEstimator, RegressorMixin, ABC):
         """
         pass
 
+    @property
+    @abstractmethod
+    def can_predict_quantiles(self):
+        pass
+
 
 # In the future, expand this class with:
 # - calculate_feature_importance()

--- a/openstef/model/regressors/xgb.py
+++ b/openstef/model/regressors/xgb.py
@@ -17,6 +17,10 @@ class XGBOpenstfRegressor(XGBRegressor, OpenstfRegressor):
     def feature_names(self):
         return self._Booster.feature_names
 
+    @property
+    def can_predict_quantiles(self):
+        return False
+
     @staticmethod
     def _get_importance_names():
         return {

--- a/openstef/model/regressors/xgb_quantile.py
+++ b/openstef/model/regressors/xgb_quantile.py
@@ -200,3 +200,7 @@ class XGBQuantileOpenstfRegressor(OpenstfRegressor):
     @property
     def feature_names(self):
         return self._Booster.feature_names
+
+    @property
+    def can_predict_quantiles(self):
+        return True

--- a/test/unit/model/test_confidence_interval_applicator.py
+++ b/test/unit/model/test_confidence_interval_applicator.py
@@ -30,6 +30,10 @@ class MockModel:
         stdev_forecast = pd.DataFrame({"forecast": [5, 6, 7], "stdev": [0.5, 0.6, 0.7]})
         return stdev_forecast["stdev"].rename(quantile)
 
+    @property
+    def can_predict_quantiles(self):
+        return True
+
 
 class TestConfidenceIntervalApplicator(TestCase):
     def setUp(self) -> None:

--- a/test/unit/model/test_custom_models.py
+++ b/test/unit/model/test_custom_models.py
@@ -33,6 +33,10 @@ class DummyRegressor(CustomOpenstfRegressor):
     def feature_names(self):
         return self._feature_names
 
+    @property
+    def can_predict_quantiles(self):
+        return False
+
     def fit(self, X, y, **fit_params):
         self._feature_names = list(X.columns)
         return self

--- a/test/unit/model/test_model_creator.py
+++ b/test/unit/model/test_model_creator.py
@@ -17,7 +17,11 @@ class TestModelCreator(TestCase):
         for model_type in valid_types:
             model = ModelCreator.create_model(model_type)
             self.assertIsInstance(model, OpenstfRegressorInterface)
-            assert hasattr(model, "can_predict_quantiles")
+            self.assertTrue(hasattr(model, "can_predict_quantiles"))
+            if model_type in ["xgb_quantile", MLModelType("xgb_quantile")]:
+                self.assertTrue(model.can_predict_quantiles)
+            else:
+                self.assertFalse(model.can_predict_quantiles)
 
     def test_create_model_quantile_model(self):
         # Test if quantile model is properly returned

--- a/test/unit/pipeline/test_pipeline_train_model.py
+++ b/test/unit/pipeline/test_pipeline_train_model.py
@@ -47,6 +47,10 @@ class DummyRegressor(CustomOpenstfRegressor):
     def feature_names(self):
         return self._feature_names
 
+    @property
+    def can_predict_quantiles(self):
+        return False
+
     def fit(self, X, y, **fit_params):
         self._feature_names = list(X.columns)
         return self


### PR DESCRIPTION
We propose to add a property that indicates if the model can provide a prediction for the quantiles.
This property replaces the check on the name of the model. Indeed the current behavior checks if "quantile" is in the name of the model to choose between the default compute of the quantiles or the use the model's predictions.

This would close issue #294 
Signed-off-by: Benoit Hardier <benoit.hardier@probayes.com>