### PR TITLE
add windowed metrics averaged over locations

### DIFF
--- a/packages/openstef-beam/src/openstef_beam/analysis/visualizations/windowed_metric_visualization.py
+++ b/packages/openstef-beam/src/openstef_beam/analysis/visualizations/windowed_metric_visualization.py
@@ -9,10 +9,13 @@ how performance metrics evolve across different time windows.
 """
 
 import operator
+from collections import defaultdict
 from datetime import datetime
 from typing import Literal, override
 
-from openstef_beam.analysis.models import AnalysisAggregation, RunName, TargetMetadata, VisualizationOutput
+import numpy as np
+
+from openstef_beam.analysis.models import AnalysisAggregation, GroupName, RunName, TargetMetadata, VisualizationOutput
 from openstef_beam.analysis.plots import (
     WindowedMetricPlotter,
 )
@@ -68,6 +71,9 @@ class WindowedMetricVisualization(VisualizationProvider):
             AnalysisAggregation.NONE,
             AnalysisAggregation.RUN_AND_NONE,
             AnalysisAggregation.TARGET,
+            AnalysisAggregation.RUN_AND_TARGET,
+            AnalysisAggregation.GROUP,
+            AnalysisAggregation.RUN_AND_GROUP,
         }
 
     def _get_metric_info(self) -> tuple[str, Quantile | Literal["global"]]:
@@ -131,6 +137,38 @@ class WindowedMetricVisualization(VisualizationProvider):
         """
         metric_display = f"{metric_name} (q={quantile_or_global})" if quantile_or_global != "global" else metric_name
         return f"Windowed {metric_display} {self.window} over Time {suffix}"
