### PR TITLE
[fix] use of deprecated assertEquals rather than assertEqual

### DIFF
--- a/test/unit/model/regressors/test_flatliner.py
+++ b/test/unit/model/regressors/test_flatliner.py
@@ -49,7 +49,7 @@ class TestLinearQuantile(BaseTestCase):
 
         result: np.ndarray = model.predict(train_input.iloc[:, 1:])
 
-        self.assertEquals(len(result), len(train_input.iloc[:, 1:]))
+        self.assertEqual(len(result), len(train_input.iloc[:, 1:]))
         self.assertTrue((result == 0).all())
 
     def test_get_feature_names_from_linear(self):


### PR DESCRIPTION
Single test was failing for later Python version because of using deprecated `assertEquals` rather than `assertEqual` in 
a `unittest.TestCase`.