### PR TITLE
feature: Added n_estimators to GBLinear to control how many iterations to run

### DIFF
--- a/packages/openstef-models/src/openstef_models/models/forecasting/gblinear_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/gblinear_forecaster.py
@@ -39,6 +39,11 @@ class GBLinearHyperParams(HyperParams):
     """Hyperparameter configuration for GBLinear forecaster."""
 
     # Learning Parameters
+    n_estimators: int = Field(
+        default=100,
+        description="Number of boosting rounds/trees to fit. Higher values may improve performance but "
+        "increase training time and risk overfitting.",
+    )
     updater: str = Field(
         default="shotgun",
         description="The updater to use for the GBLinear booster.",
@@ -166,14 +171,18 @@ class GBLinearForecaster(HorizonForecaster):
         self._config = config or GBLinearForecasterConfig()
         self._gblinear_model = xgb.XGBRegressor(
             booster="gblinear",
+            # Core parameters for forecasting
             objective="reg:quantileerror",
-            updater=self._config.hyperparams.updater,
-            reg_alpha=self._config.hyperparams.reg_alpha,
-            reg_lambda=self._config.hyperparams.reg_lambda,
-            feature_selector=self._config.hyperparams.feature_selector,
-            quantile_alpha=[float(q) for q in self._config.quantiles],
+            n_estimators=self._config.hyperparams.n_estimators,
             learning_rate=self._config.hyperparams.learning_rate,
             early_stopping_rounds=self._config.hyperparams.early_stopping_rounds,
+            # Regularization parameters
+            reg_alpha=self._config.hyperparams.reg_alpha,
+            reg_lambda=self._config.hyperparams.reg_lambda,
+            # Boosting structure control
+            feature_selector=self._config.hyperparams.feature_selector,
+            updater=self._config.hyperparams.updater,
+            quantile_alpha=[float(q) for q in self._config.quantiles],
             top_k=self._config.hyperparams.top_k,
         )
 


### PR DESCRIPTION
…
This pull request enhances the configuration and initialization of the GBLinear forecaster by introducing a new hyperparameter and improving the clarity and structure of model instantiation. The most important changes are:

**Hyperparameter configuration improvements:**

* Added a new `n_estimators` hyperparameter to the `GBLinearHyperParams` class, allowing users to control the number of boosting rounds/trees for the GBLinear model.

**Model initialization and clarity:**

* Updated the `XGBRegressor` initialization in the GBLinear forecaster to include the new `n_estimators` parameter and reorganized the parameter order for better readability and logical grouping (core parameters, regularization, boosting structure).