### PR TITLE
KTP-762 Implemented Linear Quantile Regression Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,4 @@ Please read [CODE_OF_CONDUCT.md](https://github.com/OpenSTEF/.github/blob/main/C
 
 ## Contact
 Please read [SUPPORT.md](https://github.com/OpenSTEF/.github/blob/main/SUPPORT.md) for how to connect and get into contact with the OpenSTEF project
+

--- a/openstef/data_classes/prediction_job.py
+++ b/openstef/data_classes/prediction_job.py
@@ -25,10 +25,13 @@ class PredictionJobDataClass(BaseModel):
         - ``"xgb_quantile"``
         - ``"lgb"``
         - ``"linear"``
+        - ``"linear_quantile"``
 
     If unsure what to pick, choose ``"xgb"``.
 
     """
+    model_kwargs: Optional[dict]
+    """The model parameters that should be used."""
     forecast_type: str
     """The type of forecasts that should be made.
 

--- a/openstef/enums.py
+++ b/openstef/enums.py
@@ -10,6 +10,7 @@ class MLModelType(Enum):
     XGB_QUANTILE = "xgb_quantile"
     LGB = "lgb"
     LINEAR = "linear"
+    LINEAR_QUANTILE = "linear_quantile"
     ARIMA = "arima"
 
 

--- a/openstef/feature_engineering/missing_values_transformer.py
+++ b/openstef/feature_engineering/missing_values_transformer.py
@@ -1,0 +1,69 @@
+from typing import Union, List
+
+import numpy as np
+import pandas as pd
+from sklearn.impute import SimpleImputer
+from sklearn.preprocessing import FunctionTransformer
+from sklearn.utils.validation import check_array
+
+
+class MissingValuesTransformer:
+    in_feature_names: List[str] = None
+    _n_in_features: int = None
+
+    non_null_feature_names: List[str] = None
+
+    def __init__(
+            self,
+            missing_values: Union[int, float, str, None] = np.nan,
+            imputation_strategy: str = None,
+            fill_value: Union[str, int, float] = None,
+    ):
+        """Initialize missing values handler."""
+        self.missing_values = missing_values
+        self.imputation_strategy = imputation_strategy
+        self.fill_value = fill_value
+
+    def fit(self, x, y=None):
+        _ = check_array(x, force_all_finite="allow-nan")
+        if type(x) != pd.DataFrame:
+            x = pd.DataFrame(np.asarray(x))
+
+        self.in_feature_names = list(x.columns)
+        self._n_in_features = x.shape[1]
+
+        # Remove always null columns
+        is_column_null = x.isnull().all(axis="index")
+        self.non_null_feature_names = list(x.columns[~is_column_null])
+
+        # Build the proper imputation transformer
+        # - Identity function if strategy is None
+        # - SimpleImputer with the dedicated strategy
+        if self.imputation_strategy is None:
+            self.imputer_ = FunctionTransformer(func=self._identity)
+        else:
+            self.imputer_ = SimpleImputer(
+                missing_values=self.missing_values,
+                strategy=self.imputation_strategy,
+                fill_value=self.fill_value,
+            ).set_output(transform="pandas")
+
+        # Imputers do not support labels
+        self.imputer_.fit(X=x, y=None)
+
+    def transform(self, x) -> pd.DataFrame:
+        _ = check_array(x, force_all_finite="allow-nan")
+        if type(x) != pd.DataFrame:
+            x = pd.DataFrame(np.asarray(x))
+
+        x = x[self.non_null_feature_names]
+
+        return self.imputer_.transform(x)
+
+    def fit_transform(self, x, y=None):
+        self.fit(x, y)
+        return self.transform(x)
+
+    @classmethod
+    def _identity(cls, x):
+        return x

--- a/openstef/feature_engineering/missing_values_transformer.py
+++ b/openstef/feature_engineering/missing_values_transformer.py
@@ -14,10 +14,10 @@ class MissingValuesTransformer:
     non_null_feature_names: List[str] = None
 
     def __init__(
-            self,
-            missing_values: Union[int, float, str, None] = np.nan,
-            imputation_strategy: str = None,
-            fill_value: Union[str, int, float] = None,
+        self,
+        missing_values: Union[int, float, str, None] = np.nan,
+        imputation_strategy: str = None,
+        fill_value: Union[str, int, float] = None,
     ):
         """Initialize missing values handler."""
         self.missing_values = missing_values

--- a/openstef/feature_engineering/missing_values_transformer.py
+++ b/openstef/feature_engineering/missing_values_transformer.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017-2023 Contributors to the OpenSTEF project <korte.termijn.prognoses@alliander.com> # noqa E501>
+#
+# SPDX-License-Identifier: MPL-2.0
 from typing import Union, List
 
 import numpy as np

--- a/openstef/feature_engineering/missing_values_transformer.py
+++ b/openstef/feature_engineering/missing_values_transformer.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2017-2023 Contributors to the OpenSTEF project <korte.termijn.prognoses@alliander.com> # noqa E501>
 #
 # SPDX-License-Identifier: MPL-2.0
-from typing import Union, List
+from typing import Union, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -11,8 +11,13 @@ from sklearn.utils.validation import check_array
 
 
 class MissingValuesTransformer:
-    in_feature_names: List[str] = None
-    _n_in_features: int = None
+    """
+    MissingValuesTransformer handles missing values in data by imputing them with a
+    given strategy. It also removes columns that are always null from the data.
+    """
+
+    in_feature_names: Optional[List[str]] = None
+    _n_in_features: Optional[int] = None
 
     non_null_feature_names: List[str] = None
 
@@ -22,14 +27,27 @@ class MissingValuesTransformer:
         imputation_strategy: str = None,
         fill_value: Union[str, int, float] = None,
     ):
-        """Initialize missing values handler."""
+        """
+        Initialize missing values handler.
+
+        Args:
+            missing_values: The placeholder for the missing values. All occurrences of
+                `missing_values` will be imputed.
+            imputation_strategy: The imputation strategy to use
+                Can be one of "mean", "median", "most_frequent", "constant" or None.
+            fill_value: When strategy == "constant", fill_value is used to replace all
+                occurrences of missing_values.
+        """
         self.missing_values = missing_values
         self.imputation_strategy = imputation_strategy
         self.fill_value = fill_value
 
     def fit(self, x, y=None):
+        """
+        Fit the imputer on the input data.
+        """
         _ = check_array(x, force_all_finite="allow-nan")
-        if type(x) != pd.DataFrame:
+        if not isinstance(x, pd.DataFrame):
             x = pd.DataFrame(np.asarray(x))
 
         self.in_feature_names = list(x.columns)
@@ -55,8 +73,11 @@ class MissingValuesTransformer:
         self.imputer_.fit(X=x, y=None)
 
     def transform(self, x) -> pd.DataFrame:
+        """
+        Transform the input data by imputing missing values.
+        """
         _ = check_array(x, force_all_finite="allow-nan")
-        if type(x) != pd.DataFrame:
+        if not isinstance(x, pd.DataFrame):
             x = pd.DataFrame(np.asarray(x))
 
         x = x[self.non_null_feature_names]
@@ -64,9 +85,18 @@ class MissingValuesTransformer:
         return self.imputer_.transform(x)
 
     def fit_transform(self, x, y=None):
+        """
+        Fit the imputer on the input data and transform it.
+
+        Returns:
+            The data with missing values imputed.
+        """
         self.fit(x, y)
         return self.transform(x)
 
     @classmethod
     def _identity(cls, x):
         return x
+
+    def __sklearn_is_fitted__(self) -> bool:
+        return self.in_feature_names is not None

--- a/openstef/feature_engineering/missing_values_transformer.py
+++ b/openstef/feature_engineering/missing_values_transformer.py
@@ -11,9 +11,10 @@ from sklearn.utils.validation import check_array
 
 
 class MissingValuesTransformer:
-    """
-    MissingValuesTransformer handles missing values in data by imputing them with a
-    given strategy. It also removes columns that are always null from the data.
+    """MissingValuesTransformer handles missing values in data by imputing them with a given strategy.
+
+    It also removes columns that are always null from the data.
+
     """
 
     in_feature_names: Optional[List[str]] = None
@@ -27,8 +28,7 @@ class MissingValuesTransformer:
         imputation_strategy: str = None,
         fill_value: Union[str, int, float] = None,
     ):
-        """
-        Initialize missing values handler.
+        """Initialize missing values handler.
 
         Args:
             missing_values: The placeholder for the missing values. All occurrences of
@@ -37,15 +37,14 @@ class MissingValuesTransformer:
                 Can be one of "mean", "median", "most_frequent", "constant" or None.
             fill_value: When strategy == "constant", fill_value is used to replace all
                 occurrences of missing_values.
+
         """
         self.missing_values = missing_values
         self.imputation_strategy = imputation_strategy
         self.fill_value = fill_value
 
     def fit(self, x, y=None):
-        """
-        Fit the imputer on the input data.
-        """
+        """Fit the imputer on the input data."""
         _ = check_array(x, force_all_finite="allow-nan")
         if not isinstance(x, pd.DataFrame):
             x = pd.DataFrame(np.asarray(x))
@@ -73,9 +72,7 @@ class MissingValuesTransformer:
         self.imputer_.fit(X=x, y=None)
 
     def transform(self, x) -> pd.DataFrame:
-        """
-        Transform the input data by imputing missing values.
-        """
+        """Transform the input data by imputing missing values."""
         _ = check_array(x, force_all_finite="allow-nan")
         if not isinstance(x, pd.DataFrame):
             x = pd.DataFrame(np.asarray(x))
@@ -85,11 +82,11 @@ class MissingValuesTransformer:
         return self.imputer_.transform(x)
 
     def fit_transform(self, x, y=None):
-        """
-        Fit the imputer on the input data and transform it.
+        """Fit the imputer on the input data and transform it.
 
         Returns:
             The data with missing values imputed.
+
         """
         self.fit(x, y)
         return self.transform(x)

--- a/openstef/model/model_creator.py
+++ b/openstef/model/model_creator.py
@@ -11,6 +11,7 @@ from openstef.model.regressors.arima import ARIMAOpenstfRegressor
 from openstef.model.regressors.custom_regressor import is_custom_type, load_custom_model
 from openstef.model.regressors.lgbm import LGBMOpenstfRegressor
 from openstef.model.regressors.linear import LinearOpenstfRegressor
+from openstef.model.regressors.linear_quantile import LinearQuantileOpenstfRegressor
 from openstef.model.regressors.regressor import OpenstfRegressor
 from openstef.model.regressors.xgb import XGBOpenstfRegressor
 from openstef.model.regressors.xgb_quantile import XGBQuantileOpenstfRegressor
@@ -91,6 +92,14 @@ valid_model_kwargs = {
         "imputation_strategy",
         "fill_value",
     ],
+    MLModelType.LINEAR_QUANTILE: [
+        "alpha",
+        "quantiles",
+        "solver",
+        "missing_values",
+        "imputation_strategy",
+        "fill_value",
+    ],
     MLModelType.ARIMA: [
         "backtest_max_horizon",
         "order",
@@ -109,6 +118,7 @@ class ModelCreator:
         MLModelType.LGB: LGBMOpenstfRegressor,
         MLModelType.XGB_QUANTILE: XGBQuantileOpenstfRegressor,
         MLModelType.LINEAR: LinearOpenstfRegressor,
+        MLModelType.LINEAR_QUANTILE: LinearQuantileOpenstfRegressor,
         MLModelType.ARIMA: ARIMAOpenstfRegressor,
     }
 

--- a/openstef/model/regressors/linear_quantile.py
+++ b/openstef/model/regressors/linear_quantile.py
@@ -140,6 +140,7 @@ class LinearQuantileOpenstfRegressor(OpenstfRegressor, RegressorMixin):
 
         Returns:
             Data without ignored features
+
         """
         return x.drop(columns=[c for c in x.columns if self._is_feature_ignored(c)])
 

--- a/openstef/model/regressors/linear_quantile.py
+++ b/openstef/model/regressors/linear_quantile.py
@@ -230,9 +230,6 @@ class LinearQuantileOpenstfRegressor(OpenstfRegressor, RegressorMixin):
             "quantiles",
             "alpha",
             "solver",
-            "missing_values",
-            "imputation_strategy",
-            "fill_value",
         ]
 
     def __sklearn_is_fitted__(self) -> bool:

