### PR TITLE
Add Apple Silicon installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ OpenSTEF is a Python package designed for generating short-term forecasts in the
 - [OpenSTEF](#openstef)
 - [Table of contents](#table-of-contents)
 - [External information sources](#external-information-sources)
-- [Installation](#install)
+- [Installation](#installation)
 - [Usage](#usage)
     - [Example notebooks](#example-notebooks)
     - [Reference Implementation](#reference-implementation)
@@ -58,6 +58,19 @@ A version of the pywin32 package will be installed as a secondary dependency alo
 pip install pywin32==300
 ```
 For more information on this issue see the [readme of pywin32](https://github.com/mhammond/pywin32#installing-via-pip) or [this Github issue](https://github.com/mhammond/pywin32/issues/1865#issue-1212752696).
+
+## Remark regarding installation on Apple Silicon
+
+If you want to install the `openstef` package on Apple Silicon (Mac with M1-chip or newer), you can encounter issues with the dependencies, such as `xgboost`. Solution:
+
+1. Run `brew install libomp` (if you haven’t installed Homebrew: [follow instructions here](https://brew.sh/))
+2. If your interpreter can not find the `libomp` installation in `/usr/local/bin`, it is probably in `/opt/brew/Cellar`. Run:
+```sh
+mkdir -p /usr/local/opt/libomp/
+ln -s /opt/brew/Cellar/libomp/{your_version}/lib /usr/local/opt/libomp/lib
+```
+3. Uninstall `xgboost` with `pip` (`pip uninstall xgboost`) and install with `conda-forge` (`conda install -c conda-forge xgboost`)
+4. If you encounter similar issues with `lightgbm`: uninstall `lightgbm` with `pip` (`pip uninstall lightgbm`) and install later version with `conda-forge` (`conda install -c conda-forge 'lightgbm>=4.2.0'`)
 
 # Usage
 


### PR DESCRIPTION
If you want to install the openstef package on Apple Silicon (Mac with M1-chip or newer), you can encounter issues with the dependencies, such as xgboost. With this pull request, I add instructions for solving these issues.

Credits to Lars Schilders for discovering these installation problems.