### PR TITLE
Bugfix/ktps 2779 n estimators none

### DIFF
--- a/openstef/model/confidence_interval_applicator.py
+++ b/openstef/model/confidence_interval_applicator.py
@@ -212,4 +212,6 @@ class ConfidenceIntervalApplicator:
                 self.forecast_input_data, quantile=quantile
             )
 
-        return forecast.merge(quantile_df, left_index=True, right_index=True, how='left')
+        return forecast.merge(
+            quantile_df, left_index=True, right_index=True, how="left"
+        )

--- a/openstef/model/confidence_interval_applicator.py
+++ b/openstef/model/confidence_interval_applicator.py
@@ -204,10 +204,12 @@ class ConfidenceIntervalApplicator:
                 columns added.
 
         """
+        # Only determine quantiles for datetimes in forecast
+        quantile_df = pd.DataFrame(index=self.forecast_input_data.index)
         for quantile in quantiles:
             quantile_key = f"quantile_P{quantile * 100:02.0f}"
-            forecast[quantile_key] = self.model.predict(
+            quantile_df[quantile_key] = self.model.predict(
                 self.forecast_input_data, quantile=quantile
             )
 
-        return forecast
+        return forecast.merge(quantile_df, left_index=True, right_index=True, how='left')

--- a/openstef/pipeline/train_model.py
+++ b/openstef/pipeline/train_model.py
@@ -421,6 +421,12 @@ def train_pipeline_step_train_model(
         valid_hyper_parameters.update(
             dict(early_stopping_rounds=DEFAULT_EARLY_STOPPING_ROUNDS)
         )
+        
+    # Temporary fix to allow xgboost version upgrade -> set n_estimators if present and None
+    if not valid_hyper_parameters.get("n_estimators", True):
+        valid_hyper_parameters.update(dict(n_estimators=100))
+        logging.info('Deprecation warning: n_estimators=None found, overwriting.')
+        
 
     model.set_params(**valid_hyper_parameters)
     model.fit(

--- a/openstef/pipeline/train_model.py
+++ b/openstef/pipeline/train_model.py
@@ -421,12 +421,11 @@ def train_pipeline_step_train_model(
         valid_hyper_parameters.update(
             dict(early_stopping_rounds=DEFAULT_EARLY_STOPPING_ROUNDS)
         )
-        
+
     # Temporary fix to allow xgboost version upgrade -> set n_estimators if present and None
     if not valid_hyper_parameters.get("n_estimators", True):
         valid_hyper_parameters.update(dict(n_estimators=100))
-        logging.info('Deprecation warning: n_estimators=None found, overwriting.')
-        
+        logging.info("Deprecation warning: n_estimators=None found, overwriting.")
 
     model.set_params(**valid_hyper_parameters)
     model.fit(

--- a/test/unit/model/test_confidence_interval_applicator.py
+++ b/test/unit/model/test_confidence_interval_applicator.py
@@ -5,6 +5,7 @@
 from unittest import TestCase
 from unittest.mock import patch
 
+import numpy as np
 import pandas as pd
 
 from openstef.model.confidence_interval_applicator import ConfidenceIntervalApplicator
@@ -104,6 +105,23 @@ class TestConfidenceIntervalApplicator(TestCase):
 
         for expected_column in expected_new_columns:
             self.assertTrue(expected_column in pp_forecast.columns)
+            
+    def test_add_quantiles_to_forecast_length_mismatch(self):
+        pj = {"quantiles": self.quantiles}
+        pp_forecast = ConfidenceIntervalApplicator(
+            MockModel(), self.stdev_forecast.iloc[:-1,:] # do not use last value
+        )._add_quantiles_to_forecast_quantile_regression(
+            self.stdev_forecast, pj["quantiles"]
+        )
+
+        expected_new_columns = [
+            f"quantile_P{int(q * 100):02d}" for q in pj["quantiles"]
+        ]
+
+        for expected_column in expected_new_columns:
+            self.assertTrue(expected_column in pp_forecast.columns)
+            # Assert last quantile value is missing
+            self.assertTrue(np.isnan(pp_forecast[expected_column].iloc[-1]))
 
     def test_add_quantiles_to_forecast_default(self):
         pj = {"quantiles": self.quantiles}

--- a/test/unit/model/test_confidence_interval_applicator.py
+++ b/test/unit/model/test_confidence_interval_applicator.py
@@ -105,11 +105,11 @@ class TestConfidenceIntervalApplicator(TestCase):
 
         for expected_column in expected_new_columns:
             self.assertTrue(expected_column in pp_forecast.columns)
-            
+
     def test_add_quantiles_to_forecast_length_mismatch(self):
         pj = {"quantiles": self.quantiles}
         pp_forecast = ConfidenceIntervalApplicator(
-            MockModel(), self.stdev_forecast.iloc[:-1,:] # do not use last value
+            MockModel(), self.stdev_forecast.iloc[:-1, :]  # do not use last value
         )._add_quantiles_to_forecast_quantile_regression(
             self.stdev_forecast, pj["quantiles"]
         )

--- a/test/unit/model/test_confidence_interval_applicator.py
+++ b/test/unit/model/test_confidence_interval_applicator.py
@@ -107,18 +107,23 @@ class TestConfidenceIntervalApplicator(TestCase):
             self.assertTrue(expected_column in pp_forecast.columns)
 
     def test_add_quantiles_to_forecast_length_mismatch(self):
+        # Arange
         pj = {"quantiles": self.quantiles}
+
+        # Act
         pp_forecast = ConfidenceIntervalApplicator(
             MockModel(), self.stdev_forecast.iloc[:-1, :]  # do not use last value
         )._add_quantiles_to_forecast_quantile_regression(
             self.stdev_forecast, pj["quantiles"]
         )
 
+        # Assert
         expected_new_columns = [
             f"quantile_P{int(q * 100):02d}" for q in pj["quantiles"]
         ]
 
         for expected_column in expected_new_columns:
+            # Assert the quantiles are available
             self.assertTrue(expected_column in pp_forecast.columns)
             # Assert last quantile value is missing
             self.assertTrue(np.isnan(pp_forecast[expected_column].iloc[-1]))


### PR DESCRIPTION
Fixes bug currently encountered due to model spec of old xgboost models being used to train new models. Missing parameters where filled with None, which is invalid for n_estimators.