### PR TITLE
restrict numpy version below version 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ lightgbm~=3.3
 matplotlib~=3.7
 mlflow~=2.3
 networkx~=3.1
+numpy<2.0.0
 optuna~=3.1
 optuna-integration~=3.6
 pandas~=2.2.0


### PR DESCRIPTION
some tests did not work with `numpy` version > 2.0.0, restricting to <2.0.0 for now