### PR TITLE
feature(STEF-1345): rolling aggregate load

### DIFF
--- a/openstef/data_classes/prediction_job.py
+++ b/openstef/data_classes/prediction_job.py
@@ -26,6 +26,7 @@ class PredictionJobDataClass(BaseModel):
         - ``"lgb"``
         - ``"linear"``
         - ``"linear_quantile"``
+        - ``"gblinear_quantile"``
         - ``"xgb_multioutput_quantile"``
         - ``"flatliner"``
 

--- a/openstef/data_classes/prediction_job.py
+++ b/openstef/data_classes/prediction_job.py
@@ -26,7 +26,6 @@ class PredictionJobDataClass(BaseModel):
         - ``"lgb"``
         - ``"linear"``
         - ``"linear_quantile"``
-        - ``"gblinear_quantile"``
         - ``"xgb_multioutput_quantile"``
         - ``"flatliner"``
 
@@ -83,6 +82,8 @@ class PredictionJobDataClass(BaseModel):
     data_balancing_ratio: Optional[float] = None
     """If data balancing is enabled, the data will be balanced with data from 1 year 
     ago in the future."""
+    use_rolling_aggregate_features: bool = False
+    """If True, rolling aggregate of load will be used as features in the model."""
     depends_on: Optional[list[Union[int, str]]]
     """Link to another prediction job on which this prediction job might depend."""
     sid: Optional[str]

--- a/openstef/data_classes/prediction_job.py
+++ b/openstef/data_classes/prediction_job.py
@@ -9,7 +9,7 @@ from pydantic.v1 import BaseModel
 from openstef.data_classes.data_prep import DataPrepDataClass
 from openstef.data_classes.model_specifications import ModelSpecificationDataClass
 from openstef.data_classes.split_function import SplitFuncDataClass
-from openstef.enums import PipelineType, BiddingZone
+from openstef.enums import PipelineType, BiddingZone, AggregateFunction
 
 
 class PredictionJobDataClass(BaseModel):
@@ -83,8 +83,8 @@ class PredictionJobDataClass(BaseModel):
     data_balancing_ratio: Optional[float] = None
     """If data balancing is enabled, the data will be balanced with data from 1 year 
     ago in the future."""
-    use_rolling_aggregate_features: bool = False
-    """If True, rolling aggregate of load will be used as features in the model."""
+    rolling_aggregate_features: Optional[list[AggregateFunction]] = None
+    """If not None, rolling aggregate(s) of load will be used as features in the model."""
     depends_on: Optional[list[Union[int, str]]]
     """Link to another prediction job on which this prediction job might depend."""
     sid: Optional[str]

--- a/openstef/data_classes/prediction_job.py
+++ b/openstef/data_classes/prediction_job.py
@@ -83,7 +83,7 @@ class PredictionJobDataClass(BaseModel):
     data_balancing_ratio: Optional[float] = None
     """If data balancing is enabled, the data will be balanced with data from 1 year 
     ago in the future."""
-    use_rolling_aggregate_features: bool = False
+    use_rolling_aggregate_features: Optional[bool] = False
     """If True, rolling aggregate of load will be used as features in the model."""
     depends_on: Optional[list[Union[int, str]]]
     """Link to another prediction job on which this prediction job might depend."""

--- a/openstef/data_classes/prediction_job.py
+++ b/openstef/data_classes/prediction_job.py
@@ -83,7 +83,7 @@ class PredictionJobDataClass(BaseModel):
     data_balancing_ratio: Optional[float] = None
     """If data balancing is enabled, the data will be balanced with data from 1 year 
     ago in the future."""
-    use_rolling_aggregate_features: Optional[bool] = False
+    use_rolling_aggregate_features: bool = False
     """If True, rolling aggregate of load will be used as features in the model."""
     depends_on: Optional[list[Union[int, str]]]
     """Link to another prediction job on which this prediction job might depend."""

--- a/openstef/enums.py
+++ b/openstef/enums.py
@@ -108,6 +108,13 @@ class BiddingZone(Enum):
     DE_AMP_LU = "DE_AMP_LU"
 
 
+class AggregateFunction(Enum):
+    MEAN = "mean"
+    MEDIAN = "median"
+    MAX = "max"
+    MIN = "min"
+
+
 class ModelType(Enum):
     XGB = "xgb"
     XGB_QUANTILE = "xgb_quantile"

