### PR TITLE
Feature/ktps 3015 remove old mlflow artifacts

### DIFF
--- a/openstef/model/serializer.py
+++ b/openstef/model/serializer.py
@@ -274,7 +274,9 @@ class MLflowSerializer:
         return model_age_days
 
     def remove_old_models(
-        self, experiment_name: str, max_n_models: int = 10,
+        self,
+        experiment_name: str,
+        max_n_models: int = 10,
     ):
         """Remove old models per experiment."""
         if max_n_models < 1:
@@ -300,11 +302,13 @@ class MLflowSerializer:
                 # mlflow.delete_run marks it as deleted but does not delete it by itself
                 # Remove artifacts to save disk space
                 try:
-                    repository = get_artifact_repository(mlflow.get_run(run.run_id).info.artifact_uri)
+                    repository = get_artifact_repository(
+                        mlflow.get_run(run.run_id).info.artifact_uri
+                    )
                     repository.delete_artifacts()
                     self.logger.debug("Removed artifacts")
                 except Exception as e:
-                    self.logger.info(F"Failed removing artifacts: {e}")
+                    self.logger.info(f"Failed removing artifacts: {e}")
 
     def _get_feature_names(
         self,

--- a/openstef/pipeline/train_model.py
+++ b/openstef/pipeline/train_model.py
@@ -124,7 +124,7 @@ def train_model_pipeline(
 
     # Clean up older models
     serializer.remove_old_models(
-        experiment_name=str(pj["id"]), artifact_folder=artifact_folder
+        experiment_name=str(pj["id"])
     )
 
     if pj.save_train_forecasts:

--- a/openstef/pipeline/train_model.py
+++ b/openstef/pipeline/train_model.py
@@ -123,9 +123,7 @@ def train_model_pipeline(
         Reporter.write_report_to_disk(report=report, report_folder=report_folder)
 
     # Clean up older models
-    serializer.remove_old_models(
-        experiment_name=str(pj["id"])
-    )
+    serializer.remove_old_models(experiment_name=str(pj["id"]))
 
     if pj.save_train_forecasts:
         return data_sets

--- a/test/unit/model/test_serializer.py
+++ b/test/unit/model/test_serializer.py
@@ -4,6 +4,8 @@
 
 import glob
 import tempfile
+import yaml
+from pathlib import Path
 from datetime import datetime, timedelta
 from distutils.dir_util import copy_tree
 from test.unit.utils.base import BaseTestCase
@@ -20,6 +22,20 @@ from openstef.model.serializer import MLflowSerializer
 
 
 class TestMLflowSerializer(BaseTestCase):
+    @staticmethod
+    def _rewrite_absolute_artifact_path(
+        metadata_file: str, new_path: str, artifact_path_key: str
+    ) -> None:
+        """Helper function to rewrite the absolute path of the artifacts in meta.yaml files.
+        This is required since generating new models takes too long for a unit test and relative paths are not supported."""
+        with open(metadata_file, "r") as f:
+            metadata = yaml.safe_load(f)
+
+        metadata[artifact_path_key] = f"file://{new_path}"
+
+        with open(metadata_file, "w") as f:
+            yaml.dump(metadata, f, default_flow_style=False, sort_keys=False)
+
     def setUp(self) -> None:
         super().setUp()
         self.pj, self.modelspecs = TestData.get_prediction_job_and_modelspecs(pid=307)
@@ -331,6 +347,30 @@ class TestMLflowSerializer(BaseTestCase):
             # Copy already stored models to temp dir
             copy_tree(local_model_dir, temp_model_dir)
 
+            # Fix absolute artifact path in all meta.yaml files
+            for experiment_folder in (
+                Path(f"{temp_model_dir}/mlruns").resolve().iterdir()
+            ):
+                metadata_file = experiment_folder / "meta.yaml"
+
+                # Fix experiment metadata
+                if metadata_file.exists():
+                    self._rewrite_absolute_artifact_path(
+                        metadata_file=metadata_file,
+                        new_path=experiment_folder,
+                        artifact_path_key="artifact_location",
+                    )
+                for run_folder in experiment_folder.iterdir():
+                    metadata_file = run_folder / "meta.yaml"
+
+                    # Fix run metadata
+                    if metadata_file.exists():
+                        self._rewrite_absolute_artifact_path(
+                            metadata_file=metadata_file,
+                            new_path=run_folder / "artifacts",
+                            artifact_path_key="artifact_uri",
+                        )
+
             serializer = MLflowSerializer(
                 mlflow_tracking_uri="file:" + temp_model_dir + "/mlruns"
             )
@@ -338,9 +378,7 @@ class TestMLflowSerializer(BaseTestCase):
             all_stored_models = serializer._find_models(str(self.pj["id"]))
 
             # Remove old models
-            serializer.remove_old_models(
-                str(self.pj["id"]), max_n_models=2
-            )
+            serializer.remove_old_models(str(self.pj["id"]), max_n_models=2)
             # Check which models are left
             final_stored_models = serializer._find_models(str(self.pj["id"]))
 
@@ -361,5 +399,7 @@ class TestMLflowSerializer(BaseTestCase):
             )
 
             # Check if models are removed from disk
-            model_dirs = glob.glob(f"{temp_model_dir}/mlruns/1/*/", recursive=True)
+            model_dirs = glob.glob(
+                f"{temp_model_dir}/mlruns/1/**/*.pkl", recursive=True
+            )
             self.assertEqual(len(model_dirs), 2)

--- a/test/unit/model/test_serializer.py
+++ b/test/unit/model/test_serializer.py
@@ -339,7 +339,7 @@ class TestMLflowSerializer(BaseTestCase):
 
             # Remove old models
             serializer.remove_old_models(
-                str(self.pj["id"]), max_n_models=2, artifact_folder=temp_model_dir
+                str(self.pj["id"]), max_n_models=2
             )
             # Check which models are left
             final_stored_models = serializer._find_models(str(self.pj["id"]))


### PR DESCRIPTION
As for the unit test: mlflow does not support relative paths for the artifacts in the meta.yaml files. Furthermore, creating four new models takes too long for a unit test. Therefore, I choose to dynamically update the yaml files during the test in the temp directory, using a helper function (I wonder if the placement of this function is okay)