### PR TITLE
add quantile calibration boxplot

### DIFF
--- a/packages/openstef-beam/src/openstef_beam/analysis/plots/__init__.py
+++ b/packages/openstef-beam/src/openstef_beam/analysis/plots/__init__.py
@@ -11,6 +11,7 @@ visualizations, including time series, metrics, and statistical plots.
 from .forecast_time_series_plotter import ForecastTimeSeriesPlotter
 from .grouped_target_metric_plotter import GroupedTargetMetricPlotter
 from .precision_recall_curve_plotter import PrecisionRecallCurvePlotter
+from .quantile_calibration_box_plotter import QuantileCalibrationBoxPlotter
 from .quantile_probability_plotter import QuantileProbabilityPlotter
 from .summary_table_plotter import SummaryTablePlotter
 from .windowed_metric_plotter import WindowedMetricPlotter
@@ -19,6 +20,7 @@ __all__ = [
     "ForecastTimeSeriesPlotter",
     "GroupedTargetMetricPlotter",
     "PrecisionRecallCurvePlotter",
+    "QuantileCalibrationBoxPlotter",
     "QuantileProbabilityPlotter",
     "SummaryTablePlotter",
     "WindowedMetricPlotter",

--- a/packages/openstef-beam/src/openstef_beam/analysis/plots/quantile_calibration_box_plotter.py
+++ b/packages/openstef-beam/src/openstef_beam/analysis/plots/quantile_calibration_box_plotter.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the OpenSTEF project <short.term.energy.forecasts@alliander.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Quantile calibration box plotting for forecast uncertainty validation across multiple targets.
+
+This module provides specialized boxplot visualization for evaluating probabilistic forecast
+calibration across multiple targets, showing calibration error distributions per quantile.
+"""
+
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+
+from openstef_core.types import Quantile
+
+
+class QuantileCalibrationBoxPlotter:
+    """Creates boxplots showing calibration error distributions across targets for each quantile.
+
+    This plotter visualizes how well probabilistic forecasts are calibrated by showing
+    the distribution of calibration errors (observed - forecasted probability) across
+    multiple targets for each quantile level. This helps identify:
+
+    - Which quantiles are systematically over/under-confident across targets
+    - The consistency of calibration across different targets
+    - Overall uncertainty estimation quality per quantile level
+
+    Well-calibrated forecasts will have boxplots centered around zero (no systematic bias)
+    with tight distributions (consistent calibration across targets).
+
+    Example:
+        Validating forecast calibration across multiple models and targets:
+
+        >>> from openstef_core.types import Quantile
+        >>> plotter = QuantileCalibrationBoxPlotter()
+        >>>
+        >>> # Define common quantiles for all models/targets
+        >>> quantiles = [Quantile(0.1), Quantile(0.5), Quantile(0.9)]
+        >>>
+        >>> # ModelA: Well-calibrated model across different sites
+        >>> _ = plotter.add_model("ModelA", quantiles, [Quantile(0.08), Quantile(0.52), Quantile(0.88)])  # Site1
+        >>> _ = plotter.add_model("ModelA", quantiles, [Quantile(0.12), Quantile(0.48), Quantile(0.92)])  # Site2
+        >>> _ = plotter.add_model("ModelA", quantiles, [Quantile(0.09), Quantile(0.51), Quantile(0.89)])  # Site3
+        >>>
+        >>> # ModelB: Overconfident model across different sites
+        >>> _ = plotter.add_model("ModelB", quantiles, [Quantile(0.15), Quantile(0.55), Quantile(0.85)])  # Site1
+        >>> _ = plotter.add_model("ModelB", quantiles, [Quantile(0.18), Quantile(0.58), Quantile(0.82)])  # Site2
+        >>> _ = plotter.add_model("ModelB", quantiles, [Quantile(0.16), Quantile(0.57), Quantile(0.84)])  # Site3
+        >>>
+        >>> # Generate boxplot showing calibration error distributions
+        >>> fig = plotter.plot(title="Multi-Model Calibration Analysis")
+        >>> type(fig).__name__
+        'Figure'
+    """
+
+    def __init__(self) -> None:
+        """Initialize the plotter with empty model data storage."""
+        # Model data contains the model name, forecasted probabilities, and observed probabilities
+        self.models_data: list[dict[str, str | list[Quantile]]] = []
+
+    def add_model(
+        self,
+        model_name: str,
+        forecasted_probs: list[Quantile],
+        observed_probs: list[Quantile],
+    ) -> "QuantileCalibrationBoxPlotter":
+        """Add a model's forecasted and observed probabilities to the plot.
+
+        Args:
+            model_name (str): The name of the model.
+            forecasted_probs (list[float]): List of forecasted probabilities.
+            observed_probs (list[float]): List of observed probabilities.
+
+        Returns:
+            QuantileCalibrationBoxPlotter: The current instance for method chaining.
+
+        Raises:
+            ValueError: If forecasted and observed probability lists have different lengths.
+        """
+        if len(forecasted_probs) != len(observed_probs):
+            msg = "Forecasted probabilities and observed probabilities must have the same length"
+            raise ValueError(msg)
+
+        model_data = {
+            "model": model_name,
+            "forecasted_prob": forecasted_probs,
+            "observed_prob": observed_probs,
+        }
+
+        self.models_data.append(model_data)
+        return self
+
+    def plot(self, title: str = "Quantile Calibration Boxplot") -> go.Figure:
+        """Create and return a quantile calibration boxplot for all added models.
+
+        Args:
+            title (str): Title of the plot.
+
+        Returns:
+            plotly.graph_objects.Figure: The resulting plot.
+
+        Raises:
+            ValueError: If no model data has been added.
+        """
+        if not self.models_data:
+            msg = "No model data has been added. Use add_model first."
+            raise ValueError(msg)
+
+        # Combine all model data into a single DataFrame with calibration errors
+        model_df_list: list[pd.DataFrame] = []
+        for model_data in self.models_data:
+            # Calculate calibration errors (observed - forecasted)
+            calibration_errors = [
+                float(obs) - float(fore)
+                for obs, fore in zip(model_data["observed_prob"], model_data["forecasted_prob"], strict=True)
+            ]
+
+            # Create quantile labels
+            quantile_labels = [f"P{int(float(q) * 100):02d}" for q in model_data["forecasted_prob"]]
+
+            model_df = pd.DataFrame({
+                "Model": [model_data["model"]] * len(calibration_errors),
+                "Quantile": quantile_labels,
+                "Calibration_Error": calibration_errors,
+            })
+            model_df_list.append(model_df)
+
+        models_df = pd.concat(model_df_list, ignore_index=True)
+
+        # Create the boxplot
+        fig = px.box(
+            models_df,
+            x="Quantile",
+            y="Calibration_Error",
+            color="Model",
+            title=title,
+        )
+
+        # Add a horizontal line at y=0 (perfect calibration)
+        fig.add_hline(
+            y=0,
+            line_dash="dash",
+            line_color="black",
+            annotation_text="Perfect Calibration",
+            annotation_position="bottom right",
+        )
+
+        # Add simple region labels
+        fig.add_annotation(
+            x=1,
+            y=1,
+            xref="paper",
+            yref="paper",
+            text="(Overestimation)",
+            showarrow=False,
+            font={"size": 10, "color": "gray"},
+            xanchor="right",
+            yanchor="top",
+        )
+
+        fig.add_annotation(
+            x=1,
+            y=0,
+            xref="paper",
+            yref="paper",
+            text="(Underestimation)",
+            showarrow=False,
+            font={"size": 10, "color": "gray"},
+            xanchor="right",
+            yanchor="bottom",
+        )
+
+        # Update layout for better readability
+        fig.update_layout(
+            xaxis_title="Quantile Level",
+            yaxis_title="Calibration Error (Observed - Forecasted)",
+            showlegend=True,
+            hovermode="x unified",
+        )
+
+        return fig
+
+
+__all__ = ["QuantileCalibrationBoxPlotter"]

--- a/packages/openstef-beam/src/openstef_beam/analysis/plots/quantile_calibration_box_plotter.py
+++ b/packages/openstef-beam/src/openstef_beam/analysis/plots/quantile_calibration_box_plotter.py
@@ -129,7 +129,7 @@ class QuantileCalibrationBoxPlotter:
         models_df = pd.concat(model_df_list, ignore_index=True)
 
         # Create the boxplot
-        fig = px.box(
+        fig: go.Figure = px.box(  # type: ignore[reportUnknownMemberType]
             models_df,
             x="Quantile",
             y="Calibration_Error",
@@ -138,7 +138,7 @@ class QuantileCalibrationBoxPlotter:
         )
 
         # Add a horizontal line at y=0 (perfect calibration)
-        fig.add_hline(
+        fig.add_hline(  # type: ignore[reportUnknownMemberType]
             y=0,
             line_dash="dash",
             line_color="black",
@@ -147,7 +147,7 @@ class QuantileCalibrationBoxPlotter:
         )
 
         # Add simple region labels
-        fig.add_annotation(
+        fig.add_annotation(  # type: ignore[reportUnknownMemberType]
             x=1,
             y=1,
             xref="paper",
@@ -159,7 +159,7 @@ class QuantileCalibrationBoxPlotter:
             yanchor="top",
         )
 
-        fig.add_annotation(
+        fig.add_annotation(  # type: ignore[reportUnknownMemberType]
             x=1,
             y=0,
             xref="paper",
@@ -172,7 +172,7 @@ class QuantileCalibrationBoxPlotter:
         )
 
         # Update layout for better readability
-        fig.update_layout(
+        fig.update_layout(  # type: ignore[reportUnknownMemberType]
             xaxis_title="Quantile Level",
             yaxis_title="Calibration Error (Observed - Forecasted)",
             showlegend=True,

--- a/packages/openstef-beam/src/openstef_beam/analysis/plots/quantile_calibration_box_plotter.py
+++ b/packages/openstef-beam/src/openstef_beam/analysis/plots/quantile_calibration_box_plotter.py
@@ -68,9 +68,9 @@ class QuantileCalibrationBoxPlotter:
         """Add a model's forecasted and observed probabilities to the plot.
 
         Args:
-            model_name (str): The name of the model.
-            forecasted_probs (list[float]): List of forecasted probabilities.
-            observed_probs (list[float]): List of observed probabilities.
+            model_name: The name of the model.
+            forecasted_probs: List of forecasted probabilities.
+            observed_probs: List of observed probabilities.
 
         Returns:
             QuantileCalibrationBoxPlotter: The current instance for method chaining.
@@ -117,7 +117,7 @@ class QuantileCalibrationBoxPlotter:
             ]
 
             # Create quantile labels