--- a/openstef/feature_engineering/apply_features.py
+++ b/openstef/feature_engineering/apply_features.py
@@ -131,7 +131,7 @@ def apply_features(
     # Adds daylight terrestrial feature
     data = add_daylight_terrestrial_feature(data)
 
-    if pj.use_rolling_aggregate_features:
+    if pj.get("use_rolling_aggregate_features", False):
         data = add_rolling_aggregate_features(data)
 
     # Return dataframe including all requested features

--- a/openstef/feature_engineering/apply_features.py
+++ b/openstef/feature_engineering/apply_features.py
@@ -22,6 +22,7 @@ from openstef.feature_engineering.lag_features import generate_lag_feature_funct
 from openstef.feature_engineering.bidding_zone_to_country_mapping import (
     BIDDING_ZONE_TO_COUNTRY_CODE_MAPPING,
 )
+from openstef.feature_engineering.rolling_features import add_rolling_aggregate_features
 from openstef.feature_engineering.weather_features import (
     add_additional_solar_features,
     add_additional_wind_features,
@@ -129,6 +130,9 @@ def apply_features(
 
     # Adds daylight terrestrial feature
     data = add_daylight_terrestrial_feature(data)
+
+    if pj.use_rolling_aggregate_features:
+        data = add_rolling_aggregate_features(data)
 
     # Return dataframe including all requested features
     return data

--- a/openstef/feature_engineering/apply_features.py
+++ b/openstef/feature_engineering/apply_features.py
@@ -131,8 +131,8 @@ def apply_features(
     # Adds daylight terrestrial feature
     data = add_daylight_terrestrial_feature(data)
 
-    if pj.get("use_rolling_aggregate_features", False):
-        data = add_rolling_aggregate_features(data)
+    if pj.get("rolling_aggregate_features") is not None:
+        data = add_rolling_aggregate_features(data, pj=pj)
 
     # Return dataframe including all requested features
     return data

--- a/openstef/feature_engineering/rolling_features.py
+++ b/openstef/feature_engineering/rolling_features.py
@@ -1,0 +1,32 @@
+import pandas as pd
+
+
+def add_rolling_aggregate_features(
+    data: pd.DataFrame, rolling_window: str = "24h"
+) -> pd.DataFrame:
+    """
+    Adds rolling aggregate features to the input dataframe.
+
+    These features are calculated with an aggregation over a rolling window of the data.
+    A list of requested features is used to determine whether to add the rolling features
+    or not.
+
+    Args:
+        data: Input dataframe to which the rolling features will be added.
+        rolling_window: Rolling window size in str format following
+            https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases
+
+    Returns:
+        DataFrame with added rolling features.
+    """
+    # Ensure the index is a DatetimeIndex
+    if not isinstance(data.index, pd.DatetimeIndex):
+        raise ValueError("The DataFrame index must be a DatetimeIndex.")
+
+    if "load" not in data.columns:
+        raise ValueError("The DataFrame must contain a 'load' column.")
+    rolling_window_load = data["load"].rolling(window=rolling_window)
+    data[f"rolling_median_load_{rolling_window}"] = rolling_window_load.median()
+    data[f"rolling_max_load_{rolling_window}"] = rolling_window_load.max()
+    data[f"rolling_min_load_{rolling_window}"] = rolling_window_load.min()
+    return data

--- a/openstef/feature_engineering/rolling_features.py
+++ b/openstef/feature_engineering/rolling_features.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2023 Contributors to the OpenSTEF project <korte.termijn.prognoses@alliander.com> # noqa E501>
+#
+# SPDX-License-Identifier: MPL-2.0
+
 import pandas as pd
 
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def read_long_description_from_readme():
 
 setup(
     name="openstef",
-    version="3.4.53",
+    version="3.4.54",
     packages=find_packages(include=["openstef", "openstef.*"]),
     description="Open short term energy forecaster",
     long_description=read_long_description_from_readme(),

--- a/test/unit/feature_engineering/test_apply_features.py
+++ b/test/unit/feature_engineering/test_apply_features.py
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import unittest
+from unittest.mock import MagicMock
+
+from openstef.data_classes.prediction_job import PredictionJobDataClass
 from openstef.enums import BiddingZone
 from test.unit.utils.base import BaseTestCase
 from test.unit.utils.data import TestData
@@ -298,6 +301,28 @@ class TestApplyFeaturesModule(BaseTestCase):
         )
         expected_power_output = 0.8698915256370021
         self.assertAlmostEqual(power_output, expected_power_output)
+
+    def test_add_rolling_aggregate_features(self):
+        pj = MagicMock(
+            use_rolling_aggregate_features=True,
+        )
+        pj.get.return_value = BiddingZone.NL
+
+        input_data = pd.DataFrame(
+            index=pd.date_range(
+                start="2023-01-01 00:00:00", freq="15min", periods=100, tz="UTC"
+            )
+        )
+        input_data["load"] = list(range(100))
+
+        input_data_with_features = apply_features.apply_features(
+            data=input_data,
+            pj=pj,
+        )
+
+        self.assertIn("rolling_median_load_24h", input_data_with_features.columns)
+        self.assertIn("rolling_max_load_24h", input_data_with_features.columns)
+        self.assertIn("rolling_min_load_24h", input_data_with_features.columns)
 
 
 if __name__ == "__main__":

--- a/test/unit/feature_engineering/test_apply_features.py
+++ b/test/unit/feature_engineering/test_apply_features.py
@@ -302,10 +302,10 @@ class TestApplyFeaturesModule(BaseTestCase):
         self.assertAlmostEqual(power_output, expected_power_output)
 
     def test_add_rolling_aggregate_features(self):
-        pj = MagicMock(
-            use_rolling_aggregate_features=True,
-        )
-        pj.get.return_value = BiddingZone.NL
+        pj = {
+            "use_rolling_aggregate_features": True,
+            "electricity_bidding_zone": BiddingZone.NL,
+        }
 
         input_data = pd.DataFrame(
             index=pd.date_range(

--- a/test/unit/feature_engineering/test_apply_features.py
+++ b/test/unit/feature_engineering/test_apply_features.py
@@ -5,7 +5,6 @@
 import unittest
 from unittest.mock import MagicMock
 
-from openstef.data_classes.prediction_job import PredictionJobDataClass
 from openstef.enums import BiddingZone
 from test.unit.utils.base import BaseTestCase
 from test.unit.utils.data import TestData

--- a/test/unit/feature_engineering/test_rolling_features.py
+++ b/test/unit/feature_engineering/test_rolling_features.py
@@ -79,7 +79,6 @@ def test_add_rolling_aggregate_features_flatline():
     output_data = add_rolling_aggregate_features(data, pj=pj)
 
     # Verify the columns are created
-    rolling_window = timedelta(hours=24)
     assert "rolling_median_load_1 day, 0:00:00" in output_data.columns
     assert "rolling_max_load_1 day, 0:00:00" in output_data.columns
     assert "rolling_min_load_1 day, 0:00:00" in output_data.columns

--- a/test/unit/feature_engineering/test_rolling_features.py
+++ b/test/unit/feature_engineering/test_rolling_features.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017-2023 Contributors to the OpenSTEF project <korte.termijn.prognoses@alliander.com> # noqa E501>
+#
+# SPDX-License-Identifier: MPL-2.0
+
 import numpy as np
 import pandas as pd
 import pytest


### PR DESCRIPTION
This pull request introduces a new feature for adding rolling aggregate features to the data. The most important changes include the addition of the `use_rolling_aggregate_features` attribute to the `PredictionJobDataClass`, the implementation of the `add_rolling_aggregate_features` function, and the corresponding updates to the `apply_features` function and unit tests.

New feature implementation:

* [`openstef/data_classes/prediction_job.py`](diffhunk://#diff-2c62b780df0f8c55119ed344d39ee9087371caf2b3704be2aeebfa8e5c9f4efbR86-R87): Added the `use_rolling_aggregate_features` attribute to the `PredictionJobDataClass` to enable the use of rolling aggregate features in the model.
* [`openstef/feature_engineering/rolling_features.py`](diffhunk://#diff-90f67d4d8ad439c54279e8fbd94d00825c9cf9dcb532667e5f10fd13c56e077dR1-R32): Implemented the `add_rolling_aggregate_features` function to add rolling aggregate features to the input dataframe.

Integration with existing code:

* [`openstef/feature_engineering/apply_features.py`](diffhunk://#diff-d9c6b8193caa7198b6cd942fd316d471788ade0339cae4c448e03ededba66a22R25): Imported the `add_rolling_aggregate_features` function and updated the `apply_features` function to conditionally add rolling aggregate features based on the `use_rolling_aggregate_features` attribute. [[1]](diffhunk://#diff-d9c6b8193caa7198b6cd942fd316d471788ade0339cae4c448e03ededba66a22R25) [[2]](diffhunk://#diff-d9c6b8193caa7198b6cd942fd316d471788ade0339cae4c448e03ededba66a22R134-R136)

Unit tests:

* [`test/unit/feature_engineering/test_rolling_features.py`](diffhunk://#diff-be3b041d7e33b181d9463763d22cbe4ffdc9fbbc0ca80759c477e1e67829a66eR1-R88): Added unit tests for the `add_rolling_aggregate_features` function to ensure correct functionality and error handling.