### PR TITLE
Upgrade pydantic to v2 while referencing v1

### DIFF
--- a/openstef/data_classes/data_prep.py
+++ b/openstef/data_classes/data_prep.py
@@ -7,7 +7,7 @@ import json
 from importlib import import_module
 from typing import Any, Sequence, Union, TypeVar
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 DataPrepClass = TypeVar("DataPrepClass")
 

--- a/openstef/data_classes/model_specifications.py
+++ b/openstef/data_classes/model_specifications.py
@@ -4,7 +4,7 @@
 """Specifies the dataclass for model specifications."""
 from typing import Optional, Union
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class ModelSpecificationDataClass(BaseModel):

--- a/openstef/data_classes/prediction_job.py
+++ b/openstef/data_classes/prediction_job.py
@@ -4,7 +4,7 @@
 """Specifies the prediction job dataclass."""
 from typing import Optional, Union
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from openstef.data_classes.model_specifications import ModelSpecificationDataClass
 from openstef.data_classes.split_function import SplitFuncDataClass

--- a/openstef/data_classes/split_function.py
+++ b/openstef/data_classes/split_function.py
@@ -7,7 +7,7 @@ import json
 from importlib import import_module
 from typing import Any, Callable, Sequence, Union
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class SplitFuncDataClass(BaseModel):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ optuna~=3.1
 pandas~=2.0
 plotly~=5.14
 pvlib==0.9.4
-pydantic~=1.10
+pydantic~=2.4
 pymsteams~=0.2.2   # TODO remove teams dependency
 scikit-learn~=1.3
 scipy~=1.10

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def read_long_description_from_readme():
 
 setup(
     name="openstef",
-    version="3.3.4",
+    version="3.3.4", 
     packages=find_packages(include=["openstef", "openstef.*"]),
     description="Open short term energy forecaster",
     long_description=read_long_description_from_readme(),

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def read_long_description_from_readme():
 
 setup(
     name="openstef",
-    version="3.3.4", 
+    version="3.3.4",
     packages=find_packages(include=["openstef", "openstef.*"]),
     description="Open short term energy forecaster",
     long_description=read_long_description_from_readme(),

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def read_long_description_from_readme():
 
 setup(
     name="openstef",
-    version="3.3.3",
+    version="3.3.4",
     packages=find_packages(include=["openstef", "openstef.*"]),
     description="Open short term energy forecaster",
     long_description=read_long_description_from_readme(),


### PR DESCRIPTION
The LF Energy RTDIP team leverage pydantic v2 and currently working on integration with Openstef. One particular package that we would like to upgrade in Openstef is pydantic. 

To not break code, pydantic has provided a [migration procedure](https://docs.pydantic.dev/latest/migration/#continue-using-pydantic-v1-features) that allows upgrading of the package but still being able to reference pydantic using `from pydantic.v1 import ....`. 

This PR therefore upgrades the pydantic version in requirements.txt and also updates any imports in the code to use `from pydantic.v1`