### PR TITLE
Metrics not to assume on pd.Series name

### DIFF
--- a/openstef/metrics/metrics.py
+++ b/openstef/metrics/metrics.py
@@ -171,19 +171,19 @@ def r_mne_highest(realised: pd.Series, forecast: pd.Series) -> float:
 
     # Determine load range on entire dataset
     range_ = (
-        combined["load"].max() - combined["load"].min()
-        if (combined["load"].max() - combined["load"].min()) != 0
+        combined[realised.name].max() - combined[realised.name].min()
+        if (combined[realised.name].max() - combined[realised.name].min()) != 0
         else np.nan
     )
 
     # Select 5 percent highest realised load values
-    combined["highest"] = combined["load"][
-        combined["load"] > combined["load"].quantile(0.95)
+    combined["highest"] = combined[realised.name][
+        combined[realised.name] > combined[realised.name].quantile(0.95)
     ]
     combined = combined[np.invert(np.isnan(combined["highest"]))]
 
     # Calculate rMNE for the selected points
-    diff = combined[forecast.name] - combined["load"]
+    diff = combined[forecast.name] - combined[realised.name]
 
     if len(diff[diff < 0]) < 2:
         return 0.0
@@ -208,20 +208,20 @@ def r_mpe_highest(realised: pd.Series, forecast: pd.Series) -> float:
 
     # Determine load range on entire dataset
     range_ = (
-        combined["load"].max() - combined["load"].min()
-        if (combined["load"].max() - combined["load"].min()) != 0
+        combined[realised.name].max() - combined[realised.name].min()
+        if (combined[realised.name].max() - combined[realised.name].min()) != 0
         else np.nan
     )
 
     # Select 5 percent highest realised load values
-    combined["highest"] = combined["load"][
-        combined["load"] > combined["load"].quantile(0.95)
+    combined["highest"] = combined[realised.name][
+        combined[realised.name] > combined[realised.name].quantile(0.95)
     ]
     combined = combined[np.invert(np.isnan(combined["highest"]))]
 
     # Calculate rMPE for the selected points
 
-    diff = combined[forecast.name] - combined["load"]
+    diff = combined[forecast.name] - combined[realised.name]
 
     if len(diff[diff > 0]) < 2:
         return 0.0
@@ -282,13 +282,15 @@ def skill_score_positive_peaks(
     combined = pd.concat([realised, forecast], axis=1)
 
     # Select 5 percent highest realised load values
-    combined["highest"] = combined["load"][
-        combined["load"] > combined["load"].quantile(0.95)
+    combined["highest"] = combined[realised.name][
+        combined[realised.name] > combined[realised.name].quantile(0.95)
     ]
     combined = combined[np.invert(np.isnan(combined["highest"]))]
 
     # Calculate rMAE for the selected points
-    skill_score_highest = skill_score(combined["load"], combined[forecast.name], mean)
+    skill_score_highest = skill_score(
+        combined[realised.name], combined[forecast.name], mean
+    )
 
     if np.isnan(skill_score_highest):
         return 0
@@ -304,8 +306,8 @@ def franks_skill_score(
     combined = pd.concat([realised, forecast], axis=1)
     if range_ == 1.0:
         range_ = (
-            combined["load"].max() - combined["load"].min()
-            if (combined["load"].max() - combined["load"].min()) != 0
+            combined[realised.name].max() - combined[realised.name].min()
+            if (combined[realised.name].max() - combined[realised.name].min()) != 0
             else np.nan
         )
 
@@ -325,19 +327,19 @@ def franks_skill_score_peaks(
     combined = pd.concat([realised, forecast, basecase], axis=1)
 
     range_ = (
-        combined["load"].max() - combined["load"].min()
-        if (combined["load"].max() - combined["load"].min()) != 0
+        combined[realised.name].max() - combined[realised.name].min()
+        if (combined[realised.name].max() - combined[realised.name].min()) != 0
         else np.nan
     )
     # Select 5 percent highest realised load values
-    combined["highest"] = combined["load"][
-        combined["load"] > combined["load"].quantile(0.95)
+    combined["highest"] = combined[realised.name][
+        combined[realised.name] > combined[realised.name].quantile(0.95)
     ]
     combined = combined[np.invert(np.isnan(combined["highest"]))]
 
     # Calculate rMAE for the selected points
     franks_skill_score_highest = franks_skill_score(
-        combined["load"],
+        combined[realised.name],
         combined[forecast.name],
         combined[basecase.name],
         range_=range_,


### PR DESCRIPTION
Hey,
Thank you for the amazing features of this library. I found some limitations of the implemented metrics:
- some of the metrics do not work if columns are named differently

I could rename columns before passing to the affected metrics, but it would be nicer if the functions don't rely on a column to be specifically named `"load"`.

Example:
```python
import pandas as pd
from openstef.metrics import metrics

df = pd.DataFrame(
    {
        "a_ground_truth": [1, 2, 3, 4],
        "a_forecast": [1.1, 2.1, 3.1, 4.1],
        "b_ground_truth": [1, 2, 3, 4],
        "b_forecast": [1.1, 2.1, 3.1, 4.1],
    }
)

a_r_mne_highest = metrics.r_mne_highest(df["a_ground_truth"], df["a_forecast"])
b_r_mne_highest = metrics.r_mne_highest(df["b_ground_truth"], df["b_forecast"])

print(a_r_mne_highest, b_r_mne_highest)
```

Trace of the exception:
```text
Traceback (most recent call last):
  File "/home/martino/.cache/pypoetry/virtualenvs/load-forecasting-8OKFhNKY-py3.10/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 3805, in get_loc
    return self._engine.get_loc(casted_key)
  File "index.pyx", line 167, in pandas._libs.index.IndexEngine.get_loc
  File "index.pyx", line 196, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 7081, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 7089, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'load'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/martino/code/energy-forecast/load-forecasting/example.py", line 13, in <module>
    a_r_mne_highest = metrics.r_mne_highest(df["a_ground_truth"], df["a_forecast"])
  File "/home/martino/.cache/pypoetry/virtualenvs/load-forecasting-8OKFhNKY-py3.10/lib/python3.10/site-packages/openstef/metrics/metrics.py", line 175, in r_mne_highest
    if (combined["load"].max() - combined["load"].min()) != 0
  File "/home/martino/.cache/pypoetry/virtualenvs/load-forecasting-8OKFhNKY-py3.10/lib/python3.10/site-packages/pandas/core/frame.py", line 4102, in __getitem__
    indexer = self.columns.get_loc(key)
  File "/home/martino/.cache/pypoetry/virtualenvs/load-forecasting-8OKFhNKY-py3.10/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 3812, in get_loc
    raise KeyError(key) from err
KeyError: 'load'
```