### PR TITLE
Make fallback strategy configurable

### DIFF
--- a/openstef/data_classes/prediction_job.py
+++ b/openstef/data_classes/prediction_job.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field
 from openstef.data_classes.data_prep import DataPrepDataClass
 from openstef.data_classes.model_specifications import ModelSpecificationDataClass
 from openstef.data_classes.split_function import SplitFuncDataClass
-from openstef.enums import AggregateFunction, BiddingZone, PipelineType
+from openstef.enums import AggregateFunction, BiddingZone, PipelineType, FallbackStrategy
 
 
 class PredictionJobDataClass(BaseModel):
@@ -134,6 +134,11 @@ class PredictionJobDataClass(BaseModel):
     )
     data_prep_class: Optional[DataPrepDataClass] = Field(
         None, description="The import string for the custom data prep class"
+    )
+
+    fallback_strategy: Optional[FallbackStrategy] = Field(
+        FallbackStrategy.EXTREME_DAY,
+        description="The fallback strategy to use when not enough input data is available.",
     )
 
     def __getitem__(self, item: str) -> Any:

--- a/openstef/enums.py
+++ b/openstef/enums.py
@@ -139,3 +139,7 @@ class PipelineType(Enum):
     FORECAST = "forecast"
     TRAIN = "train"
     HYPER_PARMATERS = "hyper_parameters"
+
+class FallbackStrategy(Enum):
+    EXTREME_DAY = "extreme_day"
+    RAISE_ERROR = "raise_error"

--- a/openstef/model/fallback.py
+++ b/openstef/model/fallback.py
@@ -5,11 +5,12 @@ from datetime import UTC, datetime
 
 import pandas as pd
 
+from openstef.enums import FallbackStrategy
 
 def generate_fallback(
     forecast_input: pd.DataFrame,
     load: pd.DataFrame,
-    fallback_strategy: str = "extreme_day",
+    fallback_strategy: FallbackStrategy = FallbackStrategy.EXTREME_DAY,
 ) -> pd.DataFrame:
     """Make a fall back forecast, Set the value of the forecast 'quality' column to 'substituted'.
 
@@ -20,6 +21,7 @@ def generate_fallback(
         load: index=datetime, columns=['load']
         fallback_strategy: strategy to determine fallback. options:
             - extreme_day: use daily profile of most extreme day
+            - raise_error: raise error if not enough data is available
     Returns:
         Fallback forecast DataFrame with columns; 'forecast', 'quality'
 
@@ -32,12 +34,12 @@ def generate_fallback(
     if len(load.dropna()) == 0:
         raise ValueError("No historic load data available")
 
-    if fallback_strategy != "extreme_day":
-        raise NotImplementedError(
-            f'fallback_strategy should be "extreme_day", received:{fallback_strategy}'
-        )
-
-    if fallback_strategy == "extreme_day":
+   
+    if fallback_strategy == FallbackStrategy.RAISE_ERROR:      
+        # Raise error if not enough data is available
+            raise ValueError("Not enough load data available to generate forecast")
+    
+    if fallback_strategy == FallbackStrategy.EXTREME_DAY:
         # Execute this fallback strategy
         # Find most extreme historic day and merge it by time-of-day to the requested moments
 

--- a/openstef/pipeline/create_forecast.py
+++ b/openstef/pipeline/create_forecast.py
@@ -20,6 +20,7 @@ from openstef.postprocessing.postprocessing import (
     sort_quantiles,
 )
 from openstef.validation import validation
+from openstef.enums import FallbackStrategy
 
 
 def create_forecast_pipeline(
@@ -88,7 +89,7 @@ def create_forecast_pipeline_core(
     """
     logger = get_logger(__name__)
 
-    fallback_strategy = "extreme_day"  # this can later be expanded
+    fallback_strategy = pj.get("fallback_strategy", FallbackStrategy.EXTREME_DAY)
 
     # Validate and clean data
     validated_data = validation.validate(

--- a/test/unit/model/test_fallback.py
+++ b/test/unit/model/test_fallback.py
@@ -9,6 +9,7 @@ from test.unit.utils.data import TestData
 import numpy as np
 
 from openstef.model.fallback import generate_fallback
+from openstef.enums import FallbackStrategy
 
 
 class TestFallback(BaseTestCase):
@@ -21,7 +22,7 @@ class TestFallback(BaseTestCase):
         fallback_forecast = generate_fallback(
             forecast_input=forc_section,
             load=load,
-            fallback_strategy="extreme_day",
+            fallback_strategy=FallbackStrategy.EXTREME_DAY,
         )
 
         self.assertDataframeEqual(
@@ -50,6 +51,19 @@ class TestFallback(BaseTestCase):
             forecast_input=forc_section,
             load=load,
             fallback_strategy="SomeWeirdNotImplementedStrategy",
+        )
+
+    def test_generate_fallback_raise_error(self):
+        """Test if exception is raised if load is empty"""
+        load = TestData.load("fallback_load.csv")
+        load *= np.nan
+        forc_section = TestData.load("fallback_index.csv")
+        self.assertRaises(
+            ValueError,
+            generate_fallback,
+            forecast_input=forc_section.index,
+            load=load,
+            fallback_strategy=FallbackStrategy.RAISE_ERROR,
         )
 
 


### PR DESCRIPTION
- Implemented optional fallback-strategy field in prediction job
- Implement fallback strategy enum
- Possibility to raise an error uppon insufficient data instead of forcing fallback forecast