--- a/openstef/model/regressors/linear_quantile.py
+++ b/openstef/model/regressors/linear_quantile.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2017-2023 Contributors to the OpenSTEF project <korte.termijn.prognoses@alliander.com> # noqa E501>
+#
+# SPDX-License-Identifier: MPL-2.0
 import re
 from typing import Dict, Union, Set
 

--- a/openstef/model/regressors/linear_quantile.py
+++ b/openstef/model/regressors/linear_quantile.py
@@ -1,0 +1,196 @@
+from typing import Dict, Union
+
+import numpy as np
+import pandas as pd
+from sklearn.base import RegressorMixin
+from sklearn.linear_model import QuantileRegressor
+from sklearn.preprocessing import MinMaxScaler
+from sklearn.utils.validation import check_is_fitted
+
+from openstef.feature_engineering.missing_values_transformer import \
+    MissingValuesTransformer
+from openstef.model.regressors.regressor import OpenstfRegressor
+
+DEFAULT_QUANTILES: tuple[float, ...] = (0.9, 0.5, 0.1)
+
+
+class LinearQuantileOpenstfRegressor(OpenstfRegressor, RegressorMixin):
+    quantiles: tuple[float, ...]
+    alpha: float
+    solver: str
+
+    imputer_: MissingValuesTransformer
+    x_scaler_: MinMaxScaler
+    y_scaler_: MinMaxScaler
+    models_: Dict[float, QuantileRegressor] = None
+
+    is_fitted_: bool = False
+
+    def __init__(
+            self,
+            quantiles: tuple[float, ...] = DEFAULT_QUANTILES,
+            alpha: float = 0.0,
+            solver: str = "highs",
+            missing_values: Union[int, float, str, None] = np.nan,
+            imputation_strategy: str = None,
+            fill_value: Union[str, int, float] = None,
+    ):
+        """Initialize LinearQuantileOpenstfRegressor.
+
+        Model that provides quantile regression with SKLearn QuantileRegressor.
+        For each desired quantile an QuantileRegressor model is trained,
+        these can later be used to predict quantiles.
+
+        Args:
+            quantiles: Tuple with desired quantiles, quantile 0.5 is required.
+                For example: (0.1, 0.5, 0.9)
+            alpha: Regularization constant for L1 regularization
+            solver: Solver to use for optimization
+            missing_values: Value to be considered as missing value
+            imputation_strategy: Imputation strategy
+            fill_value: Fill value
+
+        """
+        super().__init__()
+
+        # Check if quantile 0.5 is present. This is required.
+        if 0.5 not in quantiles:
+            raise ValueError(
+                "Cannot train quantile model as 0.5 is not in requested quantiles!"
+            )
+
+        self.quantiles = quantiles
+        self.alpha = alpha
+        self.solver = solver
+        self.imputer_ = MissingValuesTransformer(
+            missing_values=missing_values,
+            imputation_strategy=imputation_strategy,
+            fill_value=fill_value,
+        )
+        self.x_scaler_ = MinMaxScaler(feature_range=(-1, 1))
+        self.y_scaler_ = MinMaxScaler(feature_range=(0, 1))
+        self.models_ = {
+            quantile: QuantileRegressor(
+                alpha=alpha,
+                quantile=quantile,
+                solver=solver
+            )
+            for quantile in quantiles
+        }
+
+    @property
+    def feature_names(self) -> list:
+        """The names of the features used to train the model."""
+        check_is_fitted(self)
+        return self.imputer_.non_null_feature_names
+
+    @staticmethod
+    def _get_importance_names():
+        return {
+            "gain_importance_name": "total_gain",
+            "weight_importance_name": "weight",
+        }
+
+    @property
+    def can_predict_quantiles(self) -> bool:
+        """Attribute that indicates if the model predict particular quantiles."""
+        return True
+
+    def fit(self, x: pd.DataFrame, y: pd.Series, **kwargs) -> RegressorMixin:
+        """Fits linear quantile model.
+
+        Args:
+            x: Feature matrix
+            y: Labels
+
+        Returns:
+            Fitted LinearQuantile model
+
+        """
+        if type(y) != pd.Series:
+            y = pd.Series(np.asarray(y), name="load")
+
+        # Fix nan columns
+        x = self.imputer_.fit_transform(x)
+        if x.isna().any().any():
+            raise ValueError("There are nan values in the input data. Set "
+                             "imputation_strategy to solve them.")
+
+        # Apply feature scaling
+        x_scaled = self.x_scaler_.fit_transform(x)
+        y_scaled = self.y_scaler_.fit_transform(y.to_frame())[:, 0]
+
+        # Add more focus on extreme / peak values
+        sample_weight = np.abs(y_scaled)
+
+        # Fit quantile regressors
+        for quantile in self.quantiles:
+            self.models_[quantile].fit(
+                X=x_scaled,
+                y=y_scaled,
+                sample_weight=sample_weight
+            )
+
+        self.is_fitted_ = True
+
+        self.feature_importances_ = self._get_feature_importance_from_linear()
+
+        return self
+
+    def predict(self, x: pd.DataFrame, quantile: float = 0.5, **kwargs) -> np.array:
+        """Makes a prediction for a desired quantile.
+
+        Args:
+            x: Feature matrix
+            quantile: Quantile for which a prediciton is desired,
+                note that only quantile are available for which a model is trained,
+                and that this is a quantile-model specific keyword
+
+        Returns:
+            Prediction
+
+        Raises:
+            ValueError in case no model is trained for the requested quantile
+
+        """
+        check_is_fitted(self)
+
+        # Preprocess input data
+        x = self.imputer_.transform(x)
+        x_scaled = self.x_scaler_.transform(x)
+
+        # Make prediction
+        y_pred = self.models_[quantile].predict(X=x_scaled)
+
+        # Inverse scaling
+        y_pred = self.y_scaler_.inverse_transform(y_pred.reshape(-1, 1))[:, 0]
+
+        return y_pred
+
+    def _get_feature_importance_from_linear(self, quantile: float = 0.5) -> np.array:
+        check_is_fitted(self)
+        feature_importance_linear = np.abs(self.models_[quantile].coef_)
+        reg_feature_importances_dict = dict(
+            zip(self.imputer_.non_null_feature_names, feature_importance_linear)
+        )
+        return np.array([
+            reg_feature_importances_dict.get(c, 0)
+            for c in self.imputer_.in_feature_names
+        ])
+
+    @classmethod
+    def _get_param_names(cls):
+        return [
+            "quantiles",
+            "alpha",
+            "solver",
+            "missing_values",
+            "imputation_strategy",
+            "fill_value",
+        ]
+
+    def __sklearn_is_fitted__(self) -> bool:
+        return self.is_fitted_
+
+
+

