### PR TITLE
Only use old model for model specs and score checking if ignore_existing_models is set to False

### DIFF
--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -30,7 +30,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     # Restore
     - name: Restore pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip

--- a/openstef/pipeline/train_model.py
+++ b/openstef/pipeline/train_model.py
@@ -46,7 +46,7 @@ def train_model_pipeline(
     check_old_model_age: bool,
     mlflow_tracking_uri: str,
     artifact_folder: str,
-    start_with_new_model: bool = False,
+    ignore_existing_models: bool = False,
 ) -> Optional[tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]]:
     """Middle level pipeline that takes care of all persistent storage dependencies.
 
@@ -80,7 +80,7 @@ def train_model_pipeline(
 
     # Get old model and age
     old_model, model_specs, old_model_age = train_pipeline_step_load_model(
-        pj, serializer, start_with_new_model
+        pj, serializer, ignore_existing_models
     )
 
     # Check old model age and continue yes/no
@@ -107,7 +107,7 @@ def train_model_pipeline(
             input_data,
             old_model,
             horizons=horizons,
-            start_with_new_model=start_with_new_model,
+            ignore_existing_models=ignore_existing_models,
         )
     except OldModelHigherScoreError as OMHSE:
         logger.error("Old model is better than new model", pid=pj["id"], exc_info=OMHSE)
@@ -157,7 +157,7 @@ def train_model_pipeline_core(
     input_data: pd.DataFrame,
     old_model: OpenstfRegressor = None,
     horizons: list[float] = DEFAULT_TRAIN_HORIZONS_HOURS,
-    start_with_new_model: bool = False,
+    ignore_existing_models: bool = False,
 ) -> Tuple[
     OpenstfRegressor,
     Report,
@@ -206,7 +206,7 @@ def train_model_pipeline_core(
     model_specs.feature_names = list(train_data.columns)
 
     # Check if new model is better than old model
-    if old_model and not start_with_new_model:
+    if old_model and not ignore_existing_models:
         combined = pd.concat([train_data, validation_data])
         # skip the forecast column added at the end of dataframes
         if pj.save_train_forecasts:
@@ -321,11 +321,11 @@ def train_pipeline_common(
 def train_pipeline_step_load_model(
     pj: PredictionJobDataClass,
     serializer: MLflowSerializer,
-    start_with_new_model: bool = False,
+    ignore_existing_models: bool = False,
 ) -> Tuple[OpenstfRegressor, ModelSpecificationDataClass, Union[int, float]]:
     old_model: Optional[OpenstfRegressor]
 
-    if not start_with_new_model:
+    if not ignore_existing_models:
         try:
             old_model, model_specs = serializer.load_model(experiment_name=str(pj.id))
             old_model_age = old_model.age  # Age attribute is openstef specific

--- a/openstef/pipeline/train_model.py
+++ b/openstef/pipeline/train_model.py
@@ -206,7 +206,7 @@ def train_model_pipeline_core(
     model_specs.feature_names = list(train_data.columns)
 
     # Check if new model is better than old model
-    if old_model:
+    if old_model and not start_with_new_model:
         combined = pd.concat([train_data, validation_data])
         # skip the forecast column added at the end of dataframes
         if pj.save_train_forecasts:
@@ -223,21 +223,21 @@ def train_model_pipeline_core(
         # Try to compare new model to old model.
         # If this does not success, for example since the feature names of the
         # old model differ from the new model, the new model is considered better
-        if not start_with_new_model:
-            try:
-                score_old_model = old_model.score(x_data, y_data)
 
-                # Check if R^2 is better for old model
-                if score_old_model > score_new_model * PENALTY_FACTOR_OLD_MODEL:
-                    raise OldModelHigherScoreError(
-                        f"Old model is better than new model for {pj['id']}."
-                    )
+        try:
+            score_old_model = old_model.score(x_data, y_data)
 
-                logger.info(
-                    "New model is better than old model, continuing with training procces"
+            # Check if R^2 is better for old model
+            if score_old_model > score_new_model * PENALTY_FACTOR_OLD_MODEL:
+                raise OldModelHigherScoreError(
+                    f"Old model is better than new model for {pj['id']}."
                 )
-            except ValueError as e:
-                logger.info("Could not compare to old model", pid=pj["id"], exc_info=e)
+
+            logger.info(
+                "New model is better than old model, continuing with training procces"
+            )
+        except ValueError as e:
+            logger.info("Could not compare to old model", pid=pj["id"], exc_info=e)
 
     return model, report, model_specs, (train_data, validation_data, test_data)
 

--- a/openstef/tasks/train_model.py
+++ b/openstef/tasks/train_model.py
@@ -174,7 +174,7 @@ def train_model_task(
             check_old_model_age=check_old_model_age,
             mlflow_tracking_uri=mlflow_tracking_uri,
             artifact_folder=artifact_folder,
-            start_with_new_model=False,
+            start_with_new_model=start_with_new_model,
         )
 
         if data_sets:

--- a/openstef/tasks/train_model.py
+++ b/openstef/tasks/train_model.py
@@ -19,7 +19,8 @@ Example:
         $ python model_train.py
 
 """
