### PR TITLE
Improve performance of replace repeated values with nan

### DIFF
--- a/openstef/data_classes/prediction_job.py
+++ b/openstef/data_classes/prediction_job.py
@@ -2,10 +2,12 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-from typing import Union, Optional, List, Dict, Any
+from typing import Any, Dict, List, Optional, Union
+
 from pydantic import BaseModel
-from .split_function import SplitFuncDataClass
+
 from .model_specifications import ModelSpecificationDataClass
+from .split_function import SplitFuncDataClass
 
 
 class PredictionJobDataClass(BaseModel):

--- a/openstef/data_classes/split_function.py
+++ b/openstef/data_classes/split_function.py
@@ -2,11 +2,11 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
+import inspect
 import json
 from importlib import import_module
-from typing import Union, Dict, Callable, Any, Sequence
+from typing import Any, Callable, Dict, Sequence, Union
 
-import inspect
 from pydantic import BaseModel
 
 

--- a/openstef/model_selection/model_selection.py
+++ b/openstef/model_selection/model_selection.py
@@ -5,7 +5,7 @@ import random
 import secrets
 from datetime import timedelta
 from itertools import accumulate
-from typing import List, Tuple, Iterable
+from typing import Iterable, List, Tuple
 
 import numpy as np
 import pandas as pd

--- a/openstef/pipeline/optimize_hyperparameters.py
+++ b/openstef/pipeline/optimize_hyperparameters.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2017-2022 Contributors to the OpenSTEF project <korte.termijn.prognoses@alliander.com> # noqa E501>
 #
 # SPDX-License-Identifier: MPL-2.0
-from typing import List, Tuple, Any
+from typing import Any, List, Tuple
 
 import optuna
 import pandas as pd
@@ -14,12 +14,11 @@ from openstef.exceptions import (
     InputDataWrongColumnOrderError,
 )
 from openstef.feature_engineering.feature_applicator import TrainFeatureApplicator
-from openstef.metrics.reporter import Reporter, Report
+from openstef.metrics.reporter import Report, Reporter
 from openstef.model.model_creator import ModelCreator
-from openstef.model.regressors.regressor import OpenstfRegressor
-
 from openstef.model.objective import RegressorObjective
 from openstef.model.objective_creator import ObjectiveCreator
