### PR TITLE
improve exception message

### DIFF
--- a/openstef/tasks/create_components_forecast.py
+++ b/openstef/tasks/create_components_forecast.py
@@ -99,11 +99,11 @@ def create_components_forecast_task(
         raise ValueError(
             f"Index is not datetime. Received forecasts:{forecasts.head()}"
         )
-        
+
     # save forecast to database #######################################################
     context.database.write_forecast(forecasts)
     logger.debug("Written forecast to database")
-    
+
     # Check if forecast was complete enough, otherwise raise exception
     if forecasts.index.max() < datetime.utcnow().replace(tzinfo=pytz.utc) + timedelta(
         hours=30

--- a/openstef/tasks/create_components_forecast.py
+++ b/openstef/tasks/create_components_forecast.py
@@ -97,7 +97,7 @@ def create_components_forecast_task(
     # save forecast to database #######################################################
     context.database.write_forecast(forecasts)
     logger.debug("Written forecast to database")
-    
+
     ## Perform final sanity check
     if not isinstance(forecasts.index, pd.core.indexes.datetimes.DatetimeIndex):
         raise ValueError(
@@ -111,17 +111,18 @@ def create_components_forecast_task(
         # Check which input data is missing the most.
         # Do this by counting the NANs for (load)forecast, radiation and windspeed
         max_index = forecasts.index.max()
-        n_nas=dict(
-            nans_load_forecast = input_data.loc[max_index:, 'forecast'].isna().sum(),
-            nans_radiation = weather_data.loc[max_index:, 'radiation'].isna().sum(),
-            nans_windspeed_100m = weather_data.loc[max_index:, 'windspeed_100m'].isna().sum(),
+        n_nas = dict(
+            nans_load_forecast=input_data.loc[max_index:, "forecast"].isna().sum(),
+            nans_radiation=weather_data.loc[max_index:, "radiation"].isna().sum(),
+            nans_windspeed_100m=weather_data.loc[max_index:, "windspeed_100m"]
+            .isna()
+            .sum(),
         )
         max_na = max(n_nas, key=n_nas.get)
-        
+
         raise ComponentForecastTooShortHorizonError(
             f"Could not make component forecast for two days ahead, probably input data is missing, {max_na}: {n_nas[max_na]}"
         )
-
 
 
 def main(config: object = None, database: object = None):

--- a/openstef/tasks/create_components_forecast.py
+++ b/openstef/tasks/create_components_forecast.py
@@ -94,16 +94,17 @@ def create_components_forecast_task(
     # Make forecast for the demand, wind and pv components
     forecasts = create_components_forecast_pipeline(pj, input_data, weather_data)
 
-    # save forecast to database #######################################################
-    context.database.write_forecast(forecasts)
-    logger.debug("Written forecast to database")
-
-    ## Perform final sanity check
+    ## Perform sanity check on index
     if not isinstance(forecasts.index, pd.core.indexes.datetimes.DatetimeIndex):
         raise ValueError(
             f"Index is not datetime. Received forecasts:{forecasts.head()}"
         )
-
+        
+    # save forecast to database #######################################################
+    context.database.write_forecast(forecasts)
+    logger.debug("Written forecast to database")
+    
+    # Check if forecast was complete enough, otherwise raise exception
     if forecasts.index.max() < datetime.utcnow().replace(tzinfo=pytz.utc) + timedelta(
         hours=30
     ):


### PR DESCRIPTION
Improved exception logging so we will get less confused when we receive the Exception on acc (no harm_arome is retrieved over the weekend, so no radiation is available).
Also, changed the order, so that if the component forecast can be made partially, that part is still stored.

Follow-up story defined: 
https://alliander.atlassian.net/browse/KTPS-2797