### PR TITLE
fix(STEF-2391): Improved feature clipping (to avoid extrapolation) by switching it from minmax to std clipping.

### DIFF
--- a/openstef/model/metamodels/feature_clipper.py
+++ b/openstef/model/metamodels/feature_clipper.py
@@ -20,7 +20,7 @@ class FeatureClipper(BaseEstimator, TransformerMixin):
     extrapolating beyond these values during prediction.
     """
 
-    def __init__(self, columns: List[str], clip_std: float = 2.0):
+    def __init__(self, columns: List[str], clip_number_of_std: float = 2.0):
         """
         Initialize the FeatureClipper.
 
@@ -31,7 +31,7 @@ class FeatureClipper(BaseEstimator, TransformerMixin):
         """
         self.columns: List[str] = columns
         self.feature_ranges: Dict[str, Tuple[float, float] | FeatureStats] = {}
-        self.clip_std = clip_std
+        self.clip_number_of_std = clip_number_of_std
 
     def fit(self, X: pd.DataFrame, y: Optional[pd.Series] = None) -> "FeatureClipper":
         """
@@ -97,8 +97,8 @@ class FeatureClipper(BaseEstimator, TransformerMixin):
                 if isinstance(self.feature_ranges[col], FeatureStats):
                     stats = self.feature_ranges[col]
                     X_copy[col] = X_copy[col].clip(
-                        lower=stats.mean - self.clip_std * stats.std,
-                        upper=stats.mean + self.clip_std * stats.std,
+                        lower=stats.mean - self.clip_number_of_std * stats.std,
+                        upper=stats.mean + self.clip_number_of_std * stats.std,
                     )
                 else:
                     # Backward compatibility with previous minmax-based implementation

--- a/openstef/model/metamodels/feature_clipper.py
+++ b/openstef/model/metamodels/feature_clipper.py
@@ -4,7 +4,13 @@
 from typing import Dict, List, Optional, Tuple
 
 import pandas as pd
+from pydantic import BaseModel
 from sklearn.base import BaseEstimator, TransformerMixin
+
+
+class FeatureStats(BaseModel):
+    mean: float
+    std: float
 
 
 class FeatureClipper(BaseEstimator, TransformerMixin):
@@ -14,7 +20,7 @@ class FeatureClipper(BaseEstimator, TransformerMixin):
     extrapolating beyond these values during prediction.
     """
 
-    def __init__(self, columns: List[str]):
+    def __init__(self, columns: List[str], clip_std: float = 2.0):
         """
         Initialize the FeatureClipper.
 
@@ -24,7 +30,8 @@ class FeatureClipper(BaseEstimator, TransformerMixin):
             List of column names to be clipped.
         """
         self.columns: List[str] = columns
-        self.feature_ranges: Dict[str, Tuple[float, float]] = {}
+        self.feature_ranges: Dict[str, Tuple[float, float] | FeatureStats] = {}
+        self.clip_std = clip_std
 
     def fit(self, X: pd.DataFrame, y: Optional[pd.Series] = None) -> "FeatureClipper":
         """
@@ -54,7 +61,9 @@ class FeatureClipper(BaseEstimator, TransformerMixin):
 
         for col in self.columns:
             if col in X.columns:
-                self.feature_ranges[col] = (X[col].min(), X[col].max())
+                self.feature_ranges[col] = FeatureStats(
+                    mean=X[col].mean(), std=X[col].std()
+                )
 
         return self
 
@@ -85,7 +94,15 @@ class FeatureClipper(BaseEstimator, TransformerMixin):
 
         for col in self.columns:
             if col in X_copy.columns and col in self.feature_ranges:
-                min_val, max_val = self.feature_ranges[col]
-                X_copy[col] = X_copy[col].clip(lower=min_val, upper=max_val)
+                if isinstance(self.feature_ranges[col], FeatureStats):
+                    stats = self.feature_ranges[col]
+                    X_copy[col] = X_copy[col].clip(
+                        lower=stats.mean - self.clip_std * stats.std,
+                        upper=stats.mean + self.clip_std * stats.std,
+                    )
+                else:
+                    # Backward compatibility with previous minmax-based implementation
+                    min_val, max_val = self.feature_ranges[col]
+                    X_copy[col] = X_copy[col].clip(lower=min_val, upper=max_val)
 
         return X_copy

