### PR TITLE
allow newer statsmodels versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ pydantic-settings~=2.3
 pymsteams~=0.2.2   # TODO remove teams dependency
 scikit-learn~=1.3
 scipy~=1.10
-statsmodels~=0.13.5
+statsmodels>=0.13.5
 structlog>=23.1,<25
 xgboost~=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ pydantic-settings~=2.3
 pymsteams~=0.2.2   # TODO remove teams dependency
 scikit-learn~=1.3
 scipy~=1.10
-statsmodels>=0.13.5
+statsmodels>=0.13.5,<1.0.0
 structlog>=23.1,<25
 xgboost~=2.0


### PR DESCRIPTION
Hi,
Is it possible to allow more recent versions of statsmodels package?

the 0.14 version has more pre-built wheels, and building the 0.13 ones requires additional libraries, otherwise you get errors such as https://github.com/OpenSTEF/openstef/issues/514


Let me know.

Best,
Martino