-from datetime import datetime, timedelta, UTC
+
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pandas as pd
@@ -41,6 +42,7 @@ from openstef.tasks.utils.taskcontext import TaskContext
 
 TRAINING_PERIOD_DAYS: int = 120
 DEFAULT_CHECK_MODEL_AGE: bool = True
+DEFAULT_START_WITH_NEW_MODEL: bool = False
 
 
 def train_model_task(
@@ -49,6 +51,7 @@ def train_model_task(
     check_old_model_age: bool = DEFAULT_CHECK_MODEL_AGE,
     datetime_start: datetime = None,
     datetime_end: datetime = None,
+    start_with_new_model: bool = DEFAULT_START_WITH_NEW_MODEL,
 ) -> None:
     """Train model task.
 
@@ -104,7 +107,9 @@ def train_model_task(
     serializer = MLflowSerializer(mlflow_tracking_uri=mlflow_tracking_uri)
 
     # Get old model and age
-    _, _, old_model_age = train_pipeline_step_load_model(pj, serializer)
+    _, _, old_model_age = train_pipeline_step_load_model(
+        pj, serializer, start_with_new_model
+    )
 
     # Check old model age and continue yes/no
     if (old_model_age < MAXIMUM_MODEL_AGE) and check_old_model_age:
@@ -168,6 +173,7 @@ def train_model_task(
             check_old_model_age=check_old_model_age,
             mlflow_tracking_uri=mlflow_tracking_uri,
             artifact_folder=artifact_folder,
+            start_with_new_model=False,
         )
 
         if data_sets:

--- a/openstef/tasks/train_model.py
+++ b/openstef/tasks/train_model.py
@@ -43,7 +43,7 @@ from openstef.tasks.utils.taskcontext import TaskContext
 
 TRAINING_PERIOD_DAYS: int = 120
 DEFAULT_CHECK_MODEL_AGE: bool = True
-DEFAULT_START_WITH_NEW_MODEL: bool = False
+DEFAULT_IGNORE_EXISTING_MODELS: bool = False
 
 
 def train_model_task(
@@ -52,7 +52,7 @@ def train_model_task(
     check_old_model_age: bool = DEFAULT_CHECK_MODEL_AGE,
     datetime_start: Optional[datetime] = None,
     datetime_end: Optional[datetime] = None,
-    start_with_new_model: bool = DEFAULT_START_WITH_NEW_MODEL,
+    ignore_existing_models: bool = DEFAULT_IGNORE_EXISTING_MODELS,
 ) -> None:
     """Train model task.
 
@@ -109,7 +109,7 @@ def train_model_task(
 
     # Get old model and age
     _, _, old_model_age = train_pipeline_step_load_model(
-        pj, serializer, start_with_new_model
+        pj, serializer, ignore_existing_models
     )
 
     # Check old model age and continue yes/no
@@ -174,7 +174,7 @@ def train_model_task(
             check_old_model_age=check_old_model_age,
             mlflow_tracking_uri=mlflow_tracking_uri,
             artifact_folder=artifact_folder,
-            start_with_new_model=start_with_new_model,
+            ignore_existing_models=ignore_existing_models,
         )
 
         if data_sets:

--- a/openstef/tasks/train_model.py
+++ b/openstef/tasks/train_model.py
@@ -22,6 +22,7 @@ Example:
 
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 
@@ -49,8 +50,8 @@ def train_model_task(
     pj: PredictionJobDataClass,
     context: TaskContext,
     check_old_model_age: bool = DEFAULT_CHECK_MODEL_AGE,
-    datetime_start: datetime = None,
-    datetime_end: datetime = None,
+    datetime_start: Optional[datetime] = None,
+    datetime_end: Optional[datetime] = None,
     start_with_new_model: bool = DEFAULT_START_WITH_NEW_MODEL,
 ) -> None:
     """Train model task.

--- a/test/unit/pipeline/test_pipeline_train_model.py
+++ b/test/unit/pipeline/test_pipeline_train_model.py
@@ -564,12 +564,9 @@ class TestTrainModelPipeline(BaseTestCase):
         )
         self.assertEqual(len(serializer_mock_instance.method_calls), 3)
 
-    @patch("openstef.model.serializer.MLflowSerializer.save_model")
     @patch("openstef.pipeline.train_model.MLflowSerializer")
-    def test_train_model_start_with_new_model(self, serializer_mock, save_model_mock):
-        # Mock an old model which is better than the new one.
-
-        # Mock an old model which is better than the new one.
+    def test_train_model_start_with_new_model(self, serializer_mock):
+        # Mock an old model
         old_model_mock = MagicMock()
         old_model_mock.age = 8
         old_model_mock.modelspecs = self.model_specs
@@ -582,11 +579,15 @@ class TestTrainModelPipeline(BaseTestCase):
         serializer_mock.return_value = serializer_mock_instance
         old_model_mock.score.return_value = 0.001
 
+        #Define specific model specs for pj
         self.pj["save_train_forecasts"] = True
         _, self.pj["default_modelspecs"] = TestData.get_prediction_job_and_modelspecs(
             pid=307
         )
         self.pj["default_modelspecs"].feature_names = ["windspeed", "T-7d", "T-5d"]
+
+        # start_with_new_model is set to False - pj's default model specs will not be taken into account
+        # because old model exists
         df1_old_model, df2_old_model, df3_old_model = train_model_pipeline(
             pj=self.pj,
             input_data=self.train_input,
@@ -599,6 +600,8 @@ class TestTrainModelPipeline(BaseTestCase):
         self.assertEqual(len(serializer_mock_instance.load_model.method_calls), 0)
         self.assertEqual(len(df1_old_model.columns), 49)
 
+
+        # Because start_with_new_model is set to True, pj's default model specs will be taken into account
         df1_new_model, df2_new_model, df3_new_model = train_model_pipeline(
             pj=self.pj,
             input_data=self.train_input,

--- a/test/unit/pipeline/test_pipeline_train_model.py
+++ b/test/unit/pipeline/test_pipeline_train_model.py
@@ -564,6 +564,51 @@ class TestTrainModelPipeline(BaseTestCase):
         )
         self.assertEqual(len(serializer_mock_instance.method_calls), 3)
 
+    @patch("openstef.model.serializer.MLflowSerializer.save_model")
+    @patch("openstef.pipeline.train_model.MLflowSerializer")
+    def test_train_model_start_with_new_model(self, serializer_mock, save_model_mock):
+        # Mock an old model which is better than the new one.
+
+        # Mock an old model which is better than the new one.
+        old_model_mock = MagicMock()
+        old_model_mock.age = 8
+        old_model_mock.modelspecs = self.model_specs
+
+        serializer_mock_instance = MagicMock()
+        serializer_mock_instance.load_model.return_value = (
+            old_model_mock,
+            self.model_specs,
+        )
+        serializer_mock.return_value = serializer_mock_instance
+        old_model_mock.score.return_value = 0.001
+
+        self.pj["save_train_forecasts"] = True
+        _, self.pj["default_modelspecs"] = TestData.get_prediction_job_and_modelspecs(
+            pid=307
+        )
+        self.pj["default_modelspecs"].feature_names = ["windspeed", "T-7d", "T-5d"]
+        df1_old_model, df2_old_model, df3_old_model = train_model_pipeline(
+            pj=self.pj,
+            input_data=self.train_input,
+            check_old_model_age=False,
+            mlflow_tracking_uri="./test/unit/trained_models/mlruns",
+            artifact_folder="./test/unit/trained_models",
+            start_with_new_model=False,
+        )
+
+        self.assertEqual(len(serializer_mock_instance.load_model.method_calls), 0)
+        self.assertEqual(len(df1_old_model.columns), 49)
+
+        df1_new_model, df2_new_model, df3_new_model = train_model_pipeline(
+            pj=self.pj,
+            input_data=self.train_input,
+            check_old_model_age=False,
+            mlflow_tracking_uri="./test/unit/trained_models/mlruns",
+            artifact_folder="./test/unit/trained_models",
+            start_with_new_model=True,
+        )
+        self.assertEqual(len(df1_new_model.columns), 6)
+
     def test_train_pipeline_common_different_quantiles_with_quantile_regressor(self):
         """Incorporated after a bug.
         Test if PJ has different quantiles compared to old model, for quantile regressor

--- a/test/unit/pipeline/test_pipeline_train_model.py
+++ b/test/unit/pipeline/test_pipeline_train_model.py
@@ -565,7 +565,7 @@ class TestTrainModelPipeline(BaseTestCase):
         self.assertEqual(len(serializer_mock_instance.method_calls), 3)
 
     @patch("openstef.pipeline.train_model.MLflowSerializer")
-    def test_train_model_start_with_new_model(self, serializer_mock):
+    def test_train_model_ignore_existing_models(self, serializer_mock):
         # Mock an old model
         old_model_mock = MagicMock()
         old_model_mock.age = 8
@@ -579,14 +579,14 @@ class TestTrainModelPipeline(BaseTestCase):
         serializer_mock.return_value = serializer_mock_instance
         old_model_mock.score.return_value = 0.001
 
-        #Define specific model specs for pj
+        # Define specific model specs for pj
         self.pj["save_train_forecasts"] = True
         _, self.pj["default_modelspecs"] = TestData.get_prediction_job_and_modelspecs(
             pid=307
         )
         self.pj["default_modelspecs"].feature_names = ["windspeed", "T-7d", "T-5d"]
 
-        # start_with_new_model is set to False - pj's default model specs will not be taken into account
+        # ignore_existing_models is set to False - pj's default model specs will not be taken into account
         # because old model exists
         df1_old_model, df2_old_model, df3_old_model = train_model_pipeline(
             pj=self.pj,
@@ -594,21 +594,21 @@ class TestTrainModelPipeline(BaseTestCase):
             check_old_model_age=False,
             mlflow_tracking_uri="./test/unit/trained_models/mlruns",
             artifact_folder="./test/unit/trained_models",
-            start_with_new_model=False,
+            ignore_existing_models=False,
         )
 
         self.assertEqual(len(serializer_mock_instance.load_model.method_calls), 0)
         self.assertEqual(len(df1_old_model.columns), 49)
 
 
-        # Because start_with_new_model is set to True, pj's default model specs will be taken into account
+        # Because ignore_existing_models is set to True, pj's default model specs will be taken into account
         df1_new_model, df2_new_model, df3_new_model = train_model_pipeline(
             pj=self.pj,
             input_data=self.train_input,
             check_old_model_age=False,
             mlflow_tracking_uri="./test/unit/trained_models/mlruns",
             artifact_folder="./test/unit/trained_models",
-            start_with_new_model=True,
+            ignore_existing_models=True,
         )
         self.assertEqual(len(df1_new_model.columns), 6)
 


### PR DESCRIPTION
- added extra option to model training that will ignore any existing models and will just train a new model.
- added unit test for this new fucntionality