### PR TITLE
feature(#626): Added feature pipeline and horizon splitting

### DIFF
--- a/packages/openstef-core/src/openstef_core/datasets/transforms.py
+++ b/packages/openstef-core/src/openstef_core/datasets/transforms.py
@@ -13,6 +13,9 @@ from abc import abstractmethod
 
 from openstef_core.datasets import TimeSeriesDataset
 from openstef_core.datasets.versioned_timeseries import VersionedTimeSeriesDataset
+from openstef_core.types import LeadTime
+
+type MultiHorizonTimeSeriesDataset = dict[LeadTime, TimeSeriesDataset]
 
 
 class TimeSeriesTransform:
@@ -79,8 +82,57 @@ class TimeSeriesTransform:
         self.fit(data)
         return self.transform(data)
 
+    def fit_horizons(self, data: dict[LeadTime, TimeSeriesDataset]) -> None:
+        """Fit the transform to multiple horizons of time series data.
 
-class TimeSeriesVersionedTransform:
+        This method allows fitting the transform on a dictionary of datasets,
+        each corresponding to a different lead time (horizon). It is useful
+        for transforms that need to learn parameters across multiple horizons.
+
+        Args:
+            data: A dictionary mapping lead times to their corresponding
+                  TimeSeriesDataset instances.
+        """
+
+    def transform_horizons(self, data: MultiHorizonTimeSeriesDataset) -> MultiHorizonTimeSeriesDataset:
+        """Transform multiple horizons of time series data.
+
+        This method applies the transformation to each dataset in the input
+        dictionary, returning a new dictionary with the transformed datasets.
+
+        Args:
+            data: A dictionary mapping lead times to their corresponding
+                  TimeSeriesDataset instances.
+
+        Returns:
+            A new dictionary mapping lead times to their transformed
+            TimeSeriesDataset instances.
+        """
+        transformed_data: MultiHorizonTimeSeriesDataset = {}
+        for horizon, dataset in data.items():
+            transformed_data[horizon] = self.transform(dataset)
+
+        return transformed_data
+
+    def fit_transform_horizons(self, data: MultiHorizonTimeSeriesDataset) -> MultiHorizonTimeSeriesDataset:
+        """Fit the transform to multiple horizons and then transform them.
+
+        This method combines fitting and transforming for multiple horizons
+        into a single step.
+
+        Args:
+            data: A dictionary mapping lead times to their corresponding
+                  TimeSeriesDataset instances.
+
+        Returns:
+            A new dictionary mapping lead times to their transformed
+            TimeSeriesDataset instances.
+        """
+        self.fit_horizons(data)
+        return self.transform_horizons(data)
+
+
+class VersionedTimeSeriesTransform:
     """Abstract base class for transforming versioned time series datasets.
 
     This class defines the interface for data transformations that operate on
@@ -97,7 +149,7 @@ class TimeSeriesVersionedTransform:
     Example:
         Implement a normalization transform for versioned data:
 
-        >>> class VersionedNormalizeTransform(TimeSeriesVersionedTransform):
+        >>> class VersionedNormalizeTransform(VersionedTimeSeriesTransform):
         ...     def __init__(self):
         ...         self.mean = None
         ...         self.std = None
@@ -160,5 +212,5 @@ class TimeSeriesVersionedTransform:
 
 __all__ = [
     "TimeSeriesTransform",
-    "TimeSeriesVersionedTransform",
+    "VersionedTimeSeriesTransform",
 ]

--- a/packages/openstef-models/src/openstef_models/exceptions.py
+++ b/packages/openstef-models/src/openstef_models/exceptions.py
@@ -1,5 +1,0 @@
-# SPDX-FileCopyrightText: 2025 Contributors to the OpenSTEF project <short.term.energy.forecasts@alliander.com>
-#
-# SPDX-License-Identifier: MPL-2.0
-
-"""Custom exceptions for the OpenSTEF models package."""

--- a/packages/openstef-models/src/openstef_models/feature_engineering/__init__.py
+++ b/packages/openstef-models/src/openstef_models/feature_engineering/__init__.py
@@ -8,3 +8,25 @@ Top-level package for feature engineering helpers used across models and
 pipelines. Provides subpackages for validation, temporal, forecasting,
 weather and energy-domain feature transforms.
 """
+
+from openstef_models.feature_engineering import (
+    energy_domain_transforms,
+    forecasting_transforms,
+    general_transforms,
+    temporal_transforms,
+    validation_transforms,
+    weather_transforms,
+)
+from openstef_models.feature_engineering.feature_pipeline import FeaturePipeline
+from openstef_models.feature_engineering.horizon_split_transform import HorizonSplitTransform
+
+__all__ = [
+    "FeaturePipeline",
+    "HorizonSplitTransform",
+    "energy_domain_transforms",
+    "forecasting_transforms",
+    "general_transforms",
+    "temporal_transforms",
+    "validation_transforms",
+    "weather_transforms",
+]

--- a/packages/openstef-models/src/openstef_models/feature_engineering/feature_pipeline.py
+++ b/packages/openstef-models/src/openstef_models/feature_engineering/feature_pipeline.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the OpenSTEF project <short.term.energy.forecasts@alliander.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Feature engineering pipeline for time series forecasting models.
+
+This module provides the FeaturePipeline class, which coordinates feature engineering
+for multi-horizon forecasting models. It handles the complete feature transformation
+process, from versioned time series data through horizon-specific transformations.
+
+The pipeline operates in two main phases:
+1. Versioned transforms: Handle complex time logic on data with forecast validity timestamps
+2. Horizon transforms: Apply standard transformations on resolved time series data
+
+This design enables efficient processing of forecasting data where features may have
+different availability times and forecast horizons require different processing.
+"""
+
+from typing import Any, override
+
+from pydantic import Field, PrivateAttr
+
+from openstef_core.base_model import BaseModel
+from openstef_core.datasets import TimeSeriesDataset, VersionedTimeSeriesDataset
+from openstef_core.datasets.transforms import TimeSeriesTransform, VersionedTimeSeriesTransform
+from openstef_core.exceptions import TransformNotFittedError
+from openstef_core.types import LeadTime
+from openstef_models.feature_engineering.horizon_split_transform import HorizonSplitTransform
+
+
+class FeaturePipeline(BaseModel):
+    """Feature engineering pipeline for multi-horizon forecasting models.
+
+    Orchestrates feature transformations in a two-stage process optimized for forecasting workflows:
+
+    1. **Versioned transforms**: Applied to raw forecasting data that includes forecast validity timestamps,
+       handling complex time logic like feature availability windows and forecast horizon dependencies.
+
+    2. **Horizon transforms**: Applied to resolved time series data for each specific forecast horizon,
+       performing standard feature engineering like scaling, aggregation, and encoding.
+
+    This design separates time-aware transformations from standard feature engineering, ensuring
+    efficient processing while maintaining forecast data integrity. The pipeline supports both
+    versioned and unversioned (single horizon) datasets.
+
+    Example:
+        Creating a forecasting pipeline with horizon-specific transforms:
+
+        >>> from openstef_core.types import LeadTime
+        >>> from openstef_models.feature_engineering.temporal_transforms import CyclicFeaturesTransform
+        >>>
+        >>> # Configure pipeline for multiple forecast horizons
+        >>> pipeline = FeaturePipeline(
+        ...     horizons=[LeadTime.from_string("PT1H"), LeadTime.from_string("PT24H")],
+        ...     versioned_transforms=[],  # No versioned transforms available yet
+        ...     horizon_transforms=[
+        ...         CyclicFeaturesTransform(included_features=["timeOfDay", "season"])
+        ...     ]
+        ... )
+        >>> len(pipeline.horizons)
+        2
+    """
+
+    horizons: list[LeadTime] = Field(
+        default_factory=lambda: [LeadTime.from_string("PT36H")],
+        description="The lead times (horizons) for which the model will make predictions.",
+    )
+
+    versioned_transforms: list[VersionedTimeSeriesTransform] = Field(
+        default=[],
+        description=(
+            "Transforms that operate on versioned time series, and usually involve complex time handling logic."
+        ),
+    )
+    horizon_transforms: list[TimeSeriesTransform] = Field(
+        default=[], description="Transforms that operate on time series with already resolved timestamps."
+    )
+
+    _horizon_split_transform: HorizonSplitTransform = PrivateAttr()
+    _is_fitted: bool = PrivateAttr(default=False)
+
+    @override
+    def model_post_init(self, context: Any) -> None:
+        self._horizon_split_transform = HorizonSplitTransform(horizons=self.horizons)
+
+    def _validate_unversioned_compatibility(self) -> None:
+        if len(self.versioned_transforms) > 0:
+            raise ValueError("When using unversioned data, the pipeline cannot contain versioned transforms.")
+        if len(self.horizons) != 1:
+            raise ValueError("When using unversioned data, exactly one horizon must be configured in the pipeline.")
+
+    def fit_transform(self, dataset: VersionedTimeSeriesDataset) -> dict[LeadTime, TimeSeriesDataset]:
+        """Fit all transforms and apply them to the input dataset.
+
+        Convenience method that combines fitting and transformation in a single call.
+
+        Args:
+            dataset: Versioned time series dataset for fitting and transforming.
+
+        Returns:
+            Dictionary mapping each lead time to its transformed TimeSeriesDataset.
+        """
+        self.fit(dataset)
+        return self.transform(dataset)
+
+    def fit(self, dataset: VersionedTimeSeriesDataset | TimeSeriesDataset) -> None:
+        """Fit all pipeline transforms to the input dataset.
+
+        Trains all transforms using the provided dataset. Supports both versioned datasets
+        (with complex time handling) and unversioned datasets (for single-horizon use cases).
+
+        Args:
+            dataset: Dataset used for fitting transforms. For unversioned data,
+                pipeline must have no versioned transforms and exactly one horizon.
+        """
+        if isinstance(dataset, TimeSeriesDataset):
+            self._validate_unversioned_compatibility()
+            horizon_datasets = {self.horizons[0]: dataset}
+        else:
+            # Fit all the versioned transforms
+            version_transformed_dataset: VersionedTimeSeriesDataset = dataset
+            for transform in self.versioned_transforms:
+                version_transformed_dataset = transform.fit_transform(version_transformed_dataset)
+
+            # Split to simple time series for fitting simple transforms
+            horizon_datasets: dict[LeadTime, TimeSeriesDataset] = self._horizon_split_transform.transform(
+                version_transformed_dataset
+            )
+
+        # Fit all the simple transforms on each simple dataset
+        for transform in self.horizon_transforms:
+            horizon_datasets = transform.fit_transform_horizons(horizon_datasets)
+
+        self._is_fitted = True
+
+    def transform(self, dataset: VersionedTimeSeriesDataset | TimeSeriesDataset) -> dict[LeadTime, TimeSeriesDataset]:
+        """Apply fitted transforms to produce horizon-specific datasets.
+
+        Transforms input data through the complete pipeline. Assumes transforms have been fitted.
+
+        Args:
+            dataset: Dataset to transform. Can be new data for prediction or training data.
+
+        Returns:
+            Dictionary mapping each LeadTime to its transformed TimeSeriesDataset.
+
+        Raises:
+            TransformNotFittedError: If pipeline hasn't been fitted before calling this method.
+        """
+        if not self._is_fitted:
+            raise TransformNotFittedError("Pipeline is not fitted yet.")
+
+        if isinstance(dataset, TimeSeriesDataset):
+            self._validate_unversioned_compatibility()
+            horizon_datasets = {self.horizons[0]: dataset}
+        else:
+            # Apply all the versioned transforms
+            version_transformed_dataset: VersionedTimeSeriesDataset = dataset
+            for transform in self.versioned_transforms:
+                version_transformed_dataset = transform.transform(version_transformed_dataset)
+
+            # Split to horizon time series for transforming horizon transforms
+            horizon_datasets: dict[LeadTime, TimeSeriesDataset] = self._horizon_split_transform.transform(
+                version_transformed_dataset
+            )
+
+        # Transform all the horizon datasets
+        transformed_datasets: dict[LeadTime, TimeSeriesDataset] = horizon_datasets
+        for transform in self.horizon_transforms:
+            transformed_datasets = transform.transform_horizons(transformed_datasets)
+
+        return transformed_datasets

--- a/packages/openstef-models/src/openstef_models/feature_engineering/general_transforms/clipping_transform.py
+++ b/packages/openstef-models/src/openstef_models/feature_engineering/general_transforms/clipping_transform.py
@@ -18,6 +18,8 @@ from openstef_core.base_model import BaseConfig
 from openstef_core.datasets import TimeSeriesDataset
 from openstef_core.datasets.transforms import TimeSeriesTransform
 from openstef_core.exceptions import TransformNotFittedError
+from openstef_core.types import LeadTime
+from openstef_models.feature_engineering.horizon_split_transform import concat_horizon_datasets_rowwise
 
 
 class ClippingTransform(BaseConfig, TimeSeriesTransform):
@@ -64,6 +66,11 @@ class ClippingTransform(BaseConfig, TimeSeriesTransform):
     _feature_mins: pd.Series = PrivateAttr(default_factory=pd.Series)
     _feature_maxs: pd.Series = PrivateAttr(default_factory=pd.Series)
     _is_fitted: bool = PrivateAttr(default=False)
+
+    @override
+    def fit_horizons(self, data: dict[LeadTime, TimeSeriesDataset]) -> None:
+        flat_data = concat_horizon_datasets_rowwise(data)
+        return self.fit(flat_data)
 
     @override
     def fit(self, data: TimeSeriesDataset) -> None:

--- a/packages/openstef-models/src/openstef_models/feature_engineering/general_transforms/imputation_transform.py
+++ b/packages/openstef-models/src/openstef_models/feature_engineering/general_transforms/imputation_transform.py
@@ -17,8 +17,10 @@ from sklearn.impute import SimpleImputer
 
 from openstef_core.base_model import BaseConfig
 from openstef_core.datasets import TimeSeriesDataset
+from openstef_core.datasets.mixins import LeadTime
 from openstef_core.datasets.transforms import TimeSeriesTransform
 from openstef_core.exceptions import TransformNotFittedError
+from openstef_models.feature_engineering.horizon_split_transform import concat_horizon_datasets_rowwise
 
 type ImputationStrategy = Literal["mean", "median", "most_frequent", "constant"]
 
@@ -142,6 +144,12 @@ class ImputationTransform(BaseConfig, TimeSeriesTransform):
             keep_empty_features=False,
         )
         self._imputer.set_output(transform="pandas")
+
+    @override
+    def fit_horizons(self, data: dict[LeadTime, TimeSeriesDataset]) -> None:
+        # Because the imputation computes a global statistic, we fit on the concatenated data
+        flat_data = concat_horizon_datasets_rowwise(data)
+        return self.fit(flat_data)
 
     @override
     def fit(self, data: TimeSeriesDataset) -> None:

--- a/packages/openstef-models/src/openstef_models/feature_engineering/general_transforms/remove_empty_columns_transform.py
+++ b/packages/openstef-models/src/openstef_models/feature_engineering/general_transforms/remove_empty_columns_transform.py
@@ -18,6 +18,8 @@ from openstef_core.base_model import BaseConfig
 from openstef_core.datasets import TimeSeriesDataset
 from openstef_core.datasets.transforms import TimeSeriesTransform
 from openstef_core.exceptions import TransformNotFittedError
+from openstef_core.types import LeadTime
+from openstef_models.feature_engineering.horizon_split_transform import concat_horizon_datasets_rowwise
 
 _logger = logging.getLogger(__name__)
 
@@ -78,6 +80,11 @@ class RemoveEmptyColumnsTransform(BaseConfig, TimeSeriesTransform):
 
     _remove_columns: set[str] = PrivateAttr(default_factory=set)  # pyright: ignore[reportUnknownVariableType]
     _is_fitted: bool = PrivateAttr(default=False)
+
+    @override
+    def fit_horizons(self, data: dict[LeadTime, TimeSeriesDataset]) -> None:
+        flat_data = concat_horizon_datasets_rowwise(data)
+        return self.fit(flat_data)
 
     @override
     def fit(self, data: TimeSeriesDataset) -> None:

--- a/packages/openstef-models/src/openstef_models/feature_engineering/general_transforms/scaler_transform.py
+++ b/packages/openstef-models/src/openstef_models/feature_engineering/general_transforms/scaler_transform.py
@@ -18,6 +18,8 @@ from openstef_core.base_model import BaseConfig
 from openstef_core.datasets import TimeSeriesDataset
 from openstef_core.datasets.transforms import TimeSeriesTransform
 from openstef_core.exceptions import MissingExtraError, TransformNotFittedError
+from openstef_core.types import LeadTime
+from openstef_models.feature_engineering.horizon_split_transform import concat_horizon_datasets_rowwise
 
 try:
     from sklearn.preprocessing import MaxAbsScaler, MinMaxScaler, RobustScaler, StandardScaler
@@ -81,6 +83,11 @@ class ScalerTransform(BaseConfig, TimeSeriesTransform):
                 self._scaler = StandardScaler()
             case "robust":
                 self._scaler = RobustScaler()
+
+    @override
+    def fit_horizons(self, data: dict[LeadTime, TimeSeriesDataset]) -> None:
+        flat_data = concat_horizon_datasets_rowwise(data)
+        return self.fit(flat_data)
 
     @override
     def fit(self, data: TimeSeriesDataset) -> None:

--- a/packages/openstef-models/src/openstef_models/feature_engineering/horizon_split_transform.py
+++ b/packages/openstef-models/src/openstef_models/feature_engineering/horizon_split_transform.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the OpenSTEF project <short.term.energy.forecasts@alliander.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Transform for splitting versioned datasets by forecast horizons.
+
+The main transform, HorizonSplitTransform, filters versioned data by lead time and
+resolves timestamps to create clean time series datasets for each forecast horizon.
+This enables efficient processing of multi-horizon forecasting models.
+"""
+
+import pandas as pd
+from pydantic import Field
+
+from openstef_core.base_model import BaseConfig
+from openstef_core.datasets import TimeSeriesDataset, VersionedTimeSeriesDataset
+from openstef_core.types import LeadTime
+
+
+class HorizonSplitTransform(BaseConfig):
+    """Transform that splits versioned datasets into horizon-specific time series.
+
+    This transform is a key component in multi-horizon forecasting pipelines. It takes
+    versioned time series data (containing forecast validity timestamps) and produces
+    separate regular time series datasets for each specified forecast horizon.
+
+    The transformation process:
+    1. Filters data by each configured lead time (forecast horizon)
+    2. Resolves timestamps to remove versioning complexity
+    3. Returns clean time series datasets ready for standard processing
+
+    Example:
+        Basic usage with energy forecasting data:
+
+        >>> import pandas as pd
+        >>> from datetime import timedelta
+        >>> from openstef_core.datasets import VersionedTimeSeriesDataset
+        >>> from openstef_core.types import LeadTime
+        >>>
+        >>> # Create sample versioned dataset
+        >>> data = pd.DataFrame({
+        ...     'timestamp': pd.date_range('2025-01-01', periods=24, freq='1h'),
+        ...     'available_at': pd.date_range('2025-01-01', periods=24, freq='1h'),
+        ...     'load': range(100, 124),
+        ...     'temperature': [20 + i*0.5 for i in range(24)]
+        ... })
+        >>> versioned_dataset = VersionedTimeSeriesDataset.from_dataframe(data, sample_interval=timedelta(hours=1))
+        >>>
+        >>> # Configure horizons
+        >>> horizons = [LeadTime.from_string("PT1H"), LeadTime.from_string("PT24H")]
+        >>> splitter = HorizonSplitTransform(horizons=horizons)
+        >>>
+        >>> # Split into horizon-specific datasets
+        >>> horizon_datasets = splitter.transform(versioned_dataset)
+        >>> len(horizon_datasets)
+        2
+    """
+
+    horizons: list[LeadTime] = Field(
+        default_factory=lambda: [LeadTime.from_string("PT36H")],
+        description="List of forecast horizons to prepare / split the dataset for.",
+    )
+
+    def transform(self, dataset: VersionedTimeSeriesDataset) -> dict[LeadTime, TimeSeriesDataset]:
+        """Split versioned dataset into horizon-specific time series datasets.
+
+        For each configured horizon, filters the versioned data and resolves timestamps
+        to create clean time series datasets suitable for standard processing.
+
+        Args:
+            dataset: Versioned time series dataset with forecast validity timestamps.
+
+        Returns:
+            Dictionary mapping each LeadTime to its corresponding TimeSeriesDataset.
+        """
+        return {horizon: dataset.filter_by_lead_time(lead_time=horizon).select_version() for horizon in self.horizons}
+
+
+def concat_horizon_datasets_rowwise(horizon_datasets: dict[LeadTime, TimeSeriesDataset]) -> TimeSeriesDataset:
+    """Concatenate multiple horizon datasets into a single dataset.
+
+    This function takes a dictionary of horizon datasets, each corresponding to a specific lead time,
+    and concatenates them row-wise into a single TimeSeriesDataset. The resulting dataset contains all
+    the data from the input datasets, with the same sample interval as the first dataset in the input.
+
+    Args:
+        horizon_datasets: A dictionary where keys are LeadTime objects and values are TimeSeriesDataset instances.
+
+    Returns:
+        A single TimeSeriesDataset containing all rows from the input datasets.
+    """
+    return TimeSeriesDataset(
+        data=pd.concat([horizon_data.data for horizon_data in horizon_datasets.values()]),
+        sample_interval=horizon_datasets[next(iter(horizon_datasets))].sample_interval,
+    )

--- a/packages/openstef-models/tests/unit/feature_engineering/test_feature_pipeline.py
+++ b/packages/openstef-models/tests/unit/feature_engineering/test_feature_pipeline.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the OpenSTEF project <short.term.energy.forecasts@alliander.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Tests for FeaturePipeline and related transform orchestration."""
+
+from datetime import timedelta
+from typing import override
+
+import pandas as pd
+import pytest
+
+from openstef_core.datasets import TimeSeriesDataset, VersionedTimeSeriesDataset
+from openstef_core.datasets.transforms import TimeSeriesTransform, VersionedTimeSeriesTransform
+from openstef_core.datasets.versioned_timeseries.dataset_part import VersionedTimeSeriesPart
+from openstef_core.exceptions import TransformNotFittedError
+from openstef_core.types import LeadTime
+from openstef_models.feature_engineering.feature_pipeline import FeaturePipeline
+from openstef_models.feature_engineering.horizon_split_transform import concat_horizon_datasets_rowwise
+
+
+class MockTimeSeriesTransform(TimeSeriesTransform):
+    """Mock TimeSeriesTransform for testing."""
+
+    def __init__(self, transform_suffix: str = "_transformed"):
+        self.transform_suffix = transform_suffix
+        self.is_fitted = False
+
+    @override
+    def fit_horizons(self, data: dict[LeadTime, TimeSeriesDataset]) -> None:
+        flat_data = concat_horizon_datasets_rowwise(data)
+        return self.fit(flat_data)
+
+    @override
+    def fit(self, data: TimeSeriesDataset) -> None:
+        self.is_fitted = True
+
+    @override
+    def transform(self, data: TimeSeriesDataset) -> TimeSeriesDataset:
+        if not self.is_fitted:
+            raise TransformNotFittedError("Mock transform not fitted")
+
+        # Add suffix to column names
+        new_data = data.data.copy()
+        new_data.columns = [f"{col}{self.transform_suffix}" for col in new_data.columns]
+        return TimeSeriesDataset(new_data, data.sample_interval)
+
+
+class MockVersionedTimeSeriesTransform(VersionedTimeSeriesTransform):
+    """Mock VersionedTimeSeriesTransform for testing."""
+
+    def __init__(self, transform_suffix: str = "_versioned"):
+        self.transform_suffix = transform_suffix
+        self.is_fitted = False
+
+    @override
+    def fit(self, data: VersionedTimeSeriesDataset) -> None:
+        self.is_fitted = True
+
+    @override
+    def transform(self, data: VersionedTimeSeriesDataset) -> VersionedTimeSeriesDataset:
+        if not self.is_fitted:
+            raise TransformNotFittedError("Mock versioned transform not fitted")
+
+        # Add suffix to feature names in data parts
+        new_parts: list[VersionedTimeSeriesPart] = []
+        for part in data.data_parts:
+            new_data = part.data.rename(
+                columns={
+                    col: f"{col}{self.transform_suffix}"
+                    for col in part.data.columns
+                    if col not in {"timestamp", "available_at"}
+                }
+            )
+            # Create new part with transformed data
+            new_part = VersionedTimeSeriesPart(new_data, part.sample_interval)
+            new_parts.append(new_part)
+
+        return VersionedTimeSeriesDataset(new_parts)
+
+
+@pytest.fixture
+def sample_versioned_dataset() -> VersionedTimeSeriesDataset:
+    """Create sample versioned dataset for testing."""
+    data = pd.DataFrame({
+        "timestamp": pd.to_datetime([
+            "2025-01-01T10:00:00",
+            "2025-01-01T11:00:00",
+            "2025-01-01T12:00:00",
+        ]),
+        "available_at": pd.to_datetime([
+            "2025-01-01T10:05:00",
+            "2025-01-01T11:05:00",
+            "2025-01-01T12:05:00",
+        ]),
+        "load": [100.0, 110.0, 120.0],
+        "temperature": [20.0, 21.0, 22.0],
+    })
+    return VersionedTimeSeriesDataset.from_dataframe(data, timedelta(hours=1))
+
+
+@pytest.fixture
+def sample_timeseries_dataset() -> TimeSeriesDataset:
+    """Create sample TimeSeriesDataset for testing."""
+    data = pd.DataFrame(
+        {
+            "load": [100.0, 110.0, 120.0],
+            "temperature": [20.0, 21.0, 22.0],
+        },
+        index=pd.date_range("2025-01-01 10:00", periods=3, freq="1h"),
+    )
+    return TimeSeriesDataset(data, timedelta(hours=1))
+
+
+@pytest.mark.parametrize(
+    ("horizons", "versioned_transforms", "horizon_transforms", "expected_columns"),
+    [
+        pytest.param([LeadTime.from_string("PT1H")], [], [], {"load", "temperature"}, id="no_transforms"),
+        pytest.param(
+            [LeadTime.from_string("PT1H")],
+            [MockVersionedTimeSeriesTransform("_v")],
+            [MockTimeSeriesTransform("_h")],
+            {"load_v_h", "temperature_v_h"},
+            id="all_transforms",
+        ),
+        pytest.param(
+            [LeadTime.from_string("PT1H"), LeadTime.from_string("PT24H")],
+            [],
+            [],
+            {"load", "temperature"},
+            id="multiple_horizons",
+        ),
+    ],
+)
+def test_feature_pipeline_core_functionality(
+    sample_versioned_dataset: VersionedTimeSeriesDataset,
+    horizons: list[LeadTime],
+    versioned_transforms: list[VersionedTimeSeriesTransform],
+    horizon_transforms: list[TimeSeriesTransform],
+    expected_columns: set[str],
+):
+    """Test core FeaturePipeline functionality with essential scenarios."""
+    # Arrange
+    pipeline = FeaturePipeline(
+        horizons=horizons, versioned_transforms=versioned_transforms, horizon_transforms=horizon_transforms
+    )
+
+    # Act
+    result = pipeline.fit_transform(sample_versioned_dataset)
+
+    # Assert
+    assert pipeline._is_fitted
+    assert len(result) == len(horizons)
+    for horizon in horizons:
+        assert horizon in result
+        horizon_dataset = result[horizon]
+        assert isinstance(horizon_dataset, TimeSeriesDataset)
+        assert set(horizon_dataset.data.columns) == expected_columns
+
+
+def test_feature_pipeline_transform_not_fitted_error(sample_versioned_dataset: VersionedTimeSeriesDataset):
+    """Test that transform raises error when pipeline not fitted."""
+    # Arrange
+    pipeline = FeaturePipeline()
+
+    # Act & Assert
+    with pytest.raises(TransformNotFittedError, match="Pipeline is not fitted yet"):
+        pipeline.transform(sample_versioned_dataset)
+
+
+def test_feature_pipeline_unversioned_dataset_compatibility(sample_timeseries_dataset: TimeSeriesDataset):
+    """Test pipeline works with unversioned dataset when compatible."""
+    # Arrange
+    pipeline = FeaturePipeline(
+        horizons=[LeadTime.from_string("PT1H")],
+        versioned_transforms=[],
+        horizon_transforms=[MockTimeSeriesTransform("_test")],
+    )
+
+    # Act
+    pipeline.fit(sample_timeseries_dataset)
+    result = pipeline.transform(sample_timeseries_dataset)
+
+    # Assert
+    assert pipeline._is_fitted
+    assert len(result) == 1
+    horizon_dataset = result[LeadTime.from_string("PT1H")]
+    assert set(horizon_dataset.data.columns) == {"load_test", "temperature_test"}
+
+
+def test_feature_pipeline_unversioned_dataset_validation_errors(sample_timeseries_dataset: TimeSeriesDataset):
+    """Test validation errors for incompatible unversioned dataset configurations."""
+    # Arrange - Pipeline with versioned transforms
+    pipeline_with_versioned = FeaturePipeline(
+        horizons=[LeadTime.from_string("PT1H")], versioned_transforms=[MockVersionedTimeSeriesTransform()]
+    )
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="pipeline cannot contain versioned transforms"):
+        pipeline_with_versioned.fit(sample_timeseries_dataset)
+
+    # Arrange - Pipeline with multiple horizons
+    pipeline_multi_horizon = FeaturePipeline(horizons=[LeadTime.from_string("PT1H"), LeadTime.from_string("PT24H")])
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="exactly one horizon must be configured"):
+        pipeline_multi_horizon.fit(sample_timeseries_dataset)

--- a/packages/openstef-models/tests/unit/feature_engineering/test_horizon_split_transform.py
+++ b/packages/openstef-models/tests/unit/feature_engineering/test_horizon_split_transform.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the OpenSTEF project <short.term.energy.forecasts@alliander.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Tests for HorizonSplitTransform and concat_horizon_datasets_rowwise."""
+
+from datetime import timedelta
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from openstef_core.datasets import TimeSeriesDataset, VersionedTimeSeriesDataset
+from openstef_core.types import LeadTime
+from openstef_models.feature_engineering.horizon_split_transform import (
+    HorizonSplitTransform,
+    concat_horizon_datasets_rowwise,
+)
+
+
+@pytest.fixture
+def sample_versioned_dataset() -> VersionedTimeSeriesDataset:
+    """Create sample versioned dataset for testing."""
+    data = pd.DataFrame({
+        "timestamp": pd.to_datetime([
+            "2025-01-01T10:00:00",
+            "2025-01-01T11:00:00",
+            "2025-01-01T12:00:00",
+            "2025-01-01T13:00:00",
+        ]),
+        "available_at": pd.to_datetime([
+            "2025-01-01T10:05:00",
+            "2025-01-01T11:05:00",
+            "2025-01-01T12:05:00",
+            "2025-01-01T13:05:00",
+        ]),
+        "load": [100.0, 110.0, 120.0, 130.0],
+        "temperature": [20.0, 21.0, 22.0, 23.0],
+    })
+    return VersionedTimeSeriesDataset.from_dataframe(data, timedelta(hours=1))
+
+
+@pytest.mark.parametrize(
+    ("horizons", "expected_count"),
+    [
+        pytest.param([LeadTime.from_string("PT36H")], 1, id="default_horizon"),
+        pytest.param([LeadTime.from_string("PT1H")], 1, id="single_custom_horizon"),
+        pytest.param([LeadTime.from_string("PT1H"), LeadTime.from_string("PT2H")], 2, id="two_horizons"),
+        pytest.param(
+            [LeadTime.from_string("PT15M"), LeadTime.from_string("PT1H"), LeadTime.from_string("PT24H")],
+            3,
+            id="three_horizons",
+        ),
+    ],
+)
+def test_horizon_split_transform_initialization_and_transform(
+    sample_versioned_dataset: VersionedTimeSeriesDataset, horizons: list[LeadTime], expected_count: int
+):
+    """Test HorizonSplitTransform initialization and transformation with various horizon configurations."""
+    # Arrange
+    transform = HorizonSplitTransform(horizons=horizons)
+
+    # Assert initialization
+    assert transform.horizons == horizons
+    assert len(transform.horizons) == expected_count
+
+    # Act - transform dataset
+    result = transform.transform(sample_versioned_dataset)
+
+    # Assert transformation results
+    assert len(result) == expected_count
+
+    for horizon in horizons:
+        assert horizon in result
+        horizon_dataset = result[horizon]
+        assert isinstance(horizon_dataset, TimeSeriesDataset)
+        assert horizon_dataset.sample_interval == sample_versioned_dataset.sample_interval
+
+        # Verify data structure is preserved correctly
+        assert isinstance(horizon_dataset.data.index, pd.DatetimeIndex)
+        expected_columns = {"load", "temperature"}
+        assert set(horizon_dataset.data.columns) == expected_columns
+
+        # Data should not be empty (though may be filtered)
+        assert not horizon_dataset.data.empty
+
+
+def test_horizon_split_transform_default_initialization():
+    """Test HorizonSplitTransform creates with default parameters."""
+    # Arrange & Act
+    transform = HorizonSplitTransform()
+
+    # Assert
+    assert len(transform.horizons) == 1
+    assert transform.horizons[0] == LeadTime.from_string("PT36H")
+
+
+@pytest.mark.parametrize(
+    ("datasets_config", "expected_behavior"),
+    [
+        pytest.param(
+            [{"load": [100.0, 110.0], "temperature": [20.0, 21.0], "start": "2025-01-01 10:00", "periods": 2}],
+            {"type": "single", "sample_interval": timedelta(hours=1)},
+            id="single_dataset",
+        ),
+        pytest.param(
+            [
+                {"load": [100.0, 110.0], "temperature": [20.0, 21.0], "start": "2025-01-01 10:00", "periods": 2},
+                {"load": [120.0, 130.0], "temperature": [22.0, 23.0], "start": "2025-01-01 12:00", "periods": 2},
+            ],
+            {"type": "multiple", "sample_interval": timedelta(hours=1), "total_rows": 4},
+            id="multiple_datasets",
+        ),
+        pytest.param(
+            [
+                {"load": [100.0], "start": "2025-01-01 10:00", "periods": 1, "interval": timedelta(hours=1)},
+                {"load": [110.0], "start": "2025-01-01 11:00", "periods": 1, "interval": timedelta(minutes=30)},
+            ],
+            {"type": "mixed_intervals", "sample_interval": timedelta(hours=1)},
+            id="preserves_first_sample_interval",
+        ),
+        pytest.param(
+            [
+                {"load": [100.0, 110.0], "temperature": [20.0, 21.0], "start": "2025-01-01 10:00", "periods": 2},
+                {"load": [105.0, 115.0], "temperature": [20.5, 21.5], "start": "2025-01-01 10:00", "periods": 2},
+            ],
+            {"type": "overlapping", "sample_interval": timedelta(hours=1), "total_rows": 4},
+            id="handles_overlapping_indices",
+        ),
+    ],
+)
+def test_concat_horizon_datasets_rowwise(datasets_config: list[dict[str, Any]], expected_behavior: dict[str, Any]):
+    """Test concatenating horizon datasets with various configurations."""
+    # Arrange
+    horizon_datasets: dict[LeadTime, TimeSeriesDataset] = {}
+    expected_sample_interval = expected_behavior["sample_interval"]
+
+    for i, config in enumerate(datasets_config):
+        data_dict = {k: v for k, v in config.items() if k not in {"start", "periods", "interval"}}
+        index = pd.date_range(config["start"], periods=config["periods"], freq="1h")
+        data = pd.DataFrame(data_dict, index=index)
+
+        interval = config.get("interval", timedelta(hours=1))
+        dataset = TimeSeriesDataset(data, interval)
+        horizon_datasets[LeadTime.from_string(f"PT{i + 1}H")] = dataset
+
+    # Act
+    result = concat_horizon_datasets_rowwise(horizon_datasets)
+
+    # Assert
+    assert isinstance(result, TimeSeriesDataset)
+    assert result.sample_interval == expected_sample_interval
+
+    if expected_behavior["type"] == "single":
+        # Single dataset should be identical to input
+        original_dataset = next(iter(horizon_datasets.values()))
+        pd.testing.assert_frame_equal(result.data, original_dataset.data)
+    elif "total_rows" in expected_behavior:
+        # Check expected number of rows
+        assert len(result.data) == expected_behavior["total_rows"]
+
+
+def test_concat_horizon_datasets_rowwise_empty_datasets():
+    """Test concatenation with empty datasets."""
+    # Arrange
+    empty_data = pd.DataFrame(columns=["load", "temperature"])
+    empty_data.index = pd.DatetimeIndex([], name="timestamp")
+    empty_dataset = TimeSeriesDataset(empty_data, timedelta(hours=1))
+    horizon_datasets = {LeadTime.from_string("PT1H"): empty_dataset}
+
+    # Act
+    result = concat_horizon_datasets_rowwise(horizon_datasets)
+
+    # Assert
+    assert isinstance(result, TimeSeriesDataset)
+    assert result.data.empty
+    assert result.sample_interval == empty_dataset.sample_interval
+
+
+def test_horizon_split_transform_integration_with_concat():
+    """Test that HorizonSplitTransform output can be properly concatenated."""
+    # Arrange
+    data = pd.DataFrame({
+        "timestamp": pd.to_datetime([
+            "2025-01-01T10:00:00",
+            "2025-01-01T11:00:00",
+        ]),
+        "available_at": pd.to_datetime([
+            "2025-01-01T10:05:00",
+            "2025-01-01T11:05:00",
+        ]),
+        "load": [100.0, 110.0],
+    })
+    versioned_dataset = VersionedTimeSeriesDataset.from_dataframe(data, timedelta(hours=1))
+
+    horizons = [LeadTime.from_string("PT1H"), LeadTime.from_string("PT2H")]
+    transform = HorizonSplitTransform(horizons=horizons)
+
+    # Act
+    horizon_datasets = transform.transform(versioned_dataset)
+    concatenated = concat_horizon_datasets_rowwise(horizon_datasets)
+
+    # Assert
+    assert isinstance(concatenated, TimeSeriesDataset)
+    assert "load" in concatenated.data.columns
+    assert concatenated.sample_interval == versioned_dataset.sample_interval

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dev = [
   "pandas-stubs>=2.3.0.250703",
   "poethepoet>=0.36",
   "pyproject-fmt>=2.6",
-  "pyright>=1.1.403",
+  "pyright>=1.1.404",
   "pytest>=8.4.1",
   "pytest-cov>=6.2.1",
   "pytest-xdist>=3.8",
@@ -177,7 +177,7 @@ include = [
   "examples/**/*.py",
   "packages/*/src/**/*.py",
   "packages/*/examples/**/*.py",
-  # "packages/*/tests/**/*.py",
+  "packages/*/tests/**/*.py",
 ]
 typeCheckingMode = "strict"
 reportPrivateImportUsage = false
@@ -225,7 +225,7 @@ cmd = "uv lock --check"
 
 [tool.poe.tasks.type]
 help = "Check typing (with pyright)"
-cmd = "pyright"
+cmd = "pyright tools examples packages/*/src packages/*/examples"
 
 [tool.poe.tasks.tests]
 help = "Run pytest with xdist, marker filtering, and coverage"

--- a/uv.lock
+++ b/uv.lock
@@ -1648,7 +1648,7 @@ dev = [
     { name = "pandas-stubs", specifier = ">=2.3.0.250703" },
     { name = "poethepoet", specifier = ">=0.36" },
     { name = "pyproject-fmt", specifier = ">=2.6" },
-    { name = "pyright", specifier = ">=1.1.403" },
+    { name = "pyright", specifier = ">=1.1.404" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-xdist", specifier = ">=3.8" },
@@ -2273,15 +2273,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.403"
+version = "1.1.404"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/f6/35f885264ff08c960b23d1542038d8da86971c5d8c955cfab195a4f672d7/pyright-1.1.403.tar.gz", hash = "sha256:3ab69b9f41c67fb5bbb4d7a36243256f0d549ed3608678d381d5f51863921104", size = 3913526, upload-time = "2025-07-09T07:15:52.882Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/6e/026be64c43af681d5632722acd100b06d3d39f383ec382ff50a71a6d5bce/pyright-1.1.404.tar.gz", hash = "sha256:455e881a558ca6be9ecca0b30ce08aa78343ecc031d37a198ffa9a7a1abeb63e", size = 4065679, upload-time = "2025-08-20T18:46:14.029Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/b6/b04e5c2f41a5ccad74a1a4759da41adb20b4bc9d59a5e08d29ba60084d07/pyright-1.1.403-py3-none-any.whl", hash = "sha256:c0eeca5aa76cbef3fcc271259bbd785753c7ad7bcac99a9162b4c4c7daed23b3", size = 5684504, upload-time = "2025-07-09T07:15:50.958Z" },
+    { url = "https://files.pythonhosted.org/packages/84/30/89aa7f7d7a875bbb9a577d4b1dc5a3e404e3d2ae2657354808e905e358e0/pyright-1.1.404-py3-none-any.whl", hash = "sha256:c7b7ff1fdb7219c643079e4c3e7d4125f0dafcc19d253b47e898d130ea426419", size = 5902951, upload-time = "2025-08-20T18:46:12.096Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces a feature engineering pipeline for multi-horizon time series forecasting models and adds support for horizon-aware transformations across the codebase. The main changes include the implementation of the `FeaturePipeline` class, enhancements to the transform interface to support multi-horizon fitting and transformation, and updates to several general transforms to leverage the new horizon-aware interface.

**Feature engineering pipeline and multi-horizon support:**

* Added the `FeaturePipeline` class to orchestrate versioned and horizon-specific feature transformations for multi-horizon forecasting workflows. The pipeline manages fitting and transforming both versioned and unversioned datasets and ensures correct handling of horizon-specific logic. [[1]](diffhunk://#diff-0bddee4ebc6862175effa54222ab7693dec46afa0b7a4ec30355dfa64dc84132R1-R172) [[2]](diffhunk://#diff-fe7c7456f13b6d4b24b11880ced228a565bc4cfab01493ed11be89faf9fadb55R11-R32)
* Introduced the `fit_horizons`, `transform_horizons`, and `fit_transform_horizons` methods to the `TimeSeriesTransform` interface, enabling transforms to process data across multiple forecast horizons in a unified way.
* Added the `MultiHorizonTimeSeriesDataset` type alias for clarity when working with horizon-indexed datasets.

**General transforms:**

* Updated `ClippingTransform`, `ImputationTransform`, `RemoveEmptyColumnsTransform`, and `ScalerTransform` to implement the new `fit_horizons` method. These transforms now concatenate horizon datasets row-wise when fitting, ensuring global statistics are computed across all horizons. [[1]](diffhunk://#diff-20fad7934baa869405965d9103bd19d8a6412d7ddb27c1cb9adeed28a15d0694R70-R74) [[2]](diffhunk://#diff-e90ceb245c27a7615a281e05187342bc5a29aa1b22fa385635679d11d6552c39R148-R153) [[3]](diffhunk://#diff-cbfa6dd1ac0577057074e927b6b3423a4c3b3a92c938f3ddd1f0f7978f8060c8R84-R88) [[4]](diffhunk://#diff-4161568fd836d2e2b2e01a4b08f6add02edb7d46c8507be10931ce59e101916eR87-R91)
* Added necessary imports for `LeadTime` and the `concat_horizon_datasets_rowwise` utility in the corresponding transform modules. [[1]](diffhunk://#diff-20fad7934baa869405965d9103bd19d8a6412d7ddb27c1cb9adeed28a15d0694R21-R22) [[2]](diffhunk://#diff-e90ceb245c27a7615a281e05187342bc5a29aa1b22fa385635679d11d6552c39R20-R23) [[3]](diffhunk://#diff-cbfa6dd1ac0577057074e927b6b3423a4c3b3a92c938f3ddd1f0f7978f8060c8R21-R22) [[4]](diffhunk://#diff-4161568fd836d2e2b2e01a4b08f6add02edb7d46c8507be10931ce59e101916eR21-R22)

**Core transform infrastructure:**

* Renamed `TimeSeriesVersionedTransform` to `VersionedTimeSeriesTransform` throughout the codebase for clarity and consistency. [[1]](diffhunk://#diff-2632edfa6ce67dd845cf19c0ca6ed783c45842b213e8953b5a767633953d65cdL100-R152) [[2]](diffhunk://#diff-2632edfa6ce67dd845cf19c0ca6ed783c45842b213e8953b5a767633953d65cdL163-R215)

**Other:**

* Removed the unused copyright and docstring header from `exceptions.py`.