### PR TITLE
fix: Made use of non_null params consistent for linear quantile model so null columns are handled correctly.

### DIFF
--- a/openstef/model/regressors/linear_quantile.py
+++ b/openstef/model/regressors/linear_quantile.py
@@ -231,7 +231,7 @@ class LinearQuantileOpenstfRegressor(OpenstfRegressor, RegressorMixin):
         return np.array(
             [
                 reg_feature_importances_dict.get(c, 0)
-                for c in self.imputer_.in_feature_names
+                for c in self.imputer_.non_null_feature_names
             ]
         )
 

--- a/openstef/model/regressors/xgb.py
+++ b/openstef/model/regressors/xgb.py
@@ -33,7 +33,9 @@ class XGBOpenstfRegressor(XGBRegressor, OpenstfRegressor):
         }
 
     def fit(
-        self, x: np.array, y: np.array,
+        self,
+        x: np.array,
+        y: np.array,
         *,
         early_stopping_rounds: Optional[int] = None,
         callbacks: Optional[list] = None,
@@ -48,5 +50,3 @@ class XGBOpenstfRegressor(XGBRegressor, OpenstfRegressor):
             self.set_params(eval_metric=eval_metric)
 
         super().fit(x, y, **kwargs)
-
-

--- a/openstef/model/regressors/xgb.py
+++ b/openstef/model/regressors/xgb.py
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: 2017-2023 Contributors to the OpenSTEF project <korte.termijn.prognoses@alliander.com> # noqa E501>
 #
 # SPDX-License-Identifier: MPL-2.0
+from typing import Optional
+
+import numpy as np
+from sklearn.base import RegressorMixin
 
 from xgboost import XGBRegressor
 
@@ -27,3 +31,22 @@ class XGBOpenstfRegressor(XGBRegressor, OpenstfRegressor):
             "gain_importance_name": "total_gain",
             "weight_importance_name": "weight",
         }
+
+    def fit(
+        self, x: np.array, y: np.array,
+        *,
+        early_stopping_rounds: Optional[int] = None,
+        callbacks: Optional[list] = None,
+        eval_metric: Optional[str] = None,
+        **kwargs
+    ):
+        if early_stopping_rounds is not None:
+            self.set_params(early_stopping_rounds=early_stopping_rounds)
+        if callbacks is not None:
+            self.set_params(callbacks=callbacks)
+        if eval_metric is not None:
+            self.set_params(eval_metric=eval_metric)
+
+        super().fit(x, y, **kwargs)
+
+

--- a/test/unit/feature_engineering/test_missing_values_transformer.py
+++ b/test/unit/feature_engineering/test_missing_values_transformer.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2017-2023 Contributors to the OpenSTEF project <korte.termijn.prognoses@alliander.com> # noqa E501>
+#
+# SPDX-License-Identifier: MPL-2.0
+from test.unit.utils.base import BaseTestCase
+
+import unittest
+import pandas as pd
+import numpy as np
+from sklearn.exceptions import NotFittedError
+from openstef.feature_engineering.missing_values_transformer import (
+    MissingValuesTransformer,
+)
+
+
+class MissingValuesTransformerTests(BaseTestCase):
+    def setUp(self):
+        self.data = pd.DataFrame(
+            {"A": [1, np.nan, 3], "B": [4, 5, np.nan], "C": [np.nan, np.nan, np.nan]}
+        )
+
+    def test_imputation_with_mean_strategy_fills_missing_values(self):
+        transformer = MissingValuesTransformer(imputation_strategy="mean")
+        transformed = transformer.fit_transform(self.data)
+        self.assertEqual(transformed.isnull().sum().sum(), 0)
+        self.assertAlmostEqual(transformed.loc[1, "A"], 2)
+        self.assertAlmostEqual(transformed.loc[2, "B"], 4.5)
+
+    def test_imputation_with_constant_strategy_fills_missing_values(self):
+        transformer = MissingValuesTransformer(
+            imputation_strategy="constant", fill_value=0
+        )
+        transformed = transformer.fit_transform(self.data)
+        self.assertEqual(transformed.isnull().sum().sum(), 0)
+        self.assertEqual(transformed.loc[1, "A"], 0)
+        self.assertEqual(transformed.loc[2, "B"], 0)
+
+    def test_columns_always_null_are_removed(self):
+        transformer = MissingValuesTransformer()
+        transformer.fit(self.data)
+        self.assertNotIn("C", transformer.non_null_feature_names)
+
+    def test_non_dataframe_input_is_converted_and_processed(self):
+        transformer = MissingValuesTransformer(imputation_strategy="mean")
+        array = np.array([[1, np.nan], [np.nan, 2]])
+        transformed = transformer.fit_transform(array)
+        self.assertIsInstance(transformed, pd.DataFrame)
+        self.assertEqual(transformed.isnull().sum().sum(), 0)
+
+    def test_fitting_transformer_without_strategy_keeps_data_unchanged(self):
+        transformer = MissingValuesTransformer()
+        transformed = transformer.fit_transform(self.data)
+        pd.testing.assert_frame_equal(transformed, self.data.drop(columns=["C"]))
+
+    def test_calling_transform_before_fit_raises_error(self):
+        transformer = MissingValuesTransformer()
+        with self.assertRaises(NotFittedError):
+            transformer.transform(self.data)
+
+    def test_imputation_with_unsupported_strategy_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            MissingValuesTransformer(imputation_strategy="unsupported")


### PR DESCRIPTION
The issue was that if you supply a null column to linear model that
* Fit function throws error
* Feature weight calculation throws an error

These changes fix it and add unit tests on missing_values_transformer

The second commit fixes current test errors due to changes in dependencies.