### PR TITLE
improve optional proloaf dependency

### DIFF
--- a/openstef/enums.py
+++ b/openstef/enums.py
@@ -3,14 +3,6 @@
 # SPDX-License-Identifier: MPL-2.0
 from enum import Enum
 
-# Specify optional modeltypes
-try:
-    from openstef.model.regressors.proloaf import OpenstfProloafRegressor
-
-    _has_proloaf = True
-except ImportError:
-    _has_proloaf = False
-
 
 # TODO replace this with ModelType (MLModelType == Machine Learning model type)
 class MLModelType(Enum):
@@ -18,10 +10,7 @@ class MLModelType(Enum):
     XGB_QUANTILE = "xgb_quantile"
     LGB = "lgb"
     LINEAR = "linear"
-    if _has_proloaf:
-        ProLoaf = "proloaf"
-    else:
-        ProLoaf = None
+    ProLoaf = "proloaf"
 
 
 class ForecastType(Enum):

--- a/openstef/enums.py
+++ b/openstef/enums.py
@@ -3,14 +3,25 @@
 # SPDX-License-Identifier: MPL-2.0
 from enum import Enum
 
+# Specify optional modeltypes
+try:
+    from openstef.model.regressors.proloaf import OpenstfProloafRegressor
+
+    _has_proloaf = True
+except ImportError:
+    _has_proloaf = False
+
 
 # TODO replace this with ModelType (MLModelType == Machine Learning model type)
 class MLModelType(Enum):
     XGB = "xgb"
     XGB_QUANTILE = "xgb_quantile"
     LGB = "lgb"
-    ProLoaf = "proloaf"
     LINEAR = "linear"
+    if _has_proloaf:
+        ProLoaf = "proloaf"
+    else:
+        ProLoaf = None
 
 
 class ForecastType(Enum):

--- a/openstef/model/model_creator.py
+++ b/openstef/model/model_creator.py
@@ -17,11 +17,8 @@ logger = structlog.get_logger(__name__)
 try:
     from openstef.model.regressors.proloaf import OpenstfProloafRegressor
 except ImportError:
-    logger.warning(
-        "Proloaf not available, switching to xgboost! See Readme how to install proloaf"
-        " dependencies"
-    )
-    OpenstfProloafRegressor = XGBOpenstfRegressor
+    logger.info("Proloaf not available, setting constructor to None")
+    OpenstfProloafRegressor = None
 
 valid_model_kwargs = {
     MLModelType.XGB: [
@@ -148,11 +145,18 @@ class ModelCreator:
                 model_type = MLModelType(model_type)
                 model_class = ModelCreator.MODEL_CONSTRUCTORS[model_type]
                 valid_kwargs = valid_model_kwargs[model_type]
+                # Check if model as imported
+                if model_class is None:
+                    raise ImportError(
+                        f"Constructor not available for '{model_type}'. "
+                        "Perhaps you forgot to install an optional dependency? "
+                        "Please refer to the ReadMe for instructions"
+                    )
         except ValueError as e:
             valid_types = [t.value for t in MLModelType]
             raise NotImplementedError(
                 f"No constructor for '{model_type}', "
-                f"valid model_types are: {valid_types}"
+                f"valid model_types are: {valid_types} "
                 "or import a custom model"
             ) from e
 

--- a/test/unit/pipeline/test_pipeline_train_model.py
+++ b/test/unit/pipeline/test_pipeline_train_model.py
@@ -106,8 +106,12 @@ class TestTrainModelPipeline(BaseTestCase):
         """
         # Select 50 data points to speedup test
         train_input = self.train_input.iloc[::50, :]
+        # Remove modeltypes which are optional, and add a dummy regressor
         for model_type in list(MLModelType) + [__name__ + ".DummyRegressor"]:
             with self.subTest(model_type=model_type):
+                # Skip the optional proloaf model
+                if model_type == MLModelType.ProLoaf:
+                    continue
                 pj = self.pj
 
                 pj["model"] = (
@@ -157,10 +161,8 @@ class TestTrainModelPipeline(BaseTestCase):
                     test_data,
                 ) = split_data_train_validation_test(data_with_features)
 
-                # not able to generate a feature importance for proloaf as this is a neural network
-                if not pj["model"] == "proloaf":
-                    importance = model.set_feature_importance()
-                    self.assertIsInstance(importance, pd.DataFrame)
+                importance = model.set_feature_importance()
+                self.assertIsInstance(importance, pd.DataFrame)
 
     def test_train_model_pipeline_with_featureAdders(self):
         pj = self.pj


### PR DESCRIPTION
When debugging another story, I was really annoyed with the 'proloaf not imported' warnings I received when I didn't even try to do anything with proloaf. While waiting for the test of that story to build, I found this solution on how to deal in a proper way with optional dependencies.
Added a unit test to test the ImportError exception explicitly


Signed-off-by: Frank Kreuwel <fpmkreuwel@gmail.com>