-            quantile_labels = [f"P{int(float(q) * 100):02d}" for q in model_data["forecasted_prob"]]
+            quantile_labels = [q.format() for q in model_data["forecasted_prob"]]
 
             model_df = pd.DataFrame({
                 "Model": [model_data["model"]] * len(calibration_errors),
@@ -146,7 +146,27 @@ class QuantileCalibrationBoxPlotter:
             annotation_position="bottom right",
         )
 
-        # Add simple region labels
+        # Add region labels for over/under estimation
+        self._add_over_under_estimation_region_labels(fig)
+
+        # Update layout for better readability
+        fig.update_layout(  # type: ignore[reportUnknownMemberType]
+            xaxis_title="Quantile Level",
+            yaxis_title="Calibration Error (Observed - Forecasted)",
+            showlegend=True,
+            hovermode="x unified",
+        )
+
+        return fig
+
+    @staticmethod
+    def _add_over_under_estimation_region_labels(fig: go.Figure) -> None:
+        """Add region labels to indicate over/under estimation areas on the plot.
+
+        Args:
+            fig: The plotly figure to add annotations to.
+        """
+        # Add overestimation label (positive calibration error region)
         fig.add_annotation(  # type: ignore[reportUnknownMemberType]
             x=1,
             y=1,
@@ -159,6 +179,7 @@ class QuantileCalibrationBoxPlotter:
             yanchor="top",
         )
 
+        # Add underestimation label (negative calibration error region)
         fig.add_annotation(  # type: ignore[reportUnknownMemberType]
             x=1,
             y=0,
@@ -170,16 +191,6 @@ class QuantileCalibrationBoxPlotter:
             xanchor="right",
             yanchor="bottom",
         )
-
-        # Update layout for better readability
-        fig.update_layout(  # type: ignore[reportUnknownMemberType]
-            xaxis_title="Quantile Level",
-            yaxis_title="Calibration Error (Observed - Forecasted)",
-            showlegend=True,
-            hovermode="x unified",
-        )
-
-        return fig
 
 
 __all__ = ["QuantileCalibrationBoxPlotter"]

--- a/packages/openstef-beam/src/openstef_beam/analysis/plots/quantile_probability_plotter.py
+++ b/packages/openstef-beam/src/openstef_beam/analysis/plots/quantile_probability_plotter.py
@@ -65,9 +65,9 @@ class QuantileProbabilityPlotter:
         """Add a model's forecasted and observed probabilities to the plot.
 
         Args:
-            model_name (str): The name of the model.
-            forecasted_probs (list[float]): List of forecasted probabilities.
-            observed_probs (list[float]): List of observed probabilities.
+            model_name: The name of the model.
+            forecasted_probs: List of forecasted probabilities.
+            observed_probs: List of observed probabilities.
 
         Returns:
             QuantileProbabilityPlotter: The current instance for method chaining.

--- a/packages/openstef-beam/src/openstef_beam/analysis/visualizations/__init__.py
+++ b/packages/openstef-beam/src/openstef_beam/analysis/visualizations/__init__.py
@@ -11,6 +11,9 @@ plots and reports from evaluation data at different aggregation levels.
 from openstef_beam.analysis.visualizations.base import MetricIdentifier, ReportTuple, VisualizationProvider
 from openstef_beam.analysis.visualizations.grouped_target_metric_visualization import GroupedTargetMetricVisualization
 from openstef_beam.analysis.visualizations.precision_recall_curve_visualization import PrecisionRecallCurveVisualization
+from openstef_beam.analysis.visualizations.quantile_calibration_box_visualization import (
+    QuantileCalibrationBoxVisualization,
+)
 from openstef_beam.analysis.visualizations.quantile_probability_visualization import QuantileProbabilityVisualization
 from openstef_beam.analysis.visualizations.summary_table_visualization import SummaryTableVisualization
 from openstef_beam.analysis.visualizations.timeseries_visualization import TimeSeriesVisualization
@@ -20,6 +23,7 @@ __all__ = [
     "GroupedTargetMetricVisualization",
     "MetricIdentifier",
     "PrecisionRecallCurveVisualization",
+    "QuantileCalibrationBoxVisualization",
     "QuantileProbabilityVisualization",
     "ReportTuple",
     "SummaryTableVisualization",

--- a/packages/openstef-beam/src/openstef_beam/analysis/visualizations/quantile_calibration_box_visualization.py
+++ b/packages/openstef-beam/src/openstef_beam/analysis/visualizations/quantile_calibration_box_visualization.py
@@ -67,8 +67,7 @@ class QuantileCalibrationBoxVisualization(VisualizationProvider):
             AnalysisAggregation.RUN_AND_GROUP,
         }
 
-    @staticmethod
-    def _extract_probabilities_from_report(report: EvaluationSubsetReport) -> ProbabilityData:
+    def _extract_probabilities_from_report(self, report: EvaluationSubsetReport) -> ProbabilityData:
         """Extract observed and forecasted probability metrics from the report's global metrics.
 
         Args:
@@ -96,10 +95,10 @@ class QuantileCalibrationBoxVisualization(VisualizationProvider):
                     observed_probs.append(Quantile(observed_prob))
                     forecasted_probs.append(quantile)
 
-        if len(observed_probs) != len(forecasted_probs):
-            raise ValueError("Could not find all the observed probability metrics.")
+        prob_data = ProbabilityData(observed_probs=observed_probs, forecasted_probs=forecasted_probs)
+        self._validate_probability_data(prob_data)
 
-        return ProbabilityData(observed_probs=observed_probs, forecasted_probs=forecasted_probs)
+        return prob_data
 
     @staticmethod
     def _validate_probability_data(prob_data: ProbabilityData) -> None:

--- a/packages/openstef-beam/src/openstef_beam/analysis/visualizations/quantile_calibration_box_visualization.py
+++ b/packages/openstef-beam/src/openstef_beam/analysis/visualizations/quantile_calibration_box_visualization.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the OpenSTEF project <short.term.energy.forecasts@alliander.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Quantile calibration boxplot visualization provider.
+
+This module provides visualization for quantile probability analysis, comparing
+calibration error distributions for forecasted quantiles to evaluate
+probabilistic forecast calibration.
+"""
+
+from typing import override
+
+from openstef_beam.analysis.models import AnalysisAggregation, RunName, VisualizationOutput
+from openstef_beam.analysis.plots import QuantileCalibrationBoxPlotter
+from openstef_beam.analysis.visualizations.base import ReportTuple
+from openstef_beam.analysis.visualizations.quantile_probability_visualization import QuantileProbabilityVisualization
+
+
+class QuantileCalibrationBoxVisualization(QuantileProbabilityVisualization):
+    """Creates boxplot visualization for quantile calibration across multiple targets.
+
+    Inherits from QuantileProbabilityVisualization to reuse data extraction and validation logic,
+    but overrides the plotting methods to create boxplots.
+
+    Boxplots are particularly useful for:
+    - Comparing calibration across multiple targets
+    - Showing distribution of calibration errors
+    - Identifying outlier targets or systematic biases
+    - Evaluating consistency of uncertainty estimates
+
+    Example:
+        Basic usage in analysis pipeline:
+
+        >>> from openstef_beam.analysis import AnalysisConfig
+        >>> from openstef_beam.analysis.visualizations import QuantileCalibrationBoxVisualization
+        >>>
+        >>> # Configure quantile calibration boxplot analysis
+        >>> analysis_config = AnalysisConfig(
+        ...     visualization_providers=[
+        ...         QuantileCalibrationBoxVisualization(
+        ...             name="quantile_calibration_boxplot",
+        ...         ),
+        ...     ]
+        ... )
+        >>>
+        >>> # The visualization will generate boxplots showing calibration error
+        >>> # distributions across multiple targets for comparative analysis
+    """
+
+    @property
+    @override
+    def supported_aggregations(self) -> set[AnalysisAggregation]:
+        """Boxplot visualization requires multiple targets, so NONE aggregation is excluded."""
+        return {
+            AnalysisAggregation.RUN_AND_NONE,
+            AnalysisAggregation.RUN_AND_TARGET,
+        }
+
+    @override
+    def create_by_run_and_none(self, reports: dict[RunName, list[ReportTuple]]) -> VisualizationOutput:
+        plotter = QuantileCalibrationBoxPlotter()
+
+        for run_name, report_pairs in reports.items():
+            for _metadata, report in report_pairs:
+                prob_data = self._extract_probabilities_from_report(report)
+                self._validate_probability_data(prob_data)
+
+                plotter.add_model(
+                    model_name=run_name,
+                    observed_probs=prob_data.observed_probs,
+                    forecasted_probs=prob_data.forecasted_probs,
+                )
+
+        title = self._create_plot_title("by Run")
+        figure = plotter.plot(title=title)
+
+        return VisualizationOutput(name=self.name, figure=figure)
+
+
+__all__ = ["QuantileCalibrationBoxVisualization"]

--- a/packages/openstef-beam/src/openstef_beam/analysis/visualizations/quantile_calibration_box_visualization.py
+++ b/packages/openstef-beam/src/openstef_beam/analysis/visualizations/quantile_calibration_box_visualization.py
@@ -9,15 +9,23 @@ calibration error distributions for forecasted quantiles to evaluate
 probabilistic forecast calibration.
 """
 
-from typing import override
+from typing import NamedTuple, override
 
-from openstef_beam.analysis.models import AnalysisAggregation, RunName, VisualizationOutput
+from openstef_beam.analysis.models import AnalysisAggregation, GroupName, RunName, VisualizationOutput
 from openstef_beam.analysis.plots import QuantileCalibrationBoxPlotter
-from openstef_beam.analysis.visualizations.base import ReportTuple
-from openstef_beam.analysis.visualizations.quantile_probability_visualization import QuantileProbabilityVisualization
+from openstef_beam.analysis.visualizations.base import ReportTuple, VisualizationProvider
+from openstef_beam.evaluation import EvaluationSubsetReport
+from openstef_core.types import Quantile
 
 
-class QuantileCalibrationBoxVisualization(QuantileProbabilityVisualization):
+class ProbabilityData(NamedTuple):
+    """Container for observed and forecasted probability data."""
+
+    observed_probs: list[Quantile]
+    forecasted_probs: list[Quantile]
+
+
+class QuantileCalibrationBoxVisualization(VisualizationProvider):
     """Creates boxplot visualization for quantile calibration across multiple targets.
 
     Inherits from QuantileProbabilityVisualization to reuse data extraction and validation logic,
@@ -53,16 +61,122 @@ class QuantileCalibrationBoxVisualization(QuantileProbabilityVisualization):
     def supported_aggregations(self) -> set[AnalysisAggregation]:
         """Boxplot visualization requires multiple targets, so NONE aggregation is excluded."""
         return {
-            AnalysisAggregation.RUN_AND_NONE,
+            AnalysisAggregation.TARGET,
+            AnalysisAggregation.GROUP,
             AnalysisAggregation.RUN_AND_TARGET,
+            AnalysisAggregation.RUN_AND_GROUP,
         }
 
+    @staticmethod
+    def _extract_probabilities_from_report(report: EvaluationSubsetReport) -> ProbabilityData:
+        """Extract observed and forecasted probability metrics from the report's global metrics.
+
+        Args:
+            report: The evaluation subset report containing global metrics
+
+        Returns:
+            ProbabilityData containing lists of observed and forecasted probabilities
+
+        Raises:
+            ValueError: If no global metrics are found or if probability data is inconsistent
+        """
+        global_metrics = report.get_global_metric()
+        if global_metrics is None:
+            raise ValueError("No global metrics found in the report.")
+
+        quantile_columns = global_metrics.get_quantiles()
+        observed_probs: list[Quantile] = []
+        forecasted_probs: list[Quantile] = []
+
+        for quantile in quantile_columns:
+            quantile_metrics = global_metrics.metrics.get(quantile)
+            if quantile_metrics is not None:
+                observed_prob = quantile_metrics.get("observed_probability")
+                if observed_prob is not None:
+                    observed_probs.append(Quantile(observed_prob))
+                    forecasted_probs.append(quantile)
+
+        if len(observed_probs) != len(forecasted_probs):
+            raise ValueError("Could not find all the observed probability metrics.")
+
+        return ProbabilityData(observed_probs=observed_probs, forecasted_probs=forecasted_probs)
+
+    @staticmethod
+    def _validate_probability_data(prob_data: ProbabilityData) -> None:
+        """Validate that probability data is consistent and complete.
+
+        Args:
+            prob_data: The probability data to validate
+
+        Raises:
+            ValueError: If probability data is invalid or incomplete
+        """
+        if len(prob_data.observed_probs) != len(prob_data.forecasted_probs):
+            raise ValueError("Observed and forecasted probability counts must match.")
+
+        if not prob_data.observed_probs:
+            raise ValueError("No probability data found.")
+
+    @staticmethod
+    def _create_plot_title(base_title: str, target_name: str = "") -> str:
+        """Create a formatted title for the plot.
+
+        Args:
+            base_title: The base title describing the aggregation type
+            target_name: Optional target name to include in the title
+
+        Returns:
+            Formatted plot title
+        """
+        if target_name and base_title:
+            return f"Quantile Calibration {base_title} for {target_name}"
+        if target_name:
+            return f"Quantile Calibration for {target_name}"
+        return f"Quantile Calibration {base_title}"
+
+    # making boxplots over all targets in a single group
     @override
-    def create_by_run_and_none(self, reports: dict[RunName, list[ReportTuple]]) -> VisualizationOutput:
+    def create_by_target(
+        self,
+        reports: list[ReportTuple],
+    ) -> VisualizationOutput:
+        if not reports:
+            raise ValueError("No reports provided for target-based visualization.")
+
         plotter = QuantileCalibrationBoxPlotter()
 
-        for run_name, report_pairs in reports.items():
-            for _metadata, report in report_pairs:
+        # Get the run name from the first target metadata for the title
+        run_name = reports[0][0].run_name
+
+        for _metadata, report in reports:
+            prob_data = self._extract_probabilities_from_report(report)
+            self._validate_probability_data(prob_data)
+
+            plotter.add_model(
+                model_name=run_name,
+                observed_probs=prob_data.observed_probs,
+                forecasted_probs=prob_data.forecasted_probs,
+            )
+
+        title = self._create_plot_title("over all targets in group", run_name)
+        figure = plotter.plot(title=title)
+
+        return VisualizationOutput(name=self.name, figure=figure)
+
+    # to plot all targets together (also when in different groups)
+    @override
+    def create_by_group(
+        self,
+        reports: dict[GroupName, list[ReportTuple]],
+    ) -> VisualizationOutput:
+        plotter = QuantileCalibrationBoxPlotter()
+
+        # Use the first run name for the title (if available)
+        first_group = next(iter(reports.values()), None)
+        run_name = first_group[0][0].run_name if first_group and first_group[0] else ""
+
+        for report_list in reports.values():
+            for _metadata, report in report_list:
                 prob_data = self._extract_probabilities_from_report(report)
                 self._validate_probability_data(prob_data)
 
@@ -72,7 +186,52 @@ class QuantileCalibrationBoxVisualization(QuantileProbabilityVisualization):
                     forecasted_probs=prob_data.forecasted_probs,
                 )
 
-        title = self._create_plot_title("by Run")
+        title = self._create_plot_title("over all targets", run_name)
+        figure = plotter.plot(title=title)
+
+        return VisualizationOutput(name=self.name, figure=figure)
+
+    # making boxplots over all targets in a single group
+    @override
+    def create_by_run_and_target(self, reports: dict[RunName, list[ReportTuple]]) -> VisualizationOutput:
+        plotter = QuantileCalibrationBoxPlotter()
+
+        for run_name, report_list in reports.items():
+            for _metadata, report in report_list:
+                prob_data = self._extract_probabilities_from_report(report)
+                self._validate_probability_data(prob_data)
+
+                plotter.add_model(
+                    model_name=run_name,
+                    observed_probs=prob_data.observed_probs,
+                    forecasted_probs=prob_data.forecasted_probs,
+                )
+
+        title = self._create_plot_title("by run and over all targets in group")
+        figure = plotter.plot(title=title)
+
+        return VisualizationOutput(name=self.name, figure=figure)
+
+    # to plot all targets together (also when in different groups)
+    @override
+    def create_by_run_and_group(
+        self,
+        reports: dict[tuple[RunName, GroupName], list[ReportTuple]],
+    ) -> VisualizationOutput:
+        plotter = QuantileCalibrationBoxPlotter()
+
+        for (run_name, _group_name), report_list in reports.items():
+            for _metadata, report in report_list:
+                prob_data = self._extract_probabilities_from_report(report)
+                self._validate_probability_data(prob_data)
+
+                plotter.add_model(
+                    model_name=run_name,
+                    observed_probs=prob_data.observed_probs,
+                    forecasted_probs=prob_data.forecasted_probs,
+                )
+
+        title = self._create_plot_title("by run and over all targets")
         figure = plotter.plot(title=title)
 
         return VisualizationOutput(name=self.name, figure=figure)

--- a/packages/openstef-beam/src/openstef_beam/analysis/visualizations/quantile_probability_visualization.py
+++ b/packages/openstef-beam/src/openstef_beam/analysis/visualizations/quantile_probability_visualization.py
@@ -72,8 +72,7 @@ class QuantileProbabilityVisualization(VisualizationProvider):
             AnalysisAggregation.TARGET,
         }
 
-    @staticmethod
-    def _extract_probabilities_from_report(report: EvaluationSubsetReport) -> ProbabilityData:
+    def _extract_probabilities_from_report(self, report: EvaluationSubsetReport) -> ProbabilityData:
         """Extract observed and forecasted probability metrics from the report's global metrics.
 
         Args:
@@ -101,10 +100,10 @@ class QuantileProbabilityVisualization(VisualizationProvider):
                     observed_probs.append(Quantile(observed_prob))
                     forecasted_probs.append(quantile)
 
-        if len(observed_probs) != len(forecasted_probs):
-            raise ValueError("Could not find all the observed probability metrics.")
+        prob_data = ProbabilityData(observed_probs=observed_probs, forecasted_probs=forecasted_probs)
+        self._validate_probability_data(prob_data)
 
-        return ProbabilityData(observed_probs=observed_probs, forecasted_probs=forecasted_probs)
+        return prob_data
 
     @staticmethod
     def _create_plot_title(base_title: str, target_name: str = "") -> str:

--- a/packages/openstef-beam/tests/unit/analysis/plots/test_quantile_calibration_box_plotter.py
+++ b/packages/openstef-beam/tests/unit/analysis/plots/test_quantile_calibration_box_plotter.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the OpenSTEF project <short.term.energy.forecasts@alliander.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Tests for QuantileCalibrationBoxPlotter - focuses on boxplot-specific functionality only.
+Rest of functionality is tested in test_quantile_probability_plotter.py"""
+
+import numpy as np
+
+from openstef_beam.analysis.plots import QuantileCalibrationBoxPlotter
+from openstef_core.types import Quantile
+
+
+def test_plot_calculates_calibration_errors_correctly():
+    """Test that plot correctly calculates calibration errors (observed - forecasted)"""
+    # Arrange
+    plotter = QuantileCalibrationBoxPlotter()
+    # Model with varied forecasted and observed values
+    plotter.add_model(
+        "model1", [Quantile(0.1), Quantile(0.5), Quantile(0.9)], [Quantile(0.15), Quantile(0.7), Quantile(0.85)]
+    )
+    plotter.add_model(
+        "model2", [Quantile(0.1), Quantile(0.5), Quantile(0.9)], [Quantile(0.12), Quantile(0.35), Quantile(0.92)]
+    )
+
+    # Act
+    fig = plotter.plot()
+
+    # Assert
+    # Find the boxplot traces and verify calibration errors are calculated correctly
+    box_traces = [trace for trace in fig.data if trace.type == "box"]
+
+    # Find model1 trace
+    model1_trace = next(trace for trace in box_traces if trace.name == "model1")
+    model1_errors = list(model1_trace.y)
+    expected_model1_errors = [0.05, 0.2, -0.05]
+    assert np.allclose(model1_errors, expected_model1_errors), (
+        f"Expected errors {expected_model1_errors}, got {model1_errors}"
+    )
+
+    # Find model2 trace
+    model2_trace = next(trace for trace in box_traces if trace.name == "model2")
+    model2_errors = list(model2_trace.y)
+    expected_model2_errors = [0.02, -0.15, 0.02]
+    assert np.allclose(model2_errors, expected_model2_errors), (
+        f"Expected errors {expected_model2_errors}, got {model2_errors}"
+    )
+
+
+def test_plot_formats_quantile_labels_correctly():
+    """Test that quantile levels are formatted as P## labels (e.g., P10, P50, P90)"""
+    # Arrange
+    plotter = QuantileCalibrationBoxPlotter()
+    plotter.add_model(
+        "model1",
+        [Quantile(0.1), Quantile(0.25), Quantile(0.5), Quantile(0.75), Quantile(0.9)],
+        [Quantile(0.11), Quantile(0.24), Quantile(0.51), Quantile(0.76), Quantile(0.94)],
+    )
+
+    # Act
+    fig = plotter.plot()
+
+    # Assert
+    # Get x-axis tick labels to verify quantile formatting
+    box_traces = [trace for trace in fig.data if trace.type == "box"]
+    x_values = []
+    for trace in box_traces:
+        x_values.extend(trace.x)
+
+    unique_x_values = set(x_values)
+    expected_labels = {"P10", "P25", "P50", "P75", "P90"}
+    assert unique_x_values == expected_labels
+
+
+def test_plot_with_multiple_targets_creates_distributions():
+    """Test that multiple targets per model create proper boxplot distributions"""
+    # Arrange
+    plotter = QuantileCalibrationBoxPlotter()
+    quantiles = [Quantile(0.1), Quantile(0.5), Quantile(0.9)]
+
+    # Add multiple data points for same model (simulating different targets)
+    plotter.add_model("ModelA", quantiles, [Quantile(0.08), Quantile(0.52), Quantile(0.88)])  # Target 1
+    plotter.add_model("ModelA", quantiles, [Quantile(0.12), Quantile(0.48), Quantile(0.92)])  # Target 2
+    plotter.add_model("ModelA", quantiles, [Quantile(0.09), Quantile(0.51), Quantile(0.89)])  # Target 3
+
+    plotter.add_model("ModelB", quantiles, [Quantile(0.15), Quantile(0.55), Quantile(0.85)])  # Target 1
+    plotter.add_model("ModelB", quantiles, [Quantile(0.18), Quantile(0.45), Quantile(0.82)])  # Target 2
+
+    # Act
+    fig = plotter.plot()
+
+    # Assert
+    box_traces = [trace for trace in fig.data if trace.type == "box"]
+
+    # Should have 2 box traces (one per model)
+    assert len(box_traces) == 2
+
+    # Verify we have the right models
+    model_a_traces = [trace for trace in box_traces if trace.name == "ModelA"]
+    model_b_traces = [trace for trace in box_traces if trace.name == "ModelB"]
+
+    assert len(model_a_traces) == 1  # One trace per model
+    assert len(model_b_traces) == 1  # One trace per model
+
+    # Each ModelA trace should have 9 data points (3 targets * 3 quantiles), ModelB should have 6
+    model_a_trace = model_a_traces[0]
+    model_b_trace = model_b_traces[0]
+    assert len(model_a_trace.y) == 9, (
+        f"ModelA should have 9 data points (3 targets * 3 quantiles), got {len(model_a_trace.y)}"
+    )
+    assert len(model_b_trace.y) == 6, (
+        f"ModelB should have 6 data points (2 targets * 3 quantiles), got {len(model_b_trace.y)}"
+    )

--- a/packages/openstef-beam/tests/unit/analysis/plots/test_quantile_calibration_box_plotter.py
+++ b/packages/openstef-beam/tests/unit/analysis/plots/test_quantile_calibration_box_plotter.py
@@ -68,7 +68,7 @@ def test_plot_formats_quantile_labels_correctly():
         x_values.extend(trace.x)
 
     unique_x_values = set(x_values)
-    expected_labels = {"P10", "P25", "P50", "P75", "P90"}
+    expected_labels = {"quantile_P10", "quantile_P25", "quantile_P50", "quantile_P75", "quantile_P90"}
     assert unique_x_values == expected_labels
 
 

--- a/packages/openstef-beam/tests/unit/analysis/visualizations/test_quantile_calibration_box_visualization.py
+++ b/packages/openstef-beam/tests/unit/analysis/visualizations/test_quantile_calibration_box_visualization.py
@@ -2,29 +2,281 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-"""Tests for QuantileCalibrationBoxVisualization - focuses on boxplot-specific visualization logic only.
-Rest of functionality is tested in test_quantile_probability_visualization.py"""
+"""Tests for QuantileCalibrationBoxVisualization."""
 
-from openstef_beam.analysis.models import AnalysisAggregation
+from unittest.mock import call, patch
+
+import pytest
+
+from openstef_beam.analysis.models.target_metadata import TargetMetadata
+from openstef_beam.analysis.plots import QuantileCalibrationBoxPlotter
 from openstef_beam.analysis.visualizations import QuantileCalibrationBoxVisualization
-from openstef_beam.analysis.visualizations.quantile_probability_visualization import QuantileProbabilityVisualization
+from openstef_beam.analysis.visualizations.base import Quantile
+from openstef_beam.analysis.visualizations.quantile_calibration_box_visualization import ProbabilityData
+from openstef_beam.evaluation.models.report import EvaluationSubsetReport
+from tests.utils.mocks import MockFigure
 
 
-def test_boxplot_visualization_distinct_from_line_visualization():
-    """Test that boxplot visualization has different supported aggregations than parent."""
-    # Arrange & Act
+@pytest.mark.parametrize(
+    ("prob_data", "expected_error"),
+    [
+        pytest.param(
+            ProbabilityData(observed_probs=[], forecasted_probs=[]),
+            "No probability data found.",
+            id="empty_data",
+        ),
+        pytest.param(
+            ProbabilityData(
+                observed_probs=[Quantile(0.1), Quantile(0.2)],
+                forecasted_probs=[Quantile(0.1)],
+            ),
+            "Observed and forecasted probability counts must match.",
+            id="mismatched_lengths",
+        ),
+    ],
+)
+def test_validate_probability_data_raises_error_for_invalid_data(prob_data: ProbabilityData, expected_error: str):
+    """Test probability data validation for various invalid inputs."""
+    # Arrange
     viz = QuantileCalibrationBoxVisualization(name="test_viz")
 
+    # Act & Assert
+    with pytest.raises(ValueError, match=expected_error):
+        viz._validate_probability_data(prob_data)
+
+
+def test_validate_probability_data_passes_for_valid_data():
+    """Test that valid probability data passes validation."""
+    # Arrange
+    viz = QuantileCalibrationBoxVisualization(name="test_viz")
+    valid_data = ProbabilityData(
+        observed_probs=[Quantile(0.1), Quantile(0.2)],
+        forecasted_probs=[Quantile(0.1), Quantile(0.5)],
+    )
+
+    # Act & Assert - should not raise
+    viz._validate_probability_data(valid_data)
+
+
+def test_extract_probabilities_from_report_returns_probability_data(
+    sample_evaluation_report_with_probabilities: EvaluationSubsetReport,
+):
+    """Test extraction of probability data from evaluation report."""
+    # Arrange
+    viz = QuantileCalibrationBoxVisualization(name="test_viz")
+
+    # Act
+    prob_data = viz._extract_probabilities_from_report(sample_evaluation_report_with_probabilities)
+
     # Assert
-    # Should be its own class
-    assert viz.__class__.__name__ == "QuantileCalibrationBoxVisualization"
+    # Verify extracted data structure and values
+    assert len(prob_data.observed_probs) == 2
+    assert len(prob_data.forecasted_probs) == 2
+    assert prob_data.observed_probs == [Quantile(0.15), Quantile(0.55)]
+    assert prob_data.forecasted_probs == [Quantile(0.1), Quantile(0.5)]
 
-    # Should inherit from QuantileProbabilityVisualization but have different behavior
-    assert isinstance(viz, QuantileProbabilityVisualization)
 
-    # Should have different supported aggregations than parent (excludes TARGET)
-    parent_viz = QuantileProbabilityVisualization(name="parent_test")
-    assert viz.supported_aggregations != parent_viz.supported_aggregations
-    # Parent should support TARGET, boxplot should not
-    assert AnalysisAggregation.TARGET in parent_viz.supported_aggregations
-    assert AnalysisAggregation.TARGET not in viz.supported_aggregations
+def test_extract_probabilities_raises_error_when_no_global_metrics(empty_evaluation_report: EvaluationSubsetReport):
+    """Test error handling when no global metrics are available."""
+    # Arrange
+    viz = QuantileCalibrationBoxVisualization(name="test_viz")
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="No global metrics found in the report"):
+        viz._extract_probabilities_from_report(empty_evaluation_report)
+
+
+def test_create_by_target_handles_multiple_targets(
+    sample_evaluation_report_with_probabilities: EvaluationSubsetReport,
+    multiple_target_metadata: list[TargetMetadata],
+    mock_plotly_figure: MockFigure,
+):
+    """Test create_by_target compares multiple targets using target names as model identifiers."""
+    # Arrange
+    viz = QuantileCalibrationBoxVisualization(name="test_viz")
+    reports = [
+        (multiple_target_metadata[0], sample_evaluation_report_with_probabilities),
+        (multiple_target_metadata[1], sample_evaluation_report_with_probabilities),
+    ]
+
+    # Act
+    with (
+        patch.object(QuantileCalibrationBoxPlotter, "plot", return_value=mock_plotly_figure) as mock_plot,
+        patch.object(QuantileCalibrationBoxPlotter, "add_model") as mock_add_model,
+    ):
+        result = viz.create_by_target(reports)
+
+    # Assert
+    # Verify each target is added
+    mock_add_model.assert_has_calls([
+        call(
+            model_name="Run1",
+            observed_probs=[Quantile(0.15), Quantile(0.55)],
+            forecasted_probs=[Quantile(0.1), Quantile(0.5)],
+        ),
+        call(
+            model_name="Run1",
+            observed_probs=[Quantile(0.15), Quantile(0.55)],
+            forecasted_probs=[Quantile(0.1), Quantile(0.5)],
+        ),
+    ])
+    mock_plot.assert_called_once_with(title="Quantile Calibration over all targets in group for Run1")
+    assert result.name == viz.name
+    assert result.figure == mock_plotly_figure
+
+
+def test_create_by_target_raises_error_when_no_reports():
+    """Test error handling for empty reports in target aggregation."""
+    # Arrange
+    viz = QuantileCalibrationBoxVisualization(name="test_viz")
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="No reports provided for target-based visualization"):
+        viz.create_by_target([])
+
+
+def test_create_by_run_and_target_handles_multiple_runs_and_targets(
+    sample_evaluation_report_with_probabilities: EvaluationSubsetReport,
+    multiple_target_metadata: list[TargetMetadata],
+    mock_plotly_figure: MockFigure,
+):
+    """Test create_by_run_and_target handles multiple runs with multiple targets each."""
+    # Arrange
+    viz = QuantileCalibrationBoxVisualization(name="test_viz")
+    reports = {
+        "Run1": [
+            (multiple_target_metadata[0], sample_evaluation_report_with_probabilities),
+            (multiple_target_metadata[1], sample_evaluation_report_with_probabilities),
+        ],
+        "Run2": [
+            (multiple_target_metadata[2], sample_evaluation_report_with_probabilities),
+            (multiple_target_metadata[2], sample_evaluation_report_with_probabilities),
+        ],
+    }
+
+    # Act
+    with (
+        patch.object(QuantileCalibrationBoxPlotter, "plot", return_value=mock_plotly_figure) as mock_plot,
+        patch.object(QuantileCalibrationBoxPlotter, "add_model") as mock_add_model,
+    ):
+        result = viz.create_by_run_and_target(reports)
+
+    # Assert
+    # Verify each target within each run is added as a separate model entry
+    mock_add_model.assert_has_calls([
+        # Run1 targets
+        call(
+            model_name="Run1",
+            observed_probs=[Quantile(0.15), Quantile(0.55)],
+            forecasted_probs=[Quantile(0.1), Quantile(0.5)],
+        ),
+        call(
+            model_name="Run1",
+            observed_probs=[Quantile(0.15), Quantile(0.55)],
+            forecasted_probs=[Quantile(0.1), Quantile(0.5)],
+        ),
+        # Run2 targets
+        call(
+            model_name="Run2",
+            observed_probs=[Quantile(0.15), Quantile(0.55)],
+            forecasted_probs=[Quantile(0.1), Quantile(0.5)],
+        ),
+        call(
+            model_name="Run2",
+            observed_probs=[Quantile(0.15), Quantile(0.55)],
+            forecasted_probs=[Quantile(0.1), Quantile(0.5)],
+        ),
+    ])
+    mock_plot.assert_called_once_with(title="Quantile Calibration by run and over all targets in group")
+    assert result.name == viz.name
+    assert result.figure == mock_plotly_figure
+
+
+def test_create_by_group_handles_multiple_groups(
+    sample_evaluation_report_with_probabilities: EvaluationSubsetReport,
+    multiple_target_metadata: list[TargetMetadata],
+    mock_plotly_figure: MockFigure,
+):
+    """Test create_by_group compares multiple groups using run name as model identifier."""
+    # Arrange
+    viz = QuantileCalibrationBoxVisualization(name="test_viz")
+    reports = {
+        "GroupA": [
+            (multiple_target_metadata[0], sample_evaluation_report_with_probabilities),
+        ],
+        "GroupB": [
+            (multiple_target_metadata[1], sample_evaluation_report_with_probabilities),
+        ],
+    }
+
+    # Act
+    with (
+        patch.object(QuantileCalibrationBoxPlotter, "plot", return_value=mock_plotly_figure) as mock_plot,
+        patch.object(QuantileCalibrationBoxPlotter, "add_model") as mock_add_model,
+    ):
+        result = viz.create_by_group(reports)
+
+    # Assert
+    mock_add_model.assert_has_calls([
+        call(
+            model_name="Run1",
+            observed_probs=[Quantile(0.15), Quantile(0.55)],
+            forecasted_probs=[Quantile(0.1), Quantile(0.5)],
+        ),
+        call(
+            model_name="Run1",
+            observed_probs=[Quantile(0.15), Quantile(0.55)],
+            forecasted_probs=[Quantile(0.1), Quantile(0.5)],
+        ),
+    ])
+    mock_plot.assert_called_once_with(title="Quantile Calibration over all targets for Run1")
+    assert result.name == viz.name
+    assert result.figure == mock_plotly_figure
+
+
+def test_create_by_run_and_group_handles_multiple_runs_and_groups(
+    sample_evaluation_report_with_probabilities: EvaluationSubsetReport,
+    multiple_target_metadata: list[TargetMetadata],
+    mock_plotly_figure: MockFigure,
+):
+    """Test create_by_run_and_group aggregates by both run and group using tuple keys."""
+    # Arrange
+    viz = QuantileCalibrationBoxVisualization(name="test_viz")
+    reports = {
+        ("Run1", "GroupA"): [
+            (multiple_target_metadata[0], sample_evaluation_report_with_probabilities),
+            (multiple_target_metadata[1], sample_evaluation_report_with_probabilities),
+        ],
+        ("Run2", "GroupB"): [
+            (multiple_target_metadata[2], sample_evaluation_report_with_probabilities),
+        ],
+    }
+
+    # Act
+    with (
+        patch.object(QuantileCalibrationBoxPlotter, "plot", return_value=mock_plotly_figure) as mock_plot,
+        patch.object(QuantileCalibrationBoxPlotter, "add_model") as mock_add_model,
+    ):
+        result = viz.create_by_run_and_group(reports)
+
+    # Assert
+    mock_add_model.assert_has_calls([
+        call(
+            model_name="Run1",
+            observed_probs=[Quantile(0.15), Quantile(0.55)],
+            forecasted_probs=[Quantile(0.1), Quantile(0.5)],
+        ),
+        call(
+            model_name="Run1",
+            observed_probs=[Quantile(0.15), Quantile(0.55)],
+            forecasted_probs=[Quantile(0.1), Quantile(0.5)],
+        ),
+        call(
+            model_name="Run2",
+            observed_probs=[Quantile(0.15), Quantile(0.55)],
+            forecasted_probs=[Quantile(0.1), Quantile(0.5)],
+        ),
+    ])
+    mock_plot.assert_called_once_with(title="Quantile Calibration by run and over all targets")
+    assert result.name == viz.name
+    assert result.figure == mock_plotly_figure

