### PR TITLE
Bugfix ktps 2272 #380 reporter location

### DIFF
--- a/openstef/feature_engineering/holiday_features.py
+++ b/openstef/feature_engineering/holiday_features.py
@@ -58,7 +58,7 @@ def generate_holiday_feature_functions(
         now = datetime.now()
         years = [now.year - 1, now.year]
 
-    country_holidays = holidays.CountryHoliday(country, years=years)
+    country_holidays = holidays.country_holidays(country, years=years)
 
     # Make holiday function dict
     holiday_functions = {}
@@ -149,7 +149,7 @@ def check_for_bridge_day(
         holiday_functions: dict with holiday feature functions
         bridge_days: list of bridgedays
     """
-    country_holidays = holidays.CountryHoliday(country, years=years)
+    country_holidays = holidays.country_holidays(country, years=years)
 
     # Define function explicitely to mitigate 'late binding' problem
     def make_holiday_func(requested_date):

--- a/openstef/metrics/reporter.py
+++ b/openstef/metrics/reporter.py
@@ -138,12 +138,12 @@ class Reporter:
             # write feature importance figure
             if report.feature_importance_figure:  # only write if figure is not none
                 report.feature_importance_figure.write_html(
-                    f"{report_folder}/weight_plot.html"
+                    os.path.join(report_folder, "weight_plot.html")
                 )
             # write predictors
             for name, figure in report.data_series_figures.items():
                 if figure:  # only write if figure is not none
-                    figure.write_html(f"{report_folder}/{name}.html")
+                    figure.write_html(os.path.join(report_folder, f"{name}.html"))
 
     def _make_data_series_figures(self, model: OpenstfRegressor) -> dict:
         """Make data series figures."""

--- a/openstef/metrics/reporter.py
+++ b/openstef/metrics/reporter.py
@@ -4,8 +4,8 @@
 import os
 import warnings
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Dict
+import structlog
 
 import numpy as np
 import pandas as pd
@@ -126,21 +126,24 @@ class Reporter:
         return results
 
     @staticmethod
-    def write_report_to_disk(report: Report, artifact_folder: str):
+    def write_report_to_disk(report: Report, report_folder: str):
         """Write report to disk; e.g. for viewing report of latest models using grafana."""
-        if artifact_folder:
+        # Initialize logger and serializer
+        logger = structlog.get_logger(__name__)
+        if report_folder:
             # create path if does not exist
-            if not os.path.exists(artifact_folder):
-                os.makedirs(artifact_folder)
+            if not os.path.exists(report_folder):
+                os.makedirs(report_folder)
+            logger.info(f"Writing reports to {report_folder}")
             # write feature importance figure
             if report.feature_importance_figure:  # only write if figure is not none
                 report.feature_importance_figure.write_html(
-                    f"{artifact_folder}/weight_plot.html"
+                    f"{report_folder}/weight_plot.html"
                 )
             # write predictors
             for name, figure in report.data_series_figures.items():
                 if figure:  # only write if figure is not none
-                    figure.write_html(f"{artifact_folder}/{name}.html")
+                    figure.write_html(f"{report_folder}/{name}.html")
 
     def _make_data_series_figures(self, model: OpenstfRegressor) -> dict:
         """Make data series figures."""

--- a/openstef/pipeline/optimize_hyperparameters.py
+++ b/openstef/pipeline/optimize_hyperparameters.py
@@ -6,6 +6,7 @@ from typing import Any, List, Tuple
 import optuna
 import pandas as pd
 import structlog
+import os
 
 from openstef.data_classes.model_specifications import ModelSpecificationDataClass
 from openstef.data_classes.prediction_job import PredictionJobDataClass
@@ -87,7 +88,8 @@ def optimize_hyperparameters_pipeline(
         trial_number=best_trial_number,
     )
     if artifact_folder:
-        Reporter.write_report_to_disk(report=report, artifact_folder=artifact_folder)
+        report_folder = os.path.join(artifact_folder, pj["id"])
+        Reporter.write_report_to_disk(report=report, report_folder=report_folder)
     return best_params
 
 

--- a/openstef/pipeline/optimize_hyperparameters.py
+++ b/openstef/pipeline/optimize_hyperparameters.py
@@ -7,6 +7,7 @@ import optuna
 import pandas as pd
 import structlog
 import os
+from pathlib import Path
 
 from openstef.data_classes.model_specifications import ModelSpecificationDataClass
 from openstef.data_classes.prediction_job import PredictionJobDataClass
@@ -88,7 +89,7 @@ def optimize_hyperparameters_pipeline(
         trial_number=best_trial_number,
     )
     if artifact_folder:
-        report_folder = os.path.join(artifact_folder, pj["id"])
+        report_folder = os.path.join(artifact_folder, str(pj["id"]))
         Reporter.write_report_to_disk(report=report, report_folder=report_folder)
     return best_params
 

--- a/openstef/pipeline/train_model.py
+++ b/openstef/pipeline/train_model.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 import logging
-from pathlib import Path
+import os
 from typing import List, Optional, Tuple, Union
 
 import pandas as pd
@@ -120,7 +120,8 @@ def train_model_pipeline(
         report=report,
     )
     if artifact_folder:
-        Reporter.write_report_to_disk(report=report, artifact_folder=artifact_folder)
+        report_folder = os.path.join(artifact_folder, pj["id"])
+        Reporter.write_report_to_disk(report=report, report_folder=report_folder)
 
     # Clean up older models
     serializer.remove_old_models(

--- a/openstef/pipeline/train_model.py
+++ b/openstef/pipeline/train_model.py
@@ -4,6 +4,7 @@
 import logging
 import os
 from typing import List, Optional, Tuple, Union
+from pathlib import Path
 
 import pandas as pd
 import structlog
@@ -120,7 +121,7 @@ def train_model_pipeline(
         report=report,
     )
     if artifact_folder:
-        report_folder = os.path.join(artifact_folder, pj["id"])
+        report_folder = os.path.join(artifact_folder, str(pj["id"]))
         Reporter.write_report_to_disk(report=report, report_folder=report_folder)
 
     # Clean up older models

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -40,8 +40,10 @@ class TestComponent(unittest.TestCase):
 
         # Assert that reports on training are stored in correct location
         expected_report_location = f'./test/component/{self.pj["id"]}'
-        written_files = glob.glob(os.path.join(expected_report_location, "*"))
-        fnames = [x.split("\\")[-1] for x in written_files]
+        fnames = [
+            os.path.basename(file_with_path)
+            for file_with_path in glob.glob(os.path.join(expected_report_location, "*"))
+        ]
         expected_fnames = [
             "Predictor0.25.html",
             "Predictor47.0.html",

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -4,6 +4,7 @@
 import os
 import unittest
 from test.unit.utils.data import TestData
+import glob
 
 from openstef.pipeline.create_forecast import create_forecast_pipeline_core
 from openstef.pipeline.optimize_hyperparameters import optimize_hyperparameters_pipeline
@@ -36,6 +37,17 @@ class TestComponent(unittest.TestCase):
             n_trials=2,
         )
         self.model_specs.hyper_params = parameters
+
+        # Assert that reports on training are stored in correct location
+        expected_report_location = f'./test/component/{self.pj["id"]}'
+        written_files = glob.glob(os.path.join(expected_report_location, "*"))
+        fnames = [x.split("\\")[-1] for x in written_files]
+        expected_fnames = [
+            "Predictor0.25.html",
+            "Predictor47.0.html",
+            "weight_plot.html",
+        ]
+        self.assertCountEqual(fnames, expected_fnames)
 
         # 2) train model, using the optimized hyperparameters
         (

--- a/test/unit/model/test_serializer.py
+++ b/test/unit/model/test_serializer.py
@@ -40,7 +40,7 @@ class TestMLflowSerializer(BaseTestCase):
         # Check model path
         assert (
             loaded_model.path.replace("\\", "/")
-            == "/C:/repos/short-term-forecasting/test/unit/trained_models/mlruns/0/d7719d5d316d4416a947e4f7ea7e73a8/artifacts/model/"
+            == "./test/unit/trained_models/mlruns/0/d7719d5d316d4416a947e4f7ea7e73a8/artifacts/model/"
         )
 
     @patch("openstef.data_classes.model_specifications.ModelSpecificationDataClass")

--- a/test/unit/model/test_serializer.py
+++ b/test/unit/model/test_serializer.py
@@ -40,7 +40,7 @@ class TestMLflowSerializer(BaseTestCase):
         # Check model path
         assert (
             loaded_model.path.replace("\\", "/")
-            == "./test/unit/trained_models/mlruns/0/d7719d5d316d4416a947e4f7ea7e73a8/artifacts/model/"
+            == "/C:/repos/short-term-forecasting/test/unit/trained_models/mlruns/0/d7719d5d316d4416a947e4f7ea7e73a8/artifacts/model/"
         )
 
     @patch("openstef.data_classes.model_specifications.ModelSpecificationDataClass")

--- a/test/unit/pipeline/test_pipeline_train_model.py
+++ b/test/unit/pipeline/test_pipeline_train_model.py
@@ -291,9 +291,7 @@ class TestTrainModelPipeline(BaseTestCase):
             "Predictor47.0.html",
             "weight_plot.html",
         ]
-        unittest.TestCase.assertCountEqual(fnames, excepted_fnames)
-
-        assert len([file for file in found_files if "Predictor" in file]) == 2
+        assert set(fnames) == set(excepted_fnames)
 
     @patch("openstef.model.serializer.MLflowSerializer.save_model")
     @patch("openstef.pipeline.train_model.train_model_pipeline_core")

--- a/test/unit/pipeline/test_pipeline_train_model.py
+++ b/test/unit/pipeline/test_pipeline_train_model.py
@@ -10,6 +10,8 @@ from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import sklearn
+import os
+import glob
 
 from openstef.enums import MLModelType
 from openstef.exceptions import (
@@ -276,6 +278,22 @@ class TestTrainModelPipeline(BaseTestCase):
             mlflow_tracking_uri="./test/unit/trained_models/mlruns",
             artifact_folder="./test/unit/trained_models",
         )
+
+        # Assert the report was attempted to be written to the correct location
+        assert report_mock.method_calls[0].args[0] == os.path.join(
+            "./test/unit/trained_models", "307", "weight_plot.html"
+        )
+        # Assert the figure is in the correct location
+        found_files = glob.glob(os.path.join("./test/unit/trained_models/307/*.html"))
+        fnames = [x.split("\\")[-1] for x in found_files]
+        excepted_fnames = [
+            "Predictor0.25.html",
+            "Predictor47.0.html",
+            "weight_plot.html",
+        ]
+        unittest.TestCase.assertCountEqual(fnames, excepted_fnames)
+
+        assert len([file for file in found_files if "Predictor" in file]) == 2
 
     @patch("openstef.model.serializer.MLflowSerializer.save_model")
     @patch("openstef.pipeline.train_model.train_model_pipeline_core")

--- a/test/unit/pipeline/test_pipeline_train_model.py
+++ b/test/unit/pipeline/test_pipeline_train_model.py
@@ -284,14 +284,18 @@ class TestTrainModelPipeline(BaseTestCase):
             "./test/unit/trained_models", "307", "weight_plot.html"
         )
         # Assert the figure is in the correct location
-        found_files = glob.glob(os.path.join("./test/unit/trained_models/307/*.html"))
-        fnames = [x.split("\\")[-1] for x in found_files]
+        found_files = [
+            os.path.basename(file_with_path)
+            for file_with_path in glob.glob(
+                os.path.join("./test/unit/trained_models/307/*.html")
+            )
+        ]
         excepted_fnames = [
             "Predictor0.25.html",
             "Predictor47.0.html",
             "weight_plot.html",
         ]
-        assert set(fnames) == set(excepted_fnames)
+        assert set(found_files) == set(excepted_fnames)
 
     @patch("openstef.model.serializer.MLflowSerializer.save_model")
     @patch("openstef.pipeline.train_model.train_model_pipeline_core")


### PR DESCRIPTION
Fix location where reports (artifacts) are stored.
The current implementation (made when adopting the mlflow functionality) wrote the reports one level too high, resulting in them being overwritten for each new training that happened (also for other prediction_jobs). 

Fixed the location where they are stored back to what we used, and added tests for this.

As a bonus I changed CountryHolidays to country_holidays, as that gave a FutureWarning and I had to wait for the build to complete.