### PR TITLE
Updated requirements.txt to use more permissive contraints for structlog.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ pymsteams~=0.2.2   # TODO remove teams dependency
 scikit-learn~=1.3
 scipy~=1.10
 statsmodels~=0.13.5
-structlog~=23.1
+structlog>=23.1,<25
 xgboost~=2.0


### PR DESCRIPTION
Reason: Most of the internal packages such as logger require structlog 24 and up. The change allows openstef to be installed alongside those packages without conflicts.

Passed all tests.