+
+    def _average_time_series_across_targets(
+        self, reports: list[ReportTuple], metric_name: str, quantile_or_global: Quantile | Literal["global"]
+    ) -> list[tuple[datetime, float]]:
+        """Average windowed metric values across multiple targets at each timestamp.
+
+        Args:
+            reports: List of (metadata, report) tuples from different targets
+            metric_name: Name of the metric to extract
+            quantile_or_global: Either a Quantile object or "global"
+
+        Returns:
+            List of (timestamp, averaged_metric_value) tuples
+        """
+        # Collect all time-value pairs from all targets
+        timestamp_values: dict[datetime, list[float]] = defaultdict(list)
+
+        for _metadata, report in reports:
+            time_value_pairs = self._extract_windowed_metric_values(report, metric_name, quantile_or_global)
+
+            for timestamp, value in time_value_pairs:
+                timestamp_values[timestamp].append(value)
+
+        # Calculate average for each timestamp
+        averaged_pairs: list[tuple[datetime, float]] = []
+        for timestamp in sorted(timestamp_values.keys()):
+            values = timestamp_values[timestamp]
+            if values:  # Only include timestamps that have data
+                avg_value = float(np.nanmean(values))
+                averaged_pairs.append((timestamp, avg_value))
+
+        return averaged_pairs
 
     @override
     def create_by_none(
@@ -225,6 +263,132 @@ class WindowedMetricVisualization(VisualizationProvider):
 
         title = self._create_plot_title(metric_name, quantile_or_global, title_suffix)
         figure = plotter.plot(title=title)
+
+        return VisualizationOutput(name=self.name, figure=figure)
+
+    # averaging over all targets in a single group
+    @override
+    def create_by_run_and_target(
+        self,
+        reports: dict[RunName, list[ReportTuple]],
+    ) -> VisualizationOutput:
+        metric_name, quantile_or_global = self._get_metric_info()
+        plotter = WindowedMetricPlotter()
+
+        # Process each run and calculate averaged metrics across its targets
+        for run_name, target_reports in reports.items():
+            if not target_reports:
+                continue
+
+            # Average windowed metrics across all targets for this run
+            averaged_pairs = self._average_time_series_across_targets(
+                reports=target_reports,
+                metric_name=metric_name,
+                quantile_or_global=quantile_or_global,
+            )
+
+            # Skip if no averaged data points found for this run
+            if not averaged_pairs:
+                continue
+
+            # Unpack the averaged pairs
+            timestamps = [pair[0] for pair in averaged_pairs]
+            metric_values = [pair[1] for pair in averaged_pairs]
+
+            # Add this run to the plotter with averaged values
+            plotter.add_model(
+                model_name=run_name,
+                timestamps=timestamps,
+                metric_values=metric_values,
+            )
+
+        title = self._create_plot_title(metric_name, quantile_or_global, "by run (averaged over targets in group)")
+        figure = plotter.plot(title=title, metric_name=metric_name)
+
+        return VisualizationOutput(name=self.name, figure=figure)
+
+    # averaging over all targets (also when in different groups)
+    @override
+    def create_by_run_and_group(
+        self,
+        reports: dict[tuple[RunName, GroupName], list[ReportTuple]],
+    ) -> VisualizationOutput:
+        metric_name, quantile_or_global = self._get_metric_info()
+        plotter = WindowedMetricPlotter()
+
+        # Collect all targets for each run
+        run_to_targets: dict[str, list[ReportTuple]] = {}
+        for (run_name, _group_name), target_reports in reports.items():
+            run_to_targets.setdefault(run_name, []).extend(target_reports)
+
+        # Average metrics over all targets for each run
+        for run_name, all_target_reports in run_to_targets.items():
+            if not all_target_reports:
+                continue
+
+            # Average windowed metrics across all targets for this run
+            averaged_pairs = self._average_time_series_across_targets(
+                reports=all_target_reports,
+                metric_name=metric_name,
+                quantile_or_global=quantile_or_global,
+            )
+
+            if not averaged_pairs:
+                continue
+
+            timestamps = [pair[0] for pair in averaged_pairs]
+            metric_values = [pair[1] for pair in averaged_pairs]
+
+            # Add this (run, group) to the plotter with averaged values
+            plotter.add_model(
+                model_name=run_name,
+                timestamps=timestamps,
+                metric_values=metric_values,
+            )
+
+        title = self._create_plot_title(metric_name, quantile_or_global, "by run (averaged over all targets)")
+        figure = plotter.plot(title=title, metric_name=metric_name)
+
+        return VisualizationOutput(name=self.name, figure=figure)
+
+    # averaging over all targets (also when in different groups) for a single run
+    @override
+    def create_by_group(
+        self,
+        reports: dict[GroupName, list[ReportTuple]],
+    ) -> VisualizationOutput:
+        metric_name, quantile_or_global = self._get_metric_info()
+        plotter = WindowedMetricPlotter()
+
+        # Collect all targets from all groups
+        all_target_reports: list[ReportTuple] = []
+        for report_list in reports.values():
+            all_target_reports.extend(report_list)
+
+        # Average metrics over all targets
+        averaged_pairs = self._average_time_series_across_targets(
+            reports=all_target_reports,
+            metric_name=metric_name,
+            quantile_or_global=quantile_or_global,
+        )
+
+        if not averaged_pairs:
+            raise ValueError("No windowed metrics found for the specified window and metric across all groups.")
+
+        timestamps = [pair[0] for pair in averaged_pairs]
+        metric_values = [pair[1] for pair in averaged_pairs]
+
+        # Use the run name from the first target if available
+        run_name = all_target_reports[0][0].run_name if all_target_reports else ""
+
+        plotter.add_model(
+            model_name=run_name,
+            timestamps=timestamps,
+            metric_values=metric_values,
+        )
+
+        title = self._create_plot_title(metric_name, quantile_or_global, "averaged over all targets")
+        figure = plotter.plot(title=title, metric_name=metric_name)
 
         return VisualizationOutput(name=self.name, figure=figure)
 

--- a/packages/openstef-beam/src/openstef_beam/analysis/visualizations/windowed_metric_visualization.py
+++ b/packages/openstef-beam/src/openstef_beam/analysis/visualizations/windowed_metric_visualization.py
@@ -180,7 +180,7 @@ class WindowedMetricVisualization(VisualizationProvider):
         time_value_pairs = self._extract_windowed_metric_values(report, metric_name, quantile_or_global)
 
         if not time_value_pairs:
-            raise ValueError("No windowed metrics found in the report for the specified window and metric.")
+            raise ValueError("No windowed metrics found for the specified window and metric.")
 
         # Unpack the sorted pairs
         timestamps = [pair[0] for pair in time_value_pairs]
@@ -210,7 +210,7 @@ class WindowedMetricVisualization(VisualizationProvider):
 
                 # Skip if no data points found for this run
                 if not time_value_pairs:
-                    continue
+                    raise ValueError("No windowed metrics found for the specified window, metric and run.")
 
                 # Unpack the sorted pairs
                 timestamps = [pair[0] for pair in time_value_pairs]
@@ -244,7 +244,7 @@ class WindowedMetricVisualization(VisualizationProvider):
 
             # Skip if no data points found for this target
             if not time_value_pairs:
-                continue
+                raise ValueError("No windowed metrics found for the specified window, metric and target.")
 
             # Unpack the sorted pairs
             timestamps = [pair[0] for pair in time_value_pairs]
@@ -278,7 +278,7 @@ class WindowedMetricVisualization(VisualizationProvider):
         # Process each run and calculate averaged metrics across its targets
         for run_name, target_reports in reports.items():
             if not target_reports:
-                continue
+                raise ValueError("No windowed metrics found for the specified window, metric and run.")
 
             # Average windowed metrics across all targets for this run
             averaged_pairs = self._average_time_series_across_targets(
@@ -289,7 +289,7 @@ class WindowedMetricVisualization(VisualizationProvider):
 
             # Skip if no averaged data points found for this run
             if not averaged_pairs:
-                raise ValueError("No windowed metrics found for the specified window and metric across all groups.")
+                raise ValueError("No windowed averaged metrics found for the specified window, metric and run.")
 
             # Unpack the averaged pairs
             timestamps = [pair[0] for pair in averaged_pairs]
@@ -324,7 +324,7 @@ class WindowedMetricVisualization(VisualizationProvider):
         # Average metrics over all targets for each run
         for run_name, all_target_reports in run_to_targets.items():
             if not all_target_reports:
-                continue
+                raise ValueError("No windowed metrics found for the specified window, metric and run.")
 
             # Average windowed metrics across all targets for this run
             averaged_pairs = self._average_time_series_across_targets(
@@ -334,7 +334,7 @@ class WindowedMetricVisualization(VisualizationProvider):
             )
 
             if not averaged_pairs:
-                continue
+                raise ValueError("No windowed averaged metrics found for the specified window, metric and run.")
 
             timestamps = [pair[0] for pair in averaged_pairs]
             metric_values = [pair[1] for pair in averaged_pairs]
@@ -373,7 +373,9 @@ class WindowedMetricVisualization(VisualizationProvider):
         )
 
         if not averaged_pairs:
-            raise ValueError("No windowed metrics found for the specified window and metric across all groups.")
+            raise ValueError(
+                "No windowed averaged metrics found for the specified window, metric and run across all groups."
+            )
 
         timestamps = [pair[0] for pair in averaged_pairs]
         metric_values = [pair[1] for pair in averaged_pairs]

--- a/packages/openstef-beam/src/openstef_beam/analysis/visualizations/windowed_metric_visualization.py
+++ b/packages/openstef-beam/src/openstef_beam/analysis/visualizations/windowed_metric_visualization.py
@@ -289,7 +289,7 @@ class WindowedMetricVisualization(VisualizationProvider):
 
             # Skip if no averaged data points found for this run
             if not averaged_pairs:
-                continue
+                    raise ValueError("No windowed metrics found for the specified window and metric across all groups.")
 
             # Unpack the averaged pairs
             timestamps = [pair[0] for pair in averaged_pairs]

--- a/packages/openstef-beam/src/openstef_beam/analysis/visualizations/windowed_metric_visualization.py
+++ b/packages/openstef-beam/src/openstef_beam/analysis/visualizations/windowed_metric_visualization.py
@@ -289,7 +289,7 @@ class WindowedMetricVisualization(VisualizationProvider):
 
             # Skip if no averaged data points found for this run
             if not averaged_pairs:
-                    raise ValueError("No windowed metrics found for the specified window and metric across all groups.")
+                raise ValueError("No windowed metrics found for the specified window and metric across all groups.")
 
             # Unpack the averaged pairs
             timestamps = [pair[0] for pair in averaged_pairs]

--- a/packages/openstef-beam/src/openstef_beam/benchmarking/__init__.py
+++ b/packages/openstef-beam/src/openstef_beam/benchmarking/__init__.py
@@ -32,7 +32,7 @@ from openstef_beam.benchmarking.storage import (
     LocalBenchmarkStorage,
     S3BenchmarkStorage,
 )
-from openstef_beam.benchmarking.target_provider import TargetProvider, TargetProviderConfig
+from openstef_beam.benchmarking.target_provider import SimpleTargetProvider, TargetProvider, TargetProviderConfig
 
 __all__ = [
     "BenchmarkCallback",
@@ -46,6 +46,7 @@ __all__ = [
     "InMemoryBenchmarkStorage",
     "LocalBenchmarkStorage",
     "S3BenchmarkStorage",
+    "SimpleTargetProvider",
     "StrictExecutionCallback",
     "TargetProvider",
     "TargetProviderConfig",

--- a/packages/openstef-beam/tests/unit/analysis/visualizations/test_windowed_metric_visualization.py
+++ b/packages/openstef-beam/tests/unit/analysis/visualizations/test_windowed_metric_visualization.py
@@ -153,7 +153,7 @@ def test_create_by_none_raises_error_when_no_windowed_data(
     """Test that create_by_none raises appropriate error when no windowed metrics are found."""
     viz = WindowedMetricVisualization(name="test_viz", metric="mae", window=sample_window)
 
-    with pytest.raises(ValueError, match="No windowed metrics found in the report for the specified window and metric"):
+    with pytest.raises(ValueError, match="No windowed metrics found for the specified window and metric"):
         viz.create_by_none(empty_evaluation_report, simple_target_metadata)
 
 

--- a/packages/openstef-beam/tests/unit/analysis/visualizations/test_windowed_metric_visualization.py
+++ b/packages/openstef-beam/tests/unit/analysis/visualizations/test_windowed_metric_visualization.py
@@ -4,9 +4,11 @@
 
 """Tests for WindowedMetricVisualization."""
 
+import copy
 from datetime import datetime
 from unittest.mock import call, patch
 
+import numpy as np
 import pytest
 
 from openstef_beam.analysis.models.target_metadata import TargetMetadata
@@ -258,5 +260,234 @@ def test_supported_aggregations_includes_time_series_types(sample_window: Window
         AnalysisAggregation.NONE,
         AnalysisAggregation.RUN_AND_NONE,
         AnalysisAggregation.TARGET,
+        AnalysisAggregation.RUN_AND_TARGET,
+        AnalysisAggregation.GROUP,
+        AnalysisAggregation.RUN_AND_GROUP,
     }
     assert viz.supported_aggregations == expected
+
+
+def test_average_time_series_across_targets_averages_correctly(
+    multiple_target_metadata: list[TargetMetadata],
+    sample_evaluation_report: EvaluationSubsetReport,
+    sample_window: Window,
+):
+    # Arrange
+    # Change the windowed metric values in sample_evaluation_report_2 to simulate different targets
+    sample_evaluation_report_2 = copy.deepcopy(sample_evaluation_report)
+    for metric in sample_evaluation_report_2.metrics:
+        if metric.window == sample_window:
+            metric.metrics["global"]["mae"] += 1.0  # add 1.0 to each value
+
+    reports = [
+        (multiple_target_metadata[0], sample_evaluation_report),
+        (multiple_target_metadata[1], sample_evaluation_report_2),
+    ]
+
+    # Act
+    viz = WindowedMetricVisualization(name="test_viz", metric="mae", window=sample_window)
+
+    averaged = viz._average_time_series_across_targets(reports, metric_name="mae", quantile_or_global="global")
+
+    # Assert
+    # The expected average is mean of [0.4, 1.4] = 0.9 and [0.6, 1.6] = 1.1
+    assert averaged == [
+        (datetime.fromisoformat("2023-01-01T01:00:00"), pytest.approx(0.9)),
+        (datetime.fromisoformat("2023-01-01T02:00:00"), pytest.approx(1.1)),
+    ]
+
+
+def test_average_time_series_across_targets_averages_correctly_with_nan(
+    multiple_target_metadata: list[TargetMetadata],
+    sample_evaluation_report: EvaluationSubsetReport,
+    sample_window: Window,
+):
+    # Arrange
+    # Change the windowed metric values in sample_evaluation_report_2 to simulate different targets
+    sample_evaluation_report_2 = copy.deepcopy(sample_evaluation_report)
+    for metric in sample_evaluation_report_2.metrics:
+        if metric.window == sample_window:
+            metric.metrics["global"]["mae"] = np.nan  # set to NaN
+
+    reports = [
+        (multiple_target_metadata[0], sample_evaluation_report),
+        (multiple_target_metadata[1], sample_evaluation_report_2),
+    ]
+
+    # Act
+    viz = WindowedMetricVisualization(name="test_viz", metric="mae", window=sample_window)
+
+    averaged = viz._average_time_series_across_targets(reports, metric_name="mae", quantile_or_global="global")
+
+    # Assert
+    # The expected average is mean of [0.4, np.nan] = 0.4 and [0.6, np.nan] = 0.6
+    assert averaged == [
+        (datetime.fromisoformat("2023-01-01T01:00:00"), 0.4),
+        (datetime.fromisoformat("2023-01-01T02:00:00"), 0.6),
+    ]
+
+
+def test_create_by_run_and_target_handles_multiple_runs_and_targets(
+    sample_window: Window,
+    multiple_target_metadata: list[TargetMetadata],
+    sample_evaluation_report: EvaluationSubsetReport,
+    mock_plotly_figure: MockFigure,
+):
+    # Arrange
+    """Test create_by_run_and_target handles multiple runs with multiple targets each."""
+    viz = WindowedMetricVisualization(name="test_viz", metric="mae", window=sample_window)
+
+    # Create a second report with modified metrics for the second target in Run1
+    sample_evaluation_report_2 = copy.deepcopy(sample_evaluation_report)
+    for metric in sample_evaluation_report_2.metrics:
+        if metric.window == sample_window:
+            metric.metrics["global"]["mae"] += 1.0  # add 1.0 to each value
+
+    # Run1: two targets, Run2: one target
+    reports = {
+        "Run1": [
+            (multiple_target_metadata[0], sample_evaluation_report),
+            (multiple_target_metadata[1], sample_evaluation_report_2),
+        ],
+        "Run2": [
+            (multiple_target_metadata[2], sample_evaluation_report),
+        ],
+    }
+
+    # Act
+    with (
+        patch.object(WindowedMetricPlotter, "plot", return_value=mock_plotly_figure) as mock_plot,
+        patch.object(WindowedMetricPlotter, "add_model") as mock_add_model,
+    ):
+        result = viz.create_by_run_and_target(reports)
+
+    # Assert
+    expected_calls = [
+        call(
+            model_name="Run1",
+            timestamps=[datetime.fromisoformat("2023-01-01T01:00:00"), datetime.fromisoformat("2023-01-01T02:00:00")],
+            metric_values=[pytest.approx(0.9), pytest.approx(1.1)],
+        ),
+        call(
+            model_name="Run2",
+            timestamps=[datetime.fromisoformat("2023-01-01T01:00:00"), datetime.fromisoformat("2023-01-01T02:00:00")],
+            metric_values=[pytest.approx(0.4), pytest.approx(0.6)],
+        ),
+    ]
+    mock_add_model.assert_has_calls(expected_calls)
+    mock_plot.assert_called_once_with(
+        title="Windowed mae (lag=PT1H,size=PT2H,stride=PT1H) over Time by run (averaged over targets in group)",
+        metric_name="mae",
+    )
+    assert result.name == viz.name
+    assert result.figure == mock_plotly_figure
+
+
+def test_create_by_run_and_group_handles_multiple_runs_and_groups(
+    sample_window: Window,
+    multiple_target_metadata: list[TargetMetadata],
+    sample_evaluation_report: EvaluationSubsetReport,
+    mock_plotly_figure: MockFigure,
+):
+    """Test create_by_run_and_group aggregates by both run and group, averaging over all targets for each run."""
+    viz = WindowedMetricVisualization(name="test_viz", metric="mae", window=sample_window)
+
+    # Create a second report with modified metrics for the second target in Run1
+    sample_evaluation_report_2 = copy.deepcopy(sample_evaluation_report)
+    for metric in sample_evaluation_report_2.metrics:
+        if metric.window == sample_window:
+            metric.metrics["global"]["mae"] += 1.0
+
+    # Run1 appears in two groups, Run2 in one group
+    # This tests that aggregation is done over all targets for each run, not per group
+    reports = {
+        ("Run1", "GroupA"): [
+            (multiple_target_metadata[0], sample_evaluation_report),
+        ],
+        ("Run1", "GroupB"): [
+            (multiple_target_metadata[1], sample_evaluation_report_2),
+        ],
+        ("Run2", "GroupB"): [
+            (multiple_target_metadata[2], sample_evaluation_report),
+        ],
+    }
+
+    # Act
+    with (
+        patch.object(WindowedMetricPlotter, "plot", return_value=mock_plotly_figure) as mock_plot,
+        patch.object(WindowedMetricPlotter, "add_model") as mock_add_model,
+    ):
+        result = viz.create_by_run_and_group(reports)
+
+    # Assert: only one call for Run1, averaging over both groups
+    expected_calls = [
+        call(
+            model_name="Run1",
+            timestamps=[datetime.fromisoformat("2023-01-01T01:00:00"), datetime.fromisoformat("2023-01-01T02:00:00")],
+            metric_values=[pytest.approx(0.9), pytest.approx(1.1)],
+        ),
+        call(
+            model_name="Run2",
+            timestamps=[datetime.fromisoformat("2023-01-01T01:00:00"), datetime.fromisoformat("2023-01-01T02:00:00")],
+            metric_values=[pytest.approx(0.4), pytest.approx(0.6)],
+        ),
+    ]
+    mock_add_model.assert_has_calls(expected_calls)
+    # Assert only one call per run, not per run-group
+    assert mock_add_model.call_count == 2
+    mock_plot.assert_called_once_with(
+        title="Windowed mae (lag=PT1H,size=PT2H,stride=PT1H) over Time by run (averaged over all targets)",
+        metric_name="mae",
+    )
+    assert result.name == viz.name
+    assert result.figure == mock_plotly_figure
+
+
+def test_create_by_group_handles_multiple_groups(
+    sample_window: Window,
+    multiple_target_metadata: list[TargetMetadata],
+    sample_evaluation_report: EvaluationSubsetReport,
+    mock_plotly_figure: MockFigure,
+):
+    """Test create_by_run_and_group aggregates by both run and group, averaging over all targets for each run."""
+    viz = WindowedMetricVisualization(name="test_viz", metric="mae", window=sample_window)
+
+    # Create a second report with modified metrics for the second target in Run1
+    sample_evaluation_report_2 = copy.deepcopy(sample_evaluation_report)
+    for metric in sample_evaluation_report_2.metrics:
+        if metric.window == sample_window:
+            metric.metrics["global"]["mae"] += 1.0
+
+    # Run1 appears in two groups
+    reports = {
+        "GroupA": [
+            (multiple_target_metadata[0], sample_evaluation_report),
+        ],
+        "GroupB": [
+            (multiple_target_metadata[1], sample_evaluation_report_2),
+        ],
+    }
+
+    # Act
+    with (
+        patch.object(WindowedMetricPlotter, "plot", return_value=mock_plotly_figure) as mock_plot,
+        patch.object(WindowedMetricPlotter, "add_model") as mock_add_model,
+    ):
+        result = viz.create_by_group(reports)
+
+    # Assert: only one call for Run1, averaging over both groups
+    expected_calls = [
+        call(
+            model_name="Run1",
+            timestamps=[datetime.fromisoformat("2023-01-01T01:00:00"), datetime.fromisoformat("2023-01-01T02:00:00")],
+            metric_values=[pytest.approx(0.9), pytest.approx(1.1)],
+        ),
+    ]
+    mock_add_model.assert_has_calls(expected_calls)
+    # Assert only one call per run, not per run-group
+    assert mock_add_model.call_count == 1
+    mock_plot.assert_called_once_with(
+        title="Windowed mae (lag=PT1H,size=PT2H,stride=PT1H) over Time averaged over all targets", metric_name="mae"
+    )
+    assert result.name == viz.name
+    assert result.figure == mock_plotly_figure


### PR DESCRIPTION
Extended the windowed metric visualization to be able to handle multiple targets for multiple runs (by taking the average over all targets within a group, per run) and groups (by taking the average over all targets in all groups, see example below). This allows for a more complete overview of the accuracy of a certain metric over time, without having to check each individual location. Windowed metrics for individual targets can still be plotted together using the "Target" aggregation level.
<img width="1443" height="663" alt="image" src="https://github.com/user-attachments/assets/65e73021-aef0-4a9b-a463-7921a231ec0e" />
