### PR TITLE
update on both .shift() and [index].iloc[column] deprecation warning

### DIFF
--- a/openstef/feature_engineering/lag_features.py
+++ b/openstef/feature_engineering/lag_features.py
@@ -43,7 +43,7 @@ def generate_lag_feature_functions(
     for minutes in lag_times_minutes:  # Add intraday-lag functions (lags in minutes)
 
         def func(x, shift=minutes):
-            return x.shift(freq="T", periods=1 * shift)
+            return x.shift(freq="min", periods=1 * shift)
 
         new = {"T-" + str(int(minutes)) + "min": func}
         lag_functions.update(new)

--- a/openstef/model/standard_deviation_generator.py
+++ b/openstef/model/standard_deviation_generator.py
@@ -72,6 +72,7 @@ class StandardDeviationGenerator:
         # For the time starts with 00, 01, 02, etc. TODO (MAKE MORE ELEGANT SOLUTION THAN A LOOP)
         for hour in range(24):
             hour_error = error[error.index == hour]
+            
             result.loc[hour, "stdev"] = np.std(hour_error)
             result.loc[hour, "hour"] = hour
 

--- a/openstef/model/standard_deviation_generator.py
+++ b/openstef/model/standard_deviation_generator.py
@@ -72,7 +72,7 @@ class StandardDeviationGenerator:
         # For the time starts with 00, 01, 02, etc. TODO (MAKE MORE ELEGANT SOLUTION THAN A LOOP)
         for hour in range(24):
             hour_error = error[error.index == hour]
-            
+
             result.loc[hour, "stdev"] = np.std(hour_error)
             result.loc[hour, "hour"] = hour
 

--- a/openstef/model/standard_deviation_generator.py
+++ b/openstef/model/standard_deviation_generator.py
@@ -72,8 +72,8 @@ class StandardDeviationGenerator:
         # For the time starts with 00, 01, 02, etc. TODO (MAKE MORE ELEGANT SOLUTION THAN A LOOP)
         for hour in range(24):
             hour_error = error[error.index == hour]
-            result["stdev"].iloc[hour] = np.std(hour_error)
-            result["hour"].iloc[hour] = hour
+            result.loc[hour, "stdev"]=np.std(hour_error)
+            result.loc[hour, "hour"] = hour
 
         result = result.astype("float")
 

--- a/openstef/model/standard_deviation_generator.py
+++ b/openstef/model/standard_deviation_generator.py
@@ -72,7 +72,7 @@ class StandardDeviationGenerator:
         # For the time starts with 00, 01, 02, etc. TODO (MAKE MORE ELEGANT SOLUTION THAN A LOOP)
         for hour in range(24):
             hour_error = error[error.index == hour]
-            result.loc[hour, "stdev"]=np.std(hour_error)
+            result.loc[hour, "stdev"] = np.std(hour_error)
             result.loc[hour, "hour"] = hour
 
         result = result.astype("float")

--- a/test/unit/pipeline/test_create_basecase.py
+++ b/test/unit/pipeline/test_create_basecase.py
@@ -28,7 +28,7 @@ class TestBaseCaseForecast(BaseTestCase):
             - (forecast_input.index.max() - timedelta(days=7))
         ).total_seconds()
         forecast_input = forecast_input.shift(
-            freq="T", periods=int(int(offset_seconds / 60.0 / 15.0) * 15)
+            freq="min", periods=int(int(offset_seconds / 60.0 / 15.0) * 15)
         )
 
         self.forecast_input = forecast_input


### PR DESCRIPTION
Fixes deprecation warning of pandas 2.2