+from openstef.model.regressors.regressor import OpenstfRegressor
 from openstef.model.serializer import MLflowSerializer
 from openstef.pipeline.train_model import (
     DEFAULT_TRAIN_HORIZONS,

--- a/openstef/pipeline/train_create_forecast_backtest.py
+++ b/openstef/pipeline/train_create_forecast_backtest.py
@@ -15,7 +15,6 @@ from openstef.postprocessing.postprocessing import (
     add_prediction_job_properties_to_forecast,
 )
 
-
 DEFAULT_TRAIN_HORIZONS: List[float] = [0.25, 24.0]
 DEFAULT_EARLY_STOPPING_ROUNDS: int = 10
 

--- a/openstef/preprocessing/preprocessing.py
+++ b/openstef/preprocessing/preprocessing.py
@@ -2,61 +2,26 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-from datetime import timedelta
-
 import numpy as np
+import pandas as pd
 
 
-def replace_repeated_values_with_nan(df, max_length, column_name):
-    """Replace repeated values with NaN.
-
-        Replace repeated values (sequentially repeating values), which repeat longer
-        than a set max_length (in data points) with NaNs.
+def replace_repeated_values_with_nan(
+    df: pd.DataFrame, max_length: int, column_name: str
+) -> pd.DataFrame:
+    """Replace sequentially repeated values with NaN.
 
     Args:
-        df (pandas.DataFrame): Data from which you would like to set repeating values to nan
-        max_length (int): If a value repeats more often, sequentially, than this value, all those points are set to NaN
-        column_name (string): the pandas dataframe column name of the column you want to process
+        df (pandas.DataFrame): Data with potential repeating values.
+        max_length (int): Maximum length of sequence. Above are set to NaN.
+        column_name (string): Column name of input dataframe with repeating values.
 
-    Rrturns:
-        pandas.DataFrame: data, similar to df, with the desired values set to NaN.
+    Returns:
+        pandas.DataFrame: Data, similar to df, with the desired values set to NaN.
     """
     data = df.copy(deep=True)
-    indices = []
-    old_value = -1000000000000
-    value = 0
-    for index, r in data.iterrows():
-        value = r[column_name]
-        if value == old_value:
-            indices.append(index)
-        elif (value != old_value) & (len(indices) > max_length):
-            indices = indices[max_length:]
-            data.loc[indices, column_name] = np.nan
-            indices = []
-            indices.append(index)
-        elif (value != old_value) & (len(indices) <= max_length):
-            indices = []
-            indices.append(index)
-        old_value = value
-    if len(indices) > max_length:
-        data.loc[indices, column_name] = np.nan
+    sequentials = data[column_name].diff().ne(0).cumsum()
+    data.loc[
+        sequentials.groupby(sequentials).transform("size") > max_length, column_name
+    ] = np.nan
     return data
-
-
-def replace_invalid_data(df, suspicious_moments):
-    """Function that detects invalid data using the nonzero_flatliner function and converts the output to NaN values.
-
-    Input:
-    - df: pd.dataFrame(index=DatetimeIndex, columns = [load1, ..., loadN]). Load_corrections should be indicated by 'LC_'
-    - suspicious_moments (pd.dataframe): output of function nonzero_flatliner in new variable
-
-
-    return:
-    - pd.DataFrame without invalid data (converted to NaN values)"""
-    if suspicious_moments is not None:
-        for index, row in suspicious_moments.iterrows():
-            df[
-                (row[0]) : (row[1] - timedelta(seconds=1))
-            ] = np.nan  # subtract 1 second to make it exclusive
-        return df
-    return df

--- a/openstef/preprocessing/preprocessing.py
+++ b/openstef/preprocessing/preprocessing.py
@@ -21,7 +21,6 @@ def replace_repeated_values_with_nan(
     """
     data = df.copy(deep=True)
     sequentials = data[column_name].diff().ne(0).cumsum()
-    data.loc[
-        sequentials.groupby(sequentials).transform("size") > max_length, column_name
-    ] = np.nan
+    grouped_sequentials_over_max = sequentials.groupby(sequentials).head(max_length)
+    data.loc[~data.index.isin(grouped_sequentials_over_max.index), column_name] = np.nan
     return data

--- a/test/unit/data_classes/test_split_function.py
+++ b/test/unit/data_classes/test_split_function.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-import unittest
-import json
 import copy
+import json
+import unittest
+
 from openstef.data_classes.split_function import SplitFuncDataClass
 
 

--- a/test/unit/feature_engineering/test_apply_features.py
+++ b/test/unit/feature_engineering/test_apply_features.py
@@ -137,14 +137,18 @@ class TestApplyFeaturesModule(BaseTestCase):
         # Skip first row, since T-30min not available for first row
         self.assertTrue(
             input_data_with_features.loc[horizon == 47, ["APX", "T-30min"]]
-            .iloc[1:,]
+            .iloc[
+                1:,
+            ]
             .isna()
             .all()
             .all()
         )
         self.assertFalse(
             input_data_with_features.loc[horizon == 0.25, ["APX", "T-30min"]]
-            .iloc[1:,]
+            .iloc[
+                1:,
+            ]
             .isna()
             .any()
             .any()

--- a/test/unit/feature_engineering/test_apply_features.py
+++ b/test/unit/feature_engineering/test_apply_features.py
@@ -137,18 +137,14 @@ class TestApplyFeaturesModule(BaseTestCase):
         # Skip first row, since T-30min not available for first row
         self.assertTrue(
             input_data_with_features.loc[horizon == 47, ["APX", "T-30min"]]
-            .iloc[
-                1:,
-            ]
+            .iloc[1:,]
             .isna()
             .all()
             .all()
         )
         self.assertFalse(
             input_data_with_features.loc[horizon == 0.25, ["APX", "T-30min"]]
-            .iloc[
-                1:,
-            ]
+            .iloc[1:,]
             .isna()
             .any()
             .any()

--- a/test/unit/pipeline/test_optimize_hyperparameters.py
+++ b/test/unit/pipeline/test_optimize_hyperparameters.py
@@ -7,15 +7,13 @@ from unittest.mock import patch
 
 import pandas as pd
 
+from openstef.data_classes.model_specifications import ModelSpecificationDataClass
 from openstef.exceptions import (
     InputDataInsufficientError,
     InputDataWrongColumnOrderError,
 )
-
 from openstef.metrics.reporter import Report
 from openstef.model.regressors.regressor import OpenstfRegressor
-from openstef.data_classes.model_specifications import ModelSpecificationDataClass
-
 from openstef.pipeline.optimize_hyperparameters import (
     optimize_hyperparameters_pipeline,
     optimize_hyperparameters_pipeline_core,

--- a/test/unit/pipeline/test_train.py
+++ b/test/unit/pipeline/test_train.py
@@ -8,11 +8,11 @@ from test.unit.utils.data import TestData
 
 import numpy as np
 import pandas as pd
+from sklearn.model_selection import TimeSeriesSplit
 
+from openstef.data_classes.split_function import SplitFuncDataClass
 from openstef.model_selection.model_selection import split_data_train_validation_test
 from openstef.pipeline.train_model import train_pipeline_step_split_data
-from openstef.data_classes.split_function import SplitFuncDataClass
-from sklearn.model_selection import TimeSeriesSplit
 
 # define constants
 SPLIT_PARAMS = {

--- a/test/unit/pipeline/test_train_predict_backtest.py
+++ b/test/unit/pipeline/test_train_predict_backtest.py
@@ -6,6 +6,7 @@ from test.unit.utils.data import TestData
 
 import numpy as np
 from sklearn.model_selection import TimeSeriesSplit
+
 from openstef.data_classes.split_function import SplitFuncDataClass
 from openstef.feature_engineering.feature_applicator import TrainFeatureApplicator
 from openstef.pipeline.train_create_forecast_backtest import (

--- a/test/unit/preprocessing/test_preprocessing.py
+++ b/test/unit/preprocessing/test_preprocessing.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import math
-import unittest
 from datetime import datetime, timedelta
 from test.unit.utils.base import BaseTestCase
 
@@ -11,35 +10,6 @@ import numpy as np
 import pandas as pd
 
 from openstef.preprocessing import preprocessing
-from openstef.validation import validation
-
-now = datetime.utcnow()
-date_range = pd.date_range(start=now - timedelta(minutes=30), end=now, freq="0.25H")
-date_range2 = pd.date_range(start=now - timedelta(minutes=60), end=now, freq="0.25H")
-date_range3 = pd.date_range(start=now - timedelta(minutes=30), end=now, freq="0.25H")
-
-df_no_flatliner = pd.DataFrame(
-    {
-        "date": date_range,
-        "LC_trafo": [0, 0, 0],
-        "col1": [8.16, 7.64, 7.44],
-        "col2": [0, 0, 0],
-    }
-)
-df_flatliner = pd.DataFrame(
-    {
-        "date": date_range2,
-        "LC_trafo": [0, 0, 0, 0, 0],
-        "col1": [8.0, 8.16, 8.16, 8.16, 8.0],
-        "col2": [8.0, 8.75, 8.75, 8.75, 8.0],
-    }
-)
-df_zero_file = pd.DataFrame({"date5": [], "LC_trafo": [], "col1": [], "col2": []})
-
-
-df_no_flatliner = df_no_flatliner.set_index("date")
-df_flatliner = df_flatliner.set_index("date")
-df_zero_file = df_zero_file.set_index("date5")
 
 
 class TestPreprocessing(BaseTestCase):
@@ -57,7 +27,6 @@ class TestPreprocessing(BaseTestCase):
         df_no_repeated = preprocessing.replace_repeated_values_with_nan(
             df, 5, "Column2"
         )
-        print(df_no_repeated.isna().values.any())
         self.assertFalse(df_no_repeated.isna().values.any())
 
         # No change, since there are 4 seq. numbers.
@@ -71,7 +40,7 @@ class TestPreprocessing(BaseTestCase):
             df, 3, "Column2"
         )
         self.assertEqual(df_no_repeated["Column1"].isna().values.sum(), 0)
-        self.assertEqual(df_no_repeated["Column2"].isna().values.sum(), 1)
+        self.assertEqual(df_no_repeated["Column2"].isna().values.sum(), 4)
         self.assertEqual(df_no_repeated["Column3"].isna().values.sum(), 0)
         self.assertTrue(df_no_repeated["Column1"].equals(df_no_repeated["Column3"]))
         self.assertTrue(math.isnan(df_no_repeated.at[end_nan, "Column2"]))
@@ -81,54 +50,8 @@ class TestPreprocessing(BaseTestCase):
             df, 2, "Column2"
         )
         self.assertEqual(df_no_repeated["Column1"].isna().values.sum(), 0)
-        self.assertEqual(df_no_repeated["Column2"].isna().values.sum(), 2)
+        self.assertEqual(df_no_repeated["Column2"].isna().values.sum(), 4)
         self.assertEqual(df_no_repeated["Column3"].isna().values.sum(), 0)
         self.assertTrue(df_no_repeated["Column1"].equals(df_no_repeated["Column3"]))
         self.assertTrue(math.isnan(df_no_repeated.at[end_nan, "Column2"]))
         self.assertTrue(math.isnan(df_no_repeated.at[end_nan - 1, "Column2"]))
-
-    def test_no_flatliner(self):
-        df = df_no_flatliner
-        suspicious_moments = validation.find_nonzero_flatliner(df, 0.25)
-
-        expected = df
-        result = preprocessing.replace_invalid_data(df, suspicious_moments)
-
-        self.assertDataframeEqual(expected, result)
-
-    def test_station_flatliner(self):
-        """Data: all trafo's containing non zero-value flatliners
-
-        Expected: list containing all trafo values and timestamps of the
-        stationsflatliners + the generates diff_columns to detect the flatliners.
-        """
-        df = df_flatliner.copy()
-        suspicious_moments = validation.find_nonzero_flatliner(df, 0.25)
-        # create expected output with diff_columns
-        df_flatliner_output = pd.DataFrame(
-            {
-                "date": date_range2,
-                "LC_trafo": [0, np.nan, np.nan, np.nan, 0],
-                "col1": [8.0, np.nan, np.nan, np.nan, 8.0],
-                "col2": [8.0, np.nan, np.nan, np.nan, 8.0],
-            }
-        )
-        df_flatliner_output = df_flatliner_output.set_index("date")
-        expected = df_flatliner_output
-        result = preprocessing.replace_invalid_data(df, suspicious_moments)
-        self.assertDataframeEqual(expected, result)
-
-    def test_no_data(self):
-        """Data: empty database
-
-        Expected: empty list, since there is no data to check
-        """
-        df = df_zero_file
-        suspicious_moments = validation.find_nonzero_flatliner(df, 0.25)
-        expected = df
-        result = preprocessing.replace_invalid_data(df, suspicious_moments)
-        self.assertDataframeEqual(expected, result)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/unit/preprocessing/test_preprocessing.py
+++ b/test/unit/preprocessing/test_preprocessing.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import math
-from datetime import datetime, timedelta
 from test.unit.utils.base import BaseTestCase
 
 import numpy as np
@@ -40,7 +39,7 @@ class TestPreprocessing(BaseTestCase):
             df, 3, "Column2"
         )
         self.assertEqual(df_no_repeated["Column1"].isna().values.sum(), 0)
-        self.assertEqual(df_no_repeated["Column2"].isna().values.sum(), 4)
+        self.assertEqual(df_no_repeated["Column2"].isna().values.sum(), 1)
         self.assertEqual(df_no_repeated["Column3"].isna().values.sum(), 0)
         self.assertTrue(df_no_repeated["Column1"].equals(df_no_repeated["Column3"]))
         self.assertTrue(math.isnan(df_no_repeated.at[end_nan, "Column2"]))
@@ -50,7 +49,7 @@ class TestPreprocessing(BaseTestCase):
             df, 2, "Column2"
         )
         self.assertEqual(df_no_repeated["Column1"].isna().values.sum(), 0)
-        self.assertEqual(df_no_repeated["Column2"].isna().values.sum(), 4)
+        self.assertEqual(df_no_repeated["Column2"].isna().values.sum(), 2)
         self.assertEqual(df_no_repeated["Column3"].isna().values.sum(), 0)
         self.assertTrue(df_no_repeated["Column1"].equals(df_no_repeated["Column3"]))
         self.assertTrue(math.isnan(df_no_repeated.at[end_nan, "Column2"]))

--- a/test/unit/validation/test_validation.py
+++ b/test/unit/validation/test_validation.py
@@ -35,7 +35,7 @@ class TestDataValidation(BaseTestCase):
         validated_data = validation.validate(
             self.pj["id"], self.data_predict, self.pj["flatliner_treshold"]
         )
-        self.assertEqual(len(validated_data[validated_data["load"].isna()]), 26)
+        self.assertEqual(50, len(validated_data[validated_data["load"].isna()]))
 
     def test_validate_none_threshold(self):
         """return the input if flatliner_threshold is None"""

--- a/test/unit/validation/test_validation.py
+++ b/test/unit/validation/test_validation.py
@@ -35,7 +35,7 @@ class TestDataValidation(BaseTestCase):
         validated_data = validation.validate(
             self.pj["id"], self.data_predict, self.pj["flatliner_treshold"]
         )
-        self.assertEqual(50, len(validated_data[validated_data["load"].isna()]))
+        self.assertEqual(26, len(validated_data[validated_data["load"].isna()]))
 
     def test_validate_none_threshold(self):
         """return the input if flatliner_threshold is None"""


### PR DESCRIPTION
Plus run isort and black

New function to replace nan has improved performance from:
725 ms ± 111 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
to:
2.41 ms ± 164 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)