--- a/test/unit/model/metamodels/test_feature_clipper.py
+++ b/test/unit/model/metamodels/test_feature_clipper.py
@@ -25,8 +25,12 @@ class TestFeatureClipper(unittest.TestCase):
     def test_fit(self):
         """Test if the fit method correctly computes min and max values."""
         self.clipper.fit(self.df_train)
-        self.assertEqual(self.clipper.feature_ranges["A"], FeatureStats(mean=2.0, std=1.0))
-        self.assertEqual(self.clipper.feature_ranges["B"], FeatureStats(mean=20.0, std=10.0))
+        self.assertEqual(
+            self.clipper.feature_ranges["A"], FeatureStats(mean=2.0, std=1.0)
+        )
+        self.assertEqual(
+            self.clipper.feature_ranges["B"], FeatureStats(mean=20.0, std=10.0)
+        )
         self.assertNotIn("D", self.clipper.feature_ranges)
 
     def test_transform(self):

--- a/test/unit/model/metamodels/test_feature_clipper.py
+++ b/test/unit/model/metamodels/test_feature_clipper.py
@@ -5,7 +5,7 @@ import unittest
 
 import pandas as pd
 
-from openstef.model.metamodels.feature_clipper import FeatureClipper
+from openstef.model.metamodels.feature_clipper import FeatureClipper, FeatureStats
 
 
 class TestFeatureClipper(unittest.TestCase):
@@ -25,8 +25,8 @@ class TestFeatureClipper(unittest.TestCase):
     def test_fit(self):
         """Test if the fit method correctly computes min and max values."""
         self.clipper.fit(self.df_train)
-        self.assertEqual(self.clipper.feature_ranges["A"], (1.0, 3.0))
-        self.assertEqual(self.clipper.feature_ranges["B"], (10.0, 30.0))
+        self.assertEqual(self.clipper.feature_ranges["A"], FeatureStats(mean=2.0, std=1.0))
+        self.assertEqual(self.clipper.feature_ranges["B"], FeatureStats(mean=20.0, std=10.0))
         self.assertNotIn("D", self.clipper.feature_ranges)
 
     def test_transform(self):
@@ -35,8 +35,8 @@ class TestFeatureClipper(unittest.TestCase):
         transformed_df = self.clipper.transform(self.df_test)
         expected_df = pd.DataFrame(
             {
-                "A": [1.0, 3.0],  # Clipped to range [1.0, 3.0]
-                "B": [10.0, 30.0],  # Clipped to range [10.0, 30.0]
+                "A": [0.5, 4.0],  # Clipped to range [0.5, 4.0]
+                "B": [5.0, 35.0],  # Clipped to range [5.0, 35.0]
                 "C": [150.0, 350.0],  # Unchanged
             }
         )

--- a/test/unit/model/regressors/test_gblinear_quantile.py
+++ b/test/unit/model/regressors/test_gblinear_quantile.py
@@ -202,8 +202,8 @@ class TestGBLinearQuantile(BaseTestCase):
 
         # Check if the 'APX' feature was clipped during prediction
         clipped_X = model.feature_clipper_.transform(X_test)
-        self.assertTrue(clipped_X["APX"].min() >= -10.0)
-        self.assertTrue(clipped_X["APX"].max() <= 200.0)
+        self.assertTrue(clipped_X["APX"].min() >= -20.0)
+        self.assertTrue(clipped_X["APX"].max() <= 240.0)
 
         # Make predictions
         y_pred = model.predict(X_test)

--- a/test/unit/model/regressors/test_linear_quantile.py
+++ b/test/unit/model/regressors/test_linear_quantile.py
@@ -213,8 +213,8 @@ class TestLinearQuantile(BaseTestCase):
 
         # Check if the 'day_ahead_electricity_price' feature was clipped during prediction
         clipped_X = model.feature_clipper_.transform(X_test)
-        self.assertTrue(clipped_X["day_ahead_electricity_price"].min() >= -10.0)
-        self.assertTrue(clipped_X["day_ahead_electricity_price"].max() <= 200.0)
+        self.assertTrue(clipped_X["day_ahead_electricity_price"].min() >= -20.0)
+        self.assertTrue(clipped_X["day_ahead_electricity_price"].max() <= 240.0)
 
         # Make predictions
         y_pred = model.predict(X_test)


### PR DESCRIPTION
* The solution is backwards compatible with models trained before this change. Newly trained models will used std clipping, older will continue using minmax until retrain.