--- a/packages/openstef-beam/tests/unit/analysis/visualizations/test_quantile_calibration_box_visualization.py
+++ b/packages/openstef-beam/tests/unit/analysis/visualizations/test_quantile_calibration_box_visualization.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the OpenSTEF project <short.term.energy.forecasts@alliander.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Tests for QuantileCalibrationBoxVisualization - focuses on boxplot-specific visualization logic only.
+Rest of functionality is tested in test_quantile_probability_visualization.py"""
+
+from openstef_beam.analysis.models import AnalysisAggregation
+from openstef_beam.analysis.visualizations import QuantileCalibrationBoxVisualization
+from openstef_beam.analysis.visualizations.quantile_probability_visualization import QuantileProbabilityVisualization
+
+
+def test_boxplot_visualization_distinct_from_line_visualization():
+    """Test that boxplot visualization has different supported aggregations than parent."""
+    # Arrange & Act
+    viz = QuantileCalibrationBoxVisualization(name="test_viz")
+
+    # Assert
+    # Should be its own class
+    assert viz.__class__.__name__ == "QuantileCalibrationBoxVisualization"
+
+    # Should inherit from QuantileProbabilityVisualization but have different behavior
+    assert isinstance(viz, QuantileProbabilityVisualization)
+
+    # Should have different supported aggregations than parent (excludes TARGET)
+    parent_viz = QuantileProbabilityVisualization(name="parent_test")
+    assert viz.supported_aggregations != parent_viz.supported_aggregations
+    # Parent should support TARGET, boxplot should not
+    assert AnalysisAggregation.TARGET in parent_viz.supported_aggregations
+    assert AnalysisAggregation.TARGET not in viz.supported_aggregations


### PR DESCRIPTION
Added scripts to plot quantile calibration across multiple targets. I chose to plot the calibration error (observed - forecasted), enabling to plot multiple boxplots next to each other for each quantile while avoiding interpretation issues. This is an example result of this visualization:

<img width="1315" height="684" alt="image" src="https://github.com/user-attachments/assets/47146ddc-e431-473e-be49-083de7ce056d" />
