### PR TITLE
test if model has can_predict_quantiles attribute

### DIFF
--- a/test/unit/model/test_model_creator.py
+++ b/test/unit/model/test_model_creator.py
@@ -28,6 +28,7 @@ class TestModelCreator(TestCase):
         self.assertIsInstance(model, OpenstfRegressorInterface)
         self.assertIsInstance(model, XGBQuantileOpenstfRegressor)
         self.assertEqual(model.quantiles, quantiles)
+        assert hasattr(model, 'can_predict_quantiles')
 
     def test_create_model_unknown_model(self):
         # Test if NotImplementedError is raised when model type is unknown


### PR DESCRIPTION
Hi Benoît, I've included a check for the attribute you propose in the unit tests.
This should fix the sonarcloud-check fail.