### PR TITLE
Bugfix/ktps 2838 stdev explodes

### DIFF
--- a/openstef/model/confidence_interval_applicator.py
+++ b/openstef/model/confidence_interval_applicator.py
@@ -67,10 +67,6 @@ class ConfidenceIntervalApplicator:
 
         The stdev for intermediate forecast horizons is interpolated.
 
-        For the input standard_deviation, it is preferred that the forecast horizon is
-        expressed in Hours, instead of 'Near/Far'. For now, Near/Far is supported,
-        but this will be deprecated.
-
         Args:
             forecast: Forecast DataFrame with columns: "forecast"
 
@@ -143,7 +139,9 @@ class ConfidenceIntervalApplicator:
             sf, sn = stdev_row[far], stdev_row[near]
             A = (sf - sn) / ((1 - np.exp(-far / tau)) - (1 - np.exp(-near / tau)))
             b = sn - A * (1 - np.exp(-near / tau))
-            return A * (1 - np.exp(-t / tau)) + b
+            value = A * (1 - np.exp(-t / tau)) + b
+            # cap the value to keep is between near and far
+            return np.max([sn, np.min([sf, value])])
 
         # If only one horizon is available use that one
         if len(stdev.columns) == 1:

--- a/openstef/model/confidence_interval_applicator.py
+++ b/openstef/model/confidence_interval_applicator.py
@@ -142,7 +142,7 @@ class ConfidenceIntervalApplicator:
             value = A * (1 - np.exp(-t / tau)) + b
             # cap the value to keep it between near and far
             if value < sn:
-                return sn 
+                return sn
             return sf if value > sf else value
 
         # If only one horizon is available use that one

--- a/openstef/model/confidence_interval_applicator.py
+++ b/openstef/model/confidence_interval_applicator.py
@@ -141,7 +141,7 @@ class ConfidenceIntervalApplicator:
             b = sn - A * (1 - np.exp(-near / tau))
             value = A * (1 - np.exp(-t / tau)) + b
             # cap the value to keep it between near and far
-            return np.max([sn, np.min([sf, value])])
+            return sn if value < sn else sf if value > sf else value
 
         # If only one horizon is available use that one
         if len(stdev.columns) == 1:

--- a/openstef/model/confidence_interval_applicator.py
+++ b/openstef/model/confidence_interval_applicator.py
@@ -141,7 +141,9 @@ class ConfidenceIntervalApplicator:
             b = sn - A * (1 - np.exp(-near / tau))
             value = A * (1 - np.exp(-t / tau)) + b
             # cap the value to keep it between near and far
-            return sn if value < sn else sf if value > sf else value
+            if value < sn:
+                return sn 
+            return sf if value > sf else value
 
         # If only one horizon is available use that one
         if len(stdev.columns) == 1:

--- a/openstef/model/confidence_interval_applicator.py
+++ b/openstef/model/confidence_interval_applicator.py
@@ -140,7 +140,7 @@ class ConfidenceIntervalApplicator:
             A = (sf - sn) / ((1 - np.exp(-far / tau)) - (1 - np.exp(-near / tau)))
             b = sn - A * (1 - np.exp(-near / tau))
             value = A * (1 - np.exp(-t / tau)) + b
-            # cap the value to keep is between near and far
+            # cap the value to keep it between near and far
             return np.max([sn, np.min([sf, value])])
 
         # If only one horizon is available use that one

--- a/openstef/model/standard_deviation_generator.py
+++ b/openstef/model/standard_deviation_generator.py
@@ -74,8 +74,8 @@ class StandardDeviationGenerator:
         for hour in range(24):
             hour_error = error[error.index == hour]
             result["stdev"].iloc[hour] = np.std(
-                hour_error.iloc[1:]
-            )  # Exclude first item as this is the hour itself!
+                hour_error
+            )  
             result["hour"].iloc[hour] = hour
 
         result = result.astype("float")

--- a/openstef/model/standard_deviation_generator.py
+++ b/openstef/model/standard_deviation_generator.py
@@ -73,9 +73,7 @@ class StandardDeviationGenerator:
         # For the time starts with 00, 01, 02, etc. TODO (MAKE MORE ELEGANT SOLUTION THAN A LOOP)
         for hour in range(24):
             hour_error = error[error.index == hour]
-            result["stdev"].iloc[hour] = np.std(
-                hour_error
-            )  
+            result["stdev"].iloc[hour] = np.std(hour_error)
             result["hour"].iloc[hour] = hour
 
         result = result.astype("float")

