### PR TITLE
feature(#688): add FlatlinerForecaster

### DIFF
--- a/packages/openstef-models/src/openstef_models/models/forecasting/flatliner_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/flatliner_forecaster.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the OpenSTEF project <short.term.energy.forecasts@alliander.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Simple constant zero forecasting model.
+
+Provides basic forecasting model that predict constant flatliner zero values. It can be used
+when a flatline (non-)zero measurement is observed in the past and expected in the future.
+"""
+
+from typing import Self, override
+
+import pandas as pd
+
+from openstef_core.datasets.validated_datasets import ForecastDataset, ForecastInputDataset
+from openstef_core.exceptions import ModelLoadingError
+from openstef_core.types import LeadTime
+from openstef_models.models.forecasting import Forecaster, ForecasterConfig
+
+
+class FlatlinerForecasterConfig(ForecasterConfig):
+    """Configuration for flatliner forecaster."""
+
+
+MODEL_CODE_VERSION = 1
+
+
+class FlatlinerForecaster(Forecaster):
+    """Flatliner forecaster that predicts a flatline of zeros.
+
+    A simple forecasting model that always predicts zero for all horizons and quantiles.
+
+    Invariants:
+        - Configuration quantiles determine the number of prediction outputs
+        - Zeros are predicted for all horizons and quantiles
+
+    Example:
+        >>> from openstef_core.types import LeadTime, Quantile
+        >>> from datetime import timedelta
+        >>> config = FlatlinerForecasterConfig(
+        ...     quantiles=[Quantile(0.5), Quantile(0.1), Quantile(0.9)],
+        ...     horizons=[LeadTime(timedelta(hours=1)), LeadTime(timedelta(hours=2))],
+        ... )
+        >>> forecaster = FlatlinerForecaster(config)
+        >>> forecaster.fit(training_data)  # doctest: +SKIP
+        >>> predictions = forecaster.predict(test_data)  # doctest: +SKIP
+
+    See Also:
+        FlatlinerCheckTransform: Transform to detect flatliner patterns in time series data.
+        Forecaster: Base class for forecasting models that predict multiple horizons.
+    """
+
+    _config: FlatlinerForecasterConfig
+
+    def __init__(
+        self,
+        config: FlatlinerForecasterConfig | None = None,
+    ) -> None:
+        """Initialize the flatliner forecaster.
+
+        Args:
+            config: Configuration specifying quantiles and horizons.
+        """
+        self._config = config or FlatlinerForecasterConfig()
+
+    @property
+    @override
+    def config(self) -> FlatlinerForecasterConfig:
+        return self._config
+
+    @property
+    @override
+    def is_fitted(self) -> bool:
+        return True
+
+    @override
+    def to_state(self) -> object:
+        return {
+            "version": MODEL_CODE_VERSION,
+            "config": self.config.model_dump(mode="json"),
+        }
+
+    @override
+    def from_state(self, state: object) -> Self:
+        if not isinstance(state, dict) or "version" not in state or state["version"] > MODEL_CODE_VERSION:
+            raise ModelLoadingError("Invalid state for FlatlinerForecaster")
+
+        return self.__class__(config=FlatlinerForecasterConfig.model_validate(state["config"]))
+
+    @override
+    def fit(
+        self,
+        data: dict[LeadTime, ForecastInputDataset],
+        data_val: dict[LeadTime, ForecastInputDataset] | None = None,
+    ) -> None:
+        pass
+
+    @override
+    def predict(self, data: dict[LeadTime, ForecastInputDataset]) -> ForecastDataset:
+        input_data_list = [horizon_data.input_data(start=horizon_data.forecast_start) for horizon_data in data.values()]
+        return ForecastDataset(
+            data=pd.concat([
+                pd.DataFrame(
+                    data={quantile.format(): 0.0 for quantile in self.config.quantiles},
+                    index=input_data.index,
+                )
+                for input_data in input_data_list
+            ]),
+            sample_interval=next(iter(data.values())).sample_interval,
+        )

--- a/packages/openstef-models/src/openstef_models/models/forecasting/forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/forecaster.py
@@ -135,7 +135,7 @@ class Forecaster(BatchPredictor[dict[LeadTime, ForecastInputDataset], ForecastDa
 
     Invariants:
         - Predictions must include all quantiles specified in the configuration
-        - predict_horizon_batch() only called when supports_batching returns True
+        - predict_batch() only called when supports_batching returns True
 
     Example:
         Implementation for a model that handles multiple horizons:
@@ -167,7 +167,7 @@ class Forecaster(BatchPredictor[dict[LeadTime, ForecastInputDataset], ForecastDa
         ...         return instance
         ...
         ...     @override
-        ...     def fit(self, input_data):
+        ...     def fit(self, input_data, data_val):
         ...         # Train on data for all horizons
         ...         self._fitted = True
         ...

--- a/packages/openstef-models/tests/unit/models/forecasting/test_flatliner_forecaster.py
+++ b/packages/openstef-models/tests/unit/models/forecasting/test_flatliner_forecaster.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the OpenSTEF project <short.term.energy.forecasts@alliander.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+from datetime import timedelta
+
+import pandas as pd
+import pytest
+
+from openstef_core.datasets.validated_datasets import ForecastInputDataset
+from openstef_core.types import LeadTime, Quantile
+from openstef_models.models.forecasting.flatliner_forecaster import FlatlinerForecaster, FlatlinerForecasterConfig
+
+
+@pytest.fixture
+def config() -> FlatlinerForecasterConfig:
+    return FlatlinerForecasterConfig(
+        quantiles=[Quantile(0.5), Quantile(0.9)], horizons=[LeadTime(timedelta(hours=1)), LeadTime(timedelta(hours=2))]
+    )
+
+
+@pytest.fixture
+def sample_multi_horizon_dataset(
+    sample_forecast_input_dataset: ForecastInputDataset,
+) -> dict[LeadTime, ForecastInputDataset]:
+    return {
+        LeadTime(timedelta(hours=1)): sample_forecast_input_dataset,
+        LeadTime(timedelta(hours=2)): sample_forecast_input_dataset,
+    }
+
+
+def test_predict_returns_zeros(
+    config: FlatlinerForecasterConfig, sample_multi_horizon_dataset: dict[LeadTime, ForecastInputDataset]
+):
+    forecaster = FlatlinerForecaster(config)
+    result = forecaster.predict(sample_multi_horizon_dataset)
+    assert isinstance(result.data, pd.DataFrame)
+    assert (result.data == 0.0).all().all()
+    assert set(result.data.columns) == {q.format() for q in config.quantiles}
+
+
+def test_is_fitted_always_true(config: FlatlinerForecasterConfig):
+    forecaster = FlatlinerForecaster(config)
+    assert forecaster.is_fitted
+
+
+def test_to_state_and_from_state(config: FlatlinerForecasterConfig):
+    forecaster = FlatlinerForecaster(config)
+    state = forecaster.to_state()
+    new_forecaster = forecaster.from_state(state)
+    assert isinstance(new_forecaster, FlatlinerForecaster)
+    assert isinstance(new_forecaster.config, FlatlinerForecasterConfig)


### PR DESCRIPTION
This pull request introduces a new simple forecasting model called `FlatlinerForecaster` to the codebase, along with corresponding configuration and unit tests. The model predicts a constant flatline of zeros for all specified horizons and quantiles, and is designed for use cases where a flatline (zero or non-zero) measurement is observed and expected to persist. Additionally, some minor documentation improvements and test coverage are included.

**New forecasting model and configuration:**

* Added `FlatlinerForecaster` and `FlatlinerForecasterConfig` classes in `flatliner_forecaster.py`, providing a forecaster that always predicts zeros for all horizons and quantiles, including methods for fitting, predicting, state serialization, and deserialization.

**Testing and validation:**

* Introduced comprehensive unit tests for the new `FlatlinerForecaster` in `test_flatliner_forecaster.py`, verifying prediction output, model state handling, and configuration.

**Documentation and minor improvements:**

* Updated docstrings in `forecaster.py` to clarify method naming (`predict_batch` instead of `predict_horizon_batch`) and parameter usage in the base `Forecaster` example. [[1]](diffhunk://#diff-723127cd060e41fa77e5d5790fb46c3b4bc1527ac510af2cfd14afc89e7c8446L138-R138) [[2]](diffhunk://#diff-723127cd060e41fa77e5d5790fb46c3b4bc1527ac510af2cfd14afc89e7c8446L170-R170)