--- a/openstef/pipeline/optimize_hyperparameters.py
+++ b/openstef/pipeline/optimize_hyperparameters.py
@@ -247,7 +247,7 @@ def optuna_optimization(
         - The objective object used by optuna
 
     """
-    model = ModelCreator.create_model(pj["model"])
+    model = ModelCreator.create_model(pj["model"], **(pj.model_kwargs or {}))
     # Apply set to default hyperparameters if they are specified in the pj
     if pj.default_modelspecs:
         valid_hyper_parameters = {

--- a/openstef/pipeline/train_create_forecast_backtest.py
+++ b/openstef/pipeline/train_create_forecast_backtest.py
@@ -61,6 +61,7 @@ def train_model_and_forecast_back_test(
         InputDataWrongColumnOrderError: when input data has a invalid column order.
         ValueError: when the horizon is a string and the corresponding column in not in the input data
         InputDataOngoingZeroFlatlinerError: when all recent load measurements are zero.
+
     """
     if pj.backtest_split_func is None:
         backtest_split_func = backtest_split_default
@@ -132,6 +133,7 @@ def train_model_and_forecast_test_core(
     Raises:
         NotImplementedError: When using invalid model type in the prediction job.
         InputDataWrongColumnOrderError: When 'load' column is not first and 'horizon' column is not last.
+
     """
     model = train_model.train_pipeline_step_train_model(
         pj, modelspecs, train_data, validation_data

--- a/openstef/pipeline/train_model.py
+++ b/openstef/pipeline/train_model.py
@@ -450,6 +450,7 @@ def train_pipeline_step_train_model(
     model = ModelCreator.create_model(
         pj["model"],
         quantiles=pj["quantiles"],
+        **(pj.model_kwargs or {}),
     )
 
     # split x and y data

--- a/openstef/postprocessing/postprocessing.py
+++ b/openstef/postprocessing/postprocessing.py
@@ -258,9 +258,9 @@ def sort_quantiles(
 ) -> pd.DataFrame:
     """Sort quantile values so quantiles do not cross.
 
-    This function assumes that all quantile columns start with 'quantile_P'
-    For more academic details on why this is mathematically sounds,
-    please refer to Quantile and Probability Curves Without Crossing (Chernozhukov, 2010)
+    This function assumes that all quantile columns start with 'quantile_P' For more academic details on why this is
+    mathematically sounds, please refer to Quantile and Probability Curves Without Crossing (Chernozhukov, 2010)
+
     """
     p_columns = [col for col in forecast.columns if col.startswith(quantile_col_start)]
 

--- a/test/unit/model/regressors/test_linear_quantile.py
+++ b/test/unit/model/regressors/test_linear_quantile.py
@@ -45,7 +45,7 @@ class TestLinearQuantile(BaseTestCase):
         self.assertIsNone(sklearn.utils.validation.check_is_fitted(model))
 
         # check if model is sklearn compatible
-        self.assertTrue(isinstance(model, sklearn.base.BaseEstimator))
+        self.assertIsInstance(model, sklearn.base.BaseEstimator)
 
         model.predict(train_input.iloc[:, 1:])
 

--- a/test/unit/model/regressors/test_linear_quantile.py
+++ b/test/unit/model/regressors/test_linear_quantile.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2017-2023 Contributors to the OpenSTEF project <korte.termijn.prognoses@alliander.com> # noqa E501>
+#
+# SPDX-License-Identifier: MPL-2.0
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import sklearn
+from sklearn.utils.estimator_checks import check_estimator
+
+from openstef.model.regressors.linear import LinearOpenstfRegressor
+from openstef.model.regressors.linear_quantile import LinearQuantileOpenstfRegressor
+from test.unit.utils.base import BaseTestCase
+from test.unit.utils.data import TestData
+
+train_input = TestData.load("reference_sets/307-train-data.csv")
+
+class MockModel:
+    coef_ = np.array([1, 1, 3])
+
+class TestLinearQuantile(BaseTestCase):
+    def setUp(self) -> None:
+        self.quantiles = [0.9, 0.5, 0.6, 0.1]
+
+    @unittest.skip  # Use this during development, this test requires not allowing nan vallues which we explicitly do allow.
+    def test_sklearn_compliant(self):
+        # Use sklearn build in check, this will raise an exception if some check fails
+        # During these tests the fit and predict methods are elaborately tested
+        # More info: https://scikit-learn.org/stable/modules/generated/sklearn.utils.estimator_checks.check_estimator.html
+        check_estimator(LinearQuantileOpenstfRegressor(quantiles=tuple(self.quantiles)))
+
+    def test_quantile_fit(self):
+        """Test happy flow of the training of model"""
+        model = LinearQuantileOpenstfRegressor()
+        model.fit(train_input.iloc[:, 1:], train_input.iloc[:, 0])
+
+        # check if the model was fitted (raises NotFittedError when not fitted)
+        self.assertIsNone(sklearn.utils.validation.check_is_fitted(model))
+
+        # check if model is sklearn compatible
+        self.assertTrue(isinstance(model, sklearn.base.BaseEstimator))
+
+        model.predict(train_input.iloc[:, 1:])
+
+        self.assertIsNotNone(model.feature_importances_)
+
+    def test_imputer(self):
+        n_sample = train_input.shape[0]
+        X = train_input.iloc[:, 1:].copy(deep=True)
+        sp = np.ones(n_sample)
+        sp[-1] = np.nan
+        X["Sparse"] = sp
+        model1 = LinearQuantileOpenstfRegressor(imputation_strategy=None)
+
+        with self.assertRaises(ValueError):
+            model1.fit(X, train_input.iloc[:, 0])
+
+        model2 = LinearQuantileOpenstfRegressor(imputation_strategy="mean")
+        model2.fit(X, train_input.iloc[:, 0])
+        self.assertIsNone(sklearn.utils.validation.check_is_fitted(model2))
+
+        X_ = pd.DataFrame(model2.imputer_.transform(X), columns=X.columns)
+        self.assertTrue((model2.predict(X_) == model2.predict(X)).all())
+
+    def test_value_error_raised(self):
+        # Check if Value Error is raised when 0.5 is not in the requested quantiles list
+        with self.assertRaises(ValueError):
+            LinearQuantileOpenstfRegressor((0.2, 0.3, 0.6, 0.7))
+
+    def test_predict_raises_valueerror_no_model_trained_for_quantile(self):
+        # Test if value error is raised when model is not available
+        with self.assertRaises(ValueError):
+            model = LinearQuantileOpenstfRegressor((0.2, 0.3, 0.5, 0.6, 0.7))
+            model.predict("test_data", quantile=0.8)
+
+    def test_importance_names(self):
+        model = LinearQuantileOpenstfRegressor(tuple(self.quantiles))
+        self.assertIsInstance(model._get_importance_names(), dict)
+
+    def test_get_feature_names_from_linear(self):
+        # Check if feature importance is extracted corretly
+        model = LinearQuantileOpenstfRegressor(quantiles=(0.2, 0.3, 0.5, 0.6, 0.7))
+        model.imputer_ = MagicMock()
+        model.imputer_.in_feature_names = ["a", "b", "c"]
+        model.imputer_.non_null_feature_names = ["a", "b", "c"]
+
+        model.is_fitted_ = True
+        model.models_ = {0.5: MockModel()}
+
+        self.assertTrue(
+            (
+                model._get_feature_importance_from_linear(quantile=0.5)
+                == np.array([1, 1, 3], dtype=np.float32)
+            ).all()
+        )
+

--- a/test/unit/model/regressors/test_linear_quantile.py
+++ b/test/unit/model/regressors/test_linear_quantile.py
@@ -16,8 +16,10 @@ from test.unit.utils.data import TestData
 
 train_input = TestData.load("reference_sets/307-train-data.csv")
 
+
 class MockModel:
     coef_ = np.array([1, 1, 3])
+
 
 class TestLinearQuantile(BaseTestCase):
     def setUp(self) -> None:
@@ -112,9 +114,7 @@ class TestLinearQuantile(BaseTestCase):
 
         # Assert
         self.assertTrue(
-            (
-                feature_importance == np.array([1, 1, 3], dtype=np.float32)
-            ).all()
+            (feature_importance == np.array([1, 1, 3], dtype=np.float32)).all()
         )
 
     def test_ignore_features(self):
@@ -123,17 +123,16 @@ class TestLinearQuantile(BaseTestCase):
 
         input_data_engineered = apply_features(train_input)
 
-        self.assertIn('T-1d', input_data_engineered.columns)
-        self.assertIn('is_eerste_kerstdag', input_data_engineered.columns)
-        self.assertIn('IsWeekDay', input_data_engineered.columns)
-        self.assertIn('load', input_data_engineered.columns)
+        self.assertIn("T-1d", input_data_engineered.columns)
+        self.assertIn("is_eerste_kerstdag", input_data_engineered.columns)
+        self.assertIn("IsWeekDay", input_data_engineered.columns)
+        self.assertIn("load", input_data_engineered.columns)
 
         # Act
         input_data_filtered = model._remove_ignored_features(input_data_engineered)
 
         # Assert
-        self.assertNotIn('T-1d', input_data_filtered.columns)
-        self.assertNotIn('is_eerste_kerstdag', input_data_filtered.columns)
-        self.assertNotIn('IsWeekDay', input_data_filtered.columns)
-        self.assertIn('load', input_data_filtered.columns)
-
+        self.assertNotIn("T-1d", input_data_filtered.columns)
+        self.assertNotIn("is_eerste_kerstdag", input_data_filtered.columns)
+        self.assertNotIn("IsWeekDay", input_data_filtered.columns)
+        self.assertIn("load", input_data_filtered.columns)

--- a/test/unit/model/test_model_creator.py
+++ b/test/unit/model/test_model_creator.py
@@ -24,6 +24,8 @@ class TestModelCreator(TestCase):
                 MLModelType("xgb_quantile"),
                 "arima",
                 MLModelType("arima"),
+                "linear_quantile",
+                MLModelType("linear_quantile"),
             ]:
                 self.assertTrue(model.can_predict_quantiles)
             else:


### PR DESCRIPTION
Following changes/features were added:
* New LinearQuantile model. Used by specifying model="linear_quantile" in PredictionJob
* Added feature filtering to ignore features deemed irrelevant.
* Added data imputer transform to replace nans in data as linear model can not work with these.
* Added tests for Linear Quantile Model.

Notes:
* The model training quite a bit slower than XGBoost Quantile.
* For each quantile a new SKLearn QuantileRegression model is trained.
* Adding more features significantly impacts training time.

Here are some insights from the comparison notebook:

### Feature Importance
Feature importance is more balanced now, possibly also because of the feature filtering:
![image](https://github.com/OpenSTEF/openstef/assets/4254771/c02352e6-957d-46ef-866e-00a15f85099e)

![image](https://github.com/OpenSTEF/openstef/assets/4254771/5036c69c-6fef-4867-9ffa-430822fb12ee)

Model also sees that AMI, AZI etc features make a nice base signal.

### Forecasting
* Model follows the load target more closely.
* The quantiles do not cross. 
* The biggest quantile (0.9 in this image is better at forecasting peaks.
* There are more false positives.
![image](https://github.com/OpenSTEF/openstef/assets/4254771/74355f00-68d9-4923-8096-2f19d988ddb3)