--- a/test/unit/model/test_confidence_interval_applicator.py
+++ b/test/unit/model/test_confidence_interval_applicator.py
@@ -34,13 +34,14 @@ class MockModel:
     @property
     def can_predict_quantiles(self):
         return True
-    
+
+
 class MockModelMultiHorizonStdev(MockModel):
     standard_deviation = pd.DataFrame(
         {
-            "stdev": [.1, 2.9, 1.6, 1.9, 3.2]+[2.1,5,8,12,14],
-            "hour": [0, 1, 2, 3, 4]*2,
-            "horizon": [5, 5, 5, 5, 5]+[10,10,10,10,10],
+            "stdev": [0.1, 2.9, 1.6, 1.9, 3.2] + [2.1, 5, 8, 12, 14],
+            "hour": [0, 1, 2, 3, 4] * 2,
+            "horizon": [5, 5, 5, 5, 5] + [10, 10, 10, 10, 10],
         }
     )
 
@@ -151,20 +152,22 @@ class TestConfidenceIntervalApplicator(TestCase):
         for expected_column in expected_new_columns:
             self.assertTrue(expected_column in pp_forecast.columns)
 
-
     def test_add_standard_deviation_to_forecast_in_past(self):
         """Forecasts for negative/zero lead times should result in an exploding stdev"""
-        forecast = pd.DataFrame({"forecast": [5, 6, 7],
-                                 "tAhead": [-1.0, 0.0, 1.0]})
+        forecast = pd.DataFrame({"forecast": [5, 6, 7], "tAhead": [-1.0, 0.0, 1.0]})
         forecast.index = [
             pd.Timestamp(2012, 5, 1, 1, 30),
             pd.Timestamp(2012, 5, 1, 1, 45),
             pd.Timestamp(2012, 5, 1, 2, 00),
         ]
-        
+
         actual_stdev_forecast = ConfidenceIntervalApplicator(
             MockModelMultiHorizonStdev(), self.stdev_forecast
         )._add_standard_deviation_to_forecast(forecast)
         self.assertTrue("stdev" in actual_stdev_forecast.columns)
-        self.assertGreaterEqual(actual_stdev_forecast["stdev"].min(), 0.1 ) #=> MockModel.standard_deviation.stdev.min()
-        self.assertLessEqual(actual_stdev_forecast["stdev"].max(), 14) # => MockModel.standard_deviation.stdev.max())
+        self.assertGreaterEqual(
+            actual_stdev_forecast["stdev"].min(), 0.1
+        )  # => MockModel.standard_deviation.stdev.min()
+        self.assertLessEqual(
+            actual_stdev_forecast["stdev"].max(), 14
+        )  # => MockModel.standard_deviation.stdev.max())

--- a/test/unit/model/test_standard_deviation_generator.py
+++ b/test/unit/model/test_standard_deviation_generator.py
@@ -11,11 +11,14 @@ from openstef.model.standard_deviation_generator import StandardDeviationGenerat
 class MockModel:
     def predict(self, *args):
 
-        # Prepare mock_forecast
+        # Prepare mock_forecast - 
+        # it should include mutliple observations of the
+        # same time of day for the same horizon, 
+        # otherwise the stdev of the error cannot be calculated
         mock_forecast = pd.DataFrame(
             {
-                "forecast": [1, 2, 3, 4, 1, 3, 3, 7],
-                "horizon": [47.0, 47.0, 47.0, 47.0, 24.0, 24.0, 24.0, 24.0],
+                "forecast": [1, 2, 3, 4, 2, 4, 6, 8],
+                "horizon": [1.0, 2.0, 3.0, 4.0]*2,
             }
         )
         mock_forecast = mock_forecast.set_index(
@@ -25,10 +28,10 @@ class MockModel:
                     "2018-01-01 01:00:00",
                     "2018-01-01 02:00:00",
                     "2018-01-01 03:00:00",
-                    "2018-01-01 00:00:00",
-                    "2018-01-01 01:00:00",
-                    "2018-01-01 02:00:00",
-                    "2018-01-01 03:00:00",
+                    "2018-01-02 00:00:00",
+                    "2018-01-02 01:00:00",
+                    "2018-01-02 02:00:00",
+                    "2018-01-02 03:00:00",
                 ]
             )
         )
