### PR TITLE
Bugfix failing tests after pandas 2.2 upgrade. 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ matplotlib~=3.7
 mlflow~=2.3
 networkx~=3.1
 optuna~=3.1
-pandas==2.2.0
+pandas~=2.2.0
 plotly~=5.18
 pvlib==0.9.4
 pydantic~=2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ matplotlib~=3.7
 mlflow~=2.3
 networkx~=3.1
 optuna~=3.1
-pandas==2.1.3
+pandas==2.2.0
 plotly~=5.18
 pvlib==0.9.4
 pydantic~=2.4

--- a/test/unit/model/test_fallback.py
+++ b/test/unit/model/test_fallback.py
@@ -24,7 +24,10 @@ class TestFallback(BaseTestCase):
             fallback_strategy="extreme_day",
         )
 
-        self.assertDataframeEqual(fallback_forecast, expected_forecast)
+        self.assertDataframeEqual(
+            fallback_forecast.sort_index(),
+            expected_forecast.sort_index(),
+        )
 
     def test_generate_fallback_empty_load(self):
         """Test if exception is raised if load is empty"""


### PR DESCRIPTION
## Issue: 
The unit test test_generate_fallback_happy_flow ([openstef/test/unit/model/test_fallback.py at e48d277d0948b015fb48e2ee6e3155d4da49a89a · OpenSTEF/openstef (github.com)](https://github.com/OpenSTEF/openstef/blob/e48d277d0948b015fb48e2ee6e3155d4da49a89a/test/unit/model/test_fallback.py#L15)) fails when using pandas 2.2.0 (as of writing the latest version of pandas)
The test works fine using pandas 2.1.3, so it seems that OpenSTEF currently breaks with the latest pandas version.

## Solution
This issue seems to be related to the following change in pandas 2.2.0: [What’s new in 2.2.0 (January 19, 2024) — pandas 2.2.0 documentation](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v2.2.0.html#merge-and-dataframe-join-now-consistently-follow-documented-sort-behavior) 
In short, previously pandas did not guarantee any sorting when doing a merge, now it does.

What is happening here is that expected_forecast is loaded from a file with no sorting applied (likely generated from verified output of the previous version.)
Because the output now is sorted ([related code](https://github.com/OpenSTEF/openstef/blob/e48d277d0948b015fb48e2ee6e3155d4da49a89a/openstef/model/fallback.py#L65)), direct comparison doesn’t work.

Updating to pandas 2.2 changes functionality of openstef either way, because there is no way to unsort the merged array. Luckily given it was not sorted before, I suspect no one expected any ordered output from the function.

Proposed fix: Sort both dataframes by index during comparison in tests. This fixes the issue, and avoids similar issues in the future if pandas decides to change guarantees of the merge function again.

This is the only test affected.