### PR TITLE
feat(#679): added dimensionality reduction transform

### DIFF
--- a/packages/openstef-models/src/openstef_models/transforms/general/__init__.py
+++ b/packages/openstef-models/src/openstef_models/transforms/general/__init__.py
@@ -9,6 +9,7 @@ across various domains.
 """
 
 from openstef_models.transforms.general.clipping_transform import ClippingTransform
+from openstef_models.transforms.general.dimensionality_reduction import DimensionalityReduction
 from openstef_models.transforms.general.imputation_transform import ImputationTransform
 from openstef_models.transforms.general.remove_empty_columns_transform import (
     RemoveEmptyColumnsTransform,
@@ -17,6 +18,7 @@ from openstef_models.transforms.general.scaler_transform import ScalerTransform
 
 __all__ = [
     "ClippingTransform",
+    "DimensionalityReduction",
     "ImputationTransform",
     "RemoveEmptyColumnsTransform",
     "ScalerTransform",

--- a/packages/openstef-models/src/openstef_models/transforms/general/dimensionality_reduction.py
+++ b/packages/openstef-models/src/openstef_models/transforms/general/dimensionality_reduction.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the OpenSTEF project <short.term.energy.forecasts@alliander.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Transform for dimensionality reduction in time series data.
+
+This module provides dimensionality reduction functionality. With a choice of various methods
+from scikit-learn to reduce the number of features in time series datasets.
+"""
+
+from typing import TYPE_CHECKING, Any, Literal, Self, cast, override
+
+import pandas as pd
+from pydantic import Field, PrivateAttr
+from sklearn.decomposition import PCA, FactorAnalysis, FastICA, KernelPCA
+
+from openstef_core.base_model import BaseConfig
+from openstef_core.datasets.timeseries_dataset import TimeSeriesDataset
+from openstef_core.exceptions import NotFittedError
+from openstef_core.mixins import State
+from openstef_core.transforms import TimeSeriesTransform
+
+if TYPE_CHECKING:
+    import numpy as np
+
+
+class DimensionalityReduction(BaseConfig, TimeSeriesTransform):
+    """Reduce the dimensionality of a given set of features.
+
+    Available methods include:
+        - PCA: linear dimensionality reduction into orthogonal components.
+        - Factor analysis: linear dimensionality reduction models observed variables as latent factors + Gaussian noise.
+        - FastICA: linear dimensionality reduction that maximizes statistical independence among components.
+        - KernelPCA: non-linear dimensionality reduction using rbf kernel.
+
+    Example:
+        >>> import pandas as pd
+        >>> from datetime import timedelta
+        >>> from openstef_core.datasets import TimeSeriesDataset
+        >>> from openstef_models.transforms.general import DimensionalityReduction
+        >>> # Create sample dataset
+        >>> data = pd.DataFrame({
+        ...     'load': [100, 120, 110, 130, 125],
+        ...     'feature1': [1.0, 2.0, 1.5, 2.5, 2.0],
+        ...     'feature2': [1.0, 2.0, 1.5, 2.5, 2.0],
+        ...     'feature3': [5.0, 11.0, 8.0, 2.0, 11.0]
+        ... }, index=pd.date_range('2025-01-01', periods=5, freq='1h'))
+        >>> dataset = TimeSeriesDataset(data, timedelta(hours=1))
+        >>> # Initialize and apply transform
+        >>> dim_reducer = DimensionalityReduction(
+        ...     columns={'feature1', 'feature2', 'feature3'},
+        ...     method="pca",
+        ...     n_components=2,
+        ...     random_state=1234
+        ... )
+        >>> dim_reducer.fit(dataset)
+        >>> transformed_dataset = dim_reducer.transform(dataset)
+        >>> transformed_dataset.data.head().round(3)
+                             component_1  component_2  load
+        2025-01-01 00:00:00       -2.383       -1.166   100
+        2025-01-01 01:00:00        3.596        0.335   120
+        2025-01-01 02:00:00        0.606       -0.416   110
+        2025-01-01 03:00:00       -5.414        0.912   130
+        2025-01-01 04:00:00        3.596        0.335   125
+
+    """
+
+    columns: list[str] | None = Field(
+        default=None,
+        description="List of column names to apply dim reduction to. If None, applies to all columns.",
+    )
+    method: Literal["pca", "factor_analysis", "fastica", "kernel_pca"] = Field(
+        default="pca", description="Dimensionality reduction method to use."
+    )
+    n_components: int = Field(default=2, description="Desired nr of components after reduction.")
+    random_state: int | None = Field(default=42, description="Random state for reproducibility.")
+
+    _dimensionality_reducer: PCA | FactorAnalysis | FastICA | KernelPCA = PrivateAttr()
+    _is_fitted: bool = PrivateAttr(default=False)
+
+    # Method-specific parameters
+    max_iter: int = Field(default=1000, description="Maximum number of iterations for Factor Analysis and FastICA.")
+
+    @property
+    @override
+    def is_fitted(self) -> bool:
+        return self._is_fitted
+
+    @override
+    def fit(self, data: TimeSeriesDataset) -> None:
+        columns = self.columns or data.data.columns
+        self._dimensionality_reducer.fit(data.data[columns])  # type: ignore[reportUnknownMemberType]
+        self._is_fitted = True
+
+    @override
+    def transform(self, data: TimeSeriesDataset) -> TimeSeriesDataset:
+        columns = self.columns or data.data.columns
+        if not self._is_fitted:
+            raise NotFittedError(self.__class__.__name__)
+        transformed_data: np.ndarray = self._dimensionality_reducer.transform(data.data[columns])  # type: ignore[reportUnknownMemberType]
+        transformed_data_pd = pd.DataFrame(
+            transformed_data,
+            index=data.data.index,
+            columns=[f"component_{i + 1}" for i in range(self.n_components)],
+        )
+        untransformed_columns = [feature_name for feature_name in data.feature_names if feature_name not in columns]
+
+        transformed_data_pd = pd.concat(
+            [transformed_data_pd, data.data[untransformed_columns]],
+            axis=1,
+        )
+
+        return TimeSeriesDataset(data=transformed_data_pd, sample_interval=data.sample_interval)
+
+    @override
+    def model_post_init(self, context: Any) -> None:
+        if self.method == "pca":
+            self._dimensionality_reducer = PCA(n_components=self.n_components, random_state=self.random_state)
+        elif self.method == "factor_analysis":
+            self._dimensionality_reducer = FactorAnalysis(
+                n_components=self.n_components, max_iter=self.max_iter, random_state=self.random_state
+            )
+        elif self.method == "fastica":
+            self._dimensionality_reducer = FastICA(
+                n_components=self.n_components, max_iter=self.max_iter, random_state=self.random_state
+            )
+        elif self.method == "kernel_pca":
+            self._dimensionality_reducer = KernelPCA(
+                n_components=self.n_components, kernel="rbf", random_state=self.random_state
+            )  # rbf for non-linear
+
+    @override
+    def to_state(self) -> State:
+        return cast(
+            State,
+            {
+                "config": self.model_dump(mode="json"),
+                "dimensionality_reducer": self._dimensionality_reducer,
+                "is_fitted": self._is_fitted,
+            },
+        )
+
+    @override
+    def from_state(self, state: State) -> Self:
+        state = cast(dict[str, Any], state)
+        instance = self.model_validate(state["config"])
+        instance._dimensionality_reducer = state["dimensionality_reducer"]  # noqa: SLF001
+        instance._is_fitted = state["is_fitted"]  # noqa: SLF001
+        return instance

--- a/packages/openstef-models/tests/unit/transforms/general/test_dimensionality_reduction.py
+++ b/packages/openstef-models/tests/unit/transforms/general/test_dimensionality_reduction.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the OpenSTEF project <short.term.energy.forecasts@alliander.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+from datetime import datetime, timedelta
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from openstef_core.datasets import TimeSeriesDataset
+from openstef_models.transforms.general.dimensionality_reduction import DimensionalityReduction
+
+
+@pytest.fixture
+def sample_forecast_input_dataset() -> TimeSeriesDataset:
+    """Create sample input dataset for forecaster training and prediction."""
+    rng = np.random.default_rng(42)
+    num_samples = 14
+    start_date = datetime.fromisoformat("2025-01-01T00:00:00")
+
+    feature_1 = rng.normal(loc=0, scale=1, size=num_samples)
+    feature_2 = rng.normal(loc=0, scale=1, size=num_samples)
+    feature_3 = rng.uniform(low=-1, high=1, size=num_samples)
+
+    return TimeSeriesDataset(
+        data=pd.DataFrame(
+            {
+                "load": (feature_1 + feature_2 + feature_3) / 3,
+                "feature1": feature_1,
+                "feature2": feature_2,
+                "feature3": feature_3,
+            },
+            index=pd.date_range(start=start_date, periods=num_samples, freq="1d"),
+        ),
+        sample_interval=timedelta(days=1),
+    )
+
+
+@pytest.mark.parametrize(
+    ("method", "expected_components"),
+    [
+        ("pca", 2),
+        ("factor_analysis", 2),
+        ("fastica", 2),
+        ("kernel_pca", 2),
+    ],
+)
+def test_dimensionality_reduction(
+    sample_forecast_input_dataset: TimeSeriesDataset,
+    method: Literal["pca", "factor_analysis", "fastica"],
+    expected_components: int,
+) -> None:
+    """Test dimensionality reduction with different methods."""
+    # Arrange
+    transform = DimensionalityReduction(
+        columns=["feature1", "feature2", "feature3"], method=method, n_components=expected_components
+    )
+    assert not transform.is_fitted
+
+    # Act
+    transform.fit(sample_forecast_input_dataset)
+    output = transform.transform(sample_forecast_input_dataset)
+
+    # Assert
+    expected_feature_count = expected_components + 1  # +1 for the 'load' column
+    assert len(output.feature_names) == expected_feature_count
+    assert transform.is_fitted
+    assert len(output.data) == len(sample_forecast_input_dataset.data)
+    assert "load" in output.feature_names
+
+    # Check that the component columns are created with expected names
+    component_columns = [col for col in output.feature_names if col.startswith("component_")]
+    assert len(component_columns) == expected_components
+
+
+@pytest.mark.parametrize(
+    ("method", "method_params"),
+    [
+        ("pca", {}),
+        ("factor_analysis", {"max_iter": 500}),
+        ("fastica", {"max_iter": 1500}),
+        ("kernel_pca", {"kernel": "poly", "gamma": 0.1}),
+    ],
+)
+def test_dimensionality_reduction_with_custom_parameters(
+    sample_forecast_input_dataset: TimeSeriesDataset,
+    method: Literal["pca", "factor_analysis", "fastica", "kernel_pca"],
+    method_params: dict[str, int],
+) -> None:
+    """Test dimensionality reduction with method-specific parameters."""
+    # Arrange
+    transform = DimensionalityReduction(
+        columns=["feature1", "feature2", "feature3"], method=method, n_components=2, **method_params
+    )
+
+    # Act
+    transform.fit(sample_forecast_input_dataset)
+    output = transform.transform(sample_forecast_input_dataset)
+
+    # Assert
+    assert transform.is_fitted
+    assert len(output.feature_names) == 3  # 2 components + 1 outcome variable
+    assert "load" in output.feature_names
+
+    # Verify method-specific parameters are set correctly
+    if method in {"factor_analysis", "fastica"}:
+        assert transform.max_iter == method_params.get("max_iter", 1000)
+
+
+def test_dimensionality_reduction__state_roundtrip(sample_forecast_input_dataset: TimeSeriesDataset) -> None:
+    """Test dimensionality reduction state round trip."""
+    # Arrange
+    original_transform = DimensionalityReduction(
+        columns=["feature1", "feature2", "feature3"], method="pca", n_components=2
+    )
+
+    original_transform.fit(sample_forecast_input_dataset)
+
+    state = original_transform.to_state()
+
+    restored_transform = DimensionalityReduction()
+    restored_transform = restored_transform.from_state(state)
+
+    original_result = original_transform.transform(sample_forecast_input_dataset)
+    restored_result = restored_transform.transform(sample_forecast_input_dataset)
+
+    # Assert
+    pd.testing.assert_frame_equal(original_result.data, restored_result.data)


### PR DESCRIPTION
This pull request introduces a new dimensionality reduction transform to the `openstef_models` package, allowing users to reduce the number of features in time series datasets using several popular scikit-learn methods. The implementation is accompanied by a comprehensive set of unit tests and integration into the package's public API.

**New Dimensionality Reduction Feature:**

* Added a new `DimensionalityReduction` class to `transforms.general`, supporting PCA, Factor Analysis, FastICA, and KernelPCA for reducing the dimensionality of time series features. The transform is configurable, supports state serialization, and is fully documented with usage examples.

**API and Public Interface Updates:**

* Registered `DimensionalityReduction` in the `__init__.py` of `transforms.general`, making it available for import as part of the package's public API. [[1]](diffhunk://#diff-ad8cd6918e1ba7200416fb155497644c30fbf46a1a1d773f83197594ec2cb18bR12) [[2]](diffhunk://#diff-ad8cd6918e1ba7200416fb155497644c30fbf46a1a1d773f83197594ec2cb18bR21)

**Testing and Validation:**

* Added a dedicated unit test file for `DimensionalityReduction`, covering multiple reduction methods, custom parameters, and state serialization/deserialization to ensure correct behavior and robustness.