@@ -44,10 +47,10 @@ class TestStandardDeviationGenerator(unittest.TestCase):
         # Prepare mock validation data
         mock_validation_data = pd.DataFrame(
             {
-                "load": [4, 2, 5, 2, 4, 2, 5, 2],
-                "feature_1": [4, 2, 5, 2, 5, 4, 8, 2],
-                "feature_2": [4, 2, 5, 2, 5, 4, 8, 2],
-                "horizon": [47.0, 47.0, 47.0, 47.0, 24.0, 24.0, 24.0, 24.0],
+                "load": [4, 2, 5, 2, 4, 2, 5, 2]*2,
+                "feature_1": [4, 2, 5, 2, 5, 4, 8, 2]*2,
+                "feature_2": [4, 2, 5, 2, 5, 4, 8, 2]*2,
+                "horizon": [47.0, 47.0, 47.0, 47.0, 24.0, 24.0, 24.0, 24.0]*2,
             }
         )
 
@@ -62,6 +65,14 @@ class TestStandardDeviationGenerator(unittest.TestCase):
                     "2018-01-01 01:00:00",
                     "2018-01-01 02:00:00",
                     "2018-01-01 03:00:00",
+                    "2018-01-02 00:00:00",
+                    "2018-01-02 01:00:00",
+                    "2018-01-02 02:00:00",
+                    "2018-01-02 03:00:00",
+                    "2018-01-02 00:00:00",
+                    "2018-01-02 01:00:00",
+                    "2018-01-02 02:00:00",
+                    "2018-01-02 03:00:00",
                 ]
             )
         )
@@ -74,7 +85,7 @@ class TestStandardDeviationGenerator(unittest.TestCase):
         # Generate reference dataframe of expected output, this data has been checked.
         ref_df = pd.DataFrame(
             {
-                "stdev": [0, 0.0, 0.0, 0.0],
+                "stdev": [0.5, 1.0, 1.5, 2.0],
                 "hour": [0.0, 1.0, 2.0, 3.0],
                 "horizon": [47.0, 47.0, 47.0, 47.0],
             }
@@ -90,3 +101,5 @@ class TestStandardDeviationGenerator(unittest.TestCase):
 
         # Check if all horizons are pressent
         self.assertEqual([47.0, 24.0], list(model.standard_deviation.horizon.unique()))
+      
+

--- a/test/unit/model/test_standard_deviation_generator.py
+++ b/test/unit/model/test_standard_deviation_generator.py
@@ -11,14 +11,14 @@ from openstef.model.standard_deviation_generator import StandardDeviationGenerat
 class MockModel:
     def predict(self, *args):
 
-        # Prepare mock_forecast - 
+        # Prepare mock_forecast -
         # it should include mutliple observations of the
-        # same time of day for the same horizon, 
+        # same time of day for the same horizon,
         # otherwise the stdev of the error cannot be calculated
         mock_forecast = pd.DataFrame(
             {
                 "forecast": [1, 2, 3, 4, 2, 4, 6, 8],
-                "horizon": [1.0, 2.0, 3.0, 4.0]*2,
+                "horizon": [1.0, 2.0, 3.0, 4.0] * 2,
             }
         )
         mock_forecast = mock_forecast.set_index(
@@ -47,10 +47,10 @@ class TestStandardDeviationGenerator(unittest.TestCase):
         # Prepare mock validation data
         mock_validation_data = pd.DataFrame(
             {
-                "load": [4, 2, 5, 2, 4, 2, 5, 2]*2,
-                "feature_1": [4, 2, 5, 2, 5, 4, 8, 2]*2,
-                "feature_2": [4, 2, 5, 2, 5, 4, 8, 2]*2,
-                "horizon": [47.0, 47.0, 47.0, 47.0, 24.0, 24.0, 24.0, 24.0]*2,
+                "load": [4, 2, 5, 2, 4, 2, 5, 2] * 2,
+                "feature_1": [4, 2, 5, 2, 5, 4, 8, 2] * 2,
+                "feature_2": [4, 2, 5, 2, 5, 4, 8, 2] * 2,
+                "horizon": [47.0, 47.0, 47.0, 47.0, 24.0, 24.0, 24.0, 24.0] * 2,
             }
         )
 
@@ -101,5 +101,3 @@ class TestStandardDeviationGenerator(unittest.TestCase):
 
         # Check if all horizons are pressent
         self.assertEqual([47.0, 24.0], list(model.standard_deviation.horizon.unique()))
-      
-


### PR DESCRIPTION
Adds a cap on the extrapolation of the standard deviation for non-trained horizons.
Also, improved the (flawed) unit test of the stdev calculation.
