### PR TITLE
feature(#689): Add basecase forecaster

### DIFF
--- a/packages/openstef-models/src/openstef_models/models/forecasting/base_case_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/base_case_forecaster.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the OpenSTEF project <short.term.energy.forecasts@alliander.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Base case forecasting model that predicts load from 1 week ago.
+
+Provides a simple baseline forecasting model that predicts the load value from
+exactly 1 week ago when available. This model serves as a naive
+baseline for comparison with more sophisticated forecasting approaches, implementing
+the common assumption that energy load patterns exhibit weekly periodicity.
+
+The forecaster looks back 7 days to find historical load values and uses them
+as predictions for future time periods. When historical data is not available
+for a specific time point, the model returns NaN for that prediction.
+"""
+
+from datetime import timedelta
+from typing import Self, override, cast
+
+import pandas as pd
+from pydantic import Field
+from scipy.stats import norm
+
+from openstef_core.datasets.validated_datasets import ForecastDataset, ForecastInputDataset
+from openstef_core.exceptions import ModelLoadingError, NotFittedError
+from openstef_core.mixins import State
+from openstef_core.mixins.predictor import HyperParams
+from openstef_core.types import LeadTime, Quantile
+from openstef_models.models.forecasting.forecaster import HorizonForecaster, HorizonForecasterConfig
+
+
+class BaseCaseForecasterHyperParams(HyperParams):
+    """Hyperparameter configuration for base case forecaster."""
+
+    lookback_days: int = Field(
+        default=7,
+        description="Number of days to look back for base case predictions.",
+        ge=1,
+    )
+
+
+class BaseCaseForecasterConfig(HorizonForecasterConfig):
+    """Configuration for base case forecaster."""
+
+    hyperparams: BaseCaseForecasterHyperParams = Field(
+        default=BaseCaseForecasterHyperParams(),
+    )
+
+
+MODEL_CODE_VERSION = 1
+
+
+class BaseCaseForecaster(HorizonForecaster):
+    """Base case forecaster that predicts load from 1 week ago.
+
+    A simple baseline forecasting model that leverages weekly periodicity in energy
+    load patterns. For each prediction time point, it looks back exactly 1 week
+    (168 hours) to find the historical load value and uses it as the prediction.
+
+    This forecaster is particularly useful for:
+    - Establishing performance baselines for more complex models
+    - Quick estimates when sophisticated models are unavailable
+    - Educational purposes to demonstrate weekly load patterns
+    - Initial model validation and sanity checking
+
+    The model assigns the same predicted value to all quantiles, as it doesn't
+    provide uncertainty estimates beyond point predictions.
+
+    Example:
+        >>> from openstef_core.types import LeadTime, Quantile
+        >>> from datetime import timedelta
+        >>> config = BaseCaseForecasterConfig(
+        ...     quantiles=[Quantile(0.5), Quantile(0.1), Quantile(0.9)],
+        ...     horizons=[LeadTime(timedelta(hours=1))],
+        ...     hyperparams=BaseCaseForecasterHyperParams(lookback_weeks=1)
+        ... )
+        >>> forecaster = BaseCaseForecaster(config)
+        >>> # forecaster.fit(training_data)
+        >>> # predictions = forecaster.predict(test_data)
+    """
+
+    _config: BaseCaseForecasterConfig
+
+    def __init__(
+        self,
+        config: BaseCaseForecasterConfig | None = None,
+    ) -> None:
+        """Initialize the base case forecaster.
+
+        Args:
+            config: Configuration specifying quantiles and hyperparameters.
+        """
+        self._config = config or BaseCaseForecasterConfig(
+            quantiles=[Quantile(0.5)],  # Default median quantile
+            horizons=[LeadTime(timedelta(hours=1))],  # Default 1-hour horizon
+        )
+
+    @property
+    @override
+    def config(self) -> BaseCaseForecasterConfig:
+        return self._config
+
+    @property
+    @override
+    def hyperparams(self) -> BaseCaseForecasterHyperParams:
+        return self._config.hyperparams
+
+    @override
+    def to_state(self) -> State:
+        return {
+            "version": MODEL_CODE_VERSION,
+            "config": self.config.model_dump(mode="json"),
+        }
+
+    @override
+    def from_state(self, state: State) -> Self:
+        if not isinstance(state, dict) or "version" not in state or state["version"] > MODEL_CODE_VERSION:
+            raise ModelLoadingError("Invalid state for BaseCaseForecaster")
+
+        return self.__class__(config=BaseCaseForecasterConfig.model_validate(state["config"]))  # noqa: SLF001
+
+    @property
+    @override
+    def is_fitted(self) -> bool:
+        return True
+
+    @override
+    def fit(self, data: ForecastInputDataset, data_val: ForecastInputDataset | None = None) -> None:
+        pass
+
+    def _create_quantile_predictions(
+        self,
+        forecast_index: pd.DatetimeIndex,
+        historical_values: pd.Series,
+        hourly_stats: pd.DataFrame
+    ) -> pd.DataFrame:
+        """Create predictions for each quantile.
+
+        Args:
+            forecast_index: The forecast period index.
+            historical_values: Historical values for each forecast timestamp.
+            hourly_stats: Hourly statistics for confidence intervals.
+
+        Returns:
+            Dictionary mapping quantile strings to prediction series.
+        """
+        predictions_data = {}
+
+        for quantile in self.config.quantiles:
+            # Calculate z-score for the quantile
+            z_score = norm.ppf(float(quantile))
+
+            # Apply confidence interval: base_value + z_score * std
+            quantile_values = historical_values + z_score * hourly_stats["std"]
+            predictions_data[quantile.format()] = quantile_values
+
+        return pd.DataFrame(
+            data=predictions_data,
+            index=forecast_index,
+        )
+
+    @override
+    def predict(self, data: ForecastInputDataset) -> ForecastDataset:
+        """Generate predictions using historical values from lookback period with confidence intervals.
+
+        Args:
+            data: The forecast input dataset containing historical data and target column.
+
+        Returns:
+            ForecastDataset containing quantile predictions for the forecast period.
+        """
+        # Get forecast timestamps
+        forecast_index = data.input_data().index
+
+        historical_values_shifted = data.target_series().shift(periods=self._config.hyperparams.lookback_days, freq="D")
+        if data.forecast_start is not None:
+            historical_values_shifted = (
+                historical_values_shifted[historical_values_shifted.index > pd.Timestamp(data.forecast_start)]
+            )
+
+        historical_with_hour = historical_values_shifted.to_frame()
+        historical_with_hour["hour"] = cast(pd.DatetimeIndex, historical_with_hour.index).hour
+
+        # Compute mean and std for each hour
+        historical_with_hour["std"] = historical_with_hour.groupby([
+            historical_with_hour.index.date,
+            historical_with_hour.index.hour,
+        ])[data.target_column].transform("std").fillna(0)
+
+        # Create quantile predictions
+        predictions_data = self._create_quantile_predictions(
+            forecast_index, historical_values_shifted, historical_with_hour
+        )
+
+        return ForecastDataset(
+            data=predictions_data,
+            sample_interval=data.sample_interval,
+        )

--- a/packages/openstef-models/src/openstef_models/models/forecasting/base_case_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/base_case_forecaster.py
@@ -11,8 +11,7 @@ assumption that energy load patterns exhibit weekly periodicity.
 
 The forecaster constructs lag column names based on hyperparameter configuration and
 uses them to make predictions. It prioritizes the primary lag (default: 7-day) but falls
-back to the fallback lag (default: 14-day) when primary lag data is not available,
-matching the behavior of the legacy create_basecase_forecast_pipeline.
+back to the fallback lag (default: 14-day) when primary lag data is not available.
 """
 
 from datetime import timedelta

--- a/packages/openstef-models/src/openstef_models/models/forecasting/base_case_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/base_case_forecaster.py
@@ -2,40 +2,44 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-"""Base case forecasting model that predicts load from 1 week ago.
+"""Base case forecasting model that uses lag features for predictions.
 
-Provides a simple baseline forecasting model that predicts the load value from
-exactly 1 week ago when available. This model serves as a naive
-baseline for comparison with more sophisticated forecasting approaches, implementing
-the common assumption that energy load patterns exhibit weekly periodicity.
+Provides a simple baseline forecasting model that predicts using historical load values
+from lag features created by LagTransform. This model serves as a naive baseline for
+comparison with more sophisticated forecasting approaches, implementing the common
+assumption that energy load patterns exhibit weekly periodicity.
 
-The forecaster looks back 7 days to find historical load values and uses them
-as predictions for future time periods. When historical data is not available
-for a specific time point, the model returns NaN for that prediction.
+The forecaster constructs lag column names based on hyperparameter configuration and
+uses them to make predictions. It prioritizes the primary lag (default: 7-day) but falls
+back to the fallback lag (default: 14-day) when primary lag data is not available,
+matching the behavior of the legacy create_basecase_forecast_pipeline.
 """
 
 from datetime import timedelta
-from typing import Self, override, cast
+from typing import Self, cast, override
 
 import pandas as pd
 from pydantic import Field
 from scipy.stats import norm
 
 from openstef_core.datasets.validated_datasets import ForecastDataset, ForecastInputDataset
-from openstef_core.exceptions import ModelLoadingError, NotFittedError
+from openstef_core.exceptions import MissingColumnsError, ModelLoadingError
 from openstef_core.mixins import State
 from openstef_core.mixins.predictor import HyperParams
-from openstef_core.types import LeadTime, Quantile
+from openstef_core.utils import timedelta_to_isoformat
 from openstef_models.models.forecasting.forecaster import HorizonForecaster, HorizonForecasterConfig
 
 
 class BaseCaseForecasterHyperParams(HyperParams):
     """Hyperparameter configuration for base case forecaster."""
 
-    lookback_days: int = Field(
-        default=7,
-        description="Number of days to look back for base case predictions.",
-        ge=1,
+    primary_lag: timedelta = Field(
+        default=timedelta(days=7),
+        description="Primary lag to use for predictions (default: 7 days for weekly patterns)",
+    )
+    fallback_lag: timedelta = Field(
+        default=timedelta(days=14),
+        description="Fallback lag to use when primary lag data is unavailable (default: 14 days)",
     )
 
 
@@ -43,7 +47,7 @@ class BaseCaseForecasterConfig(HorizonForecasterConfig):
     """Configuration for base case forecaster."""
 
     hyperparams: BaseCaseForecasterHyperParams = Field(
-        default=BaseCaseForecasterHyperParams(),
+        default_factory=BaseCaseForecasterHyperParams,
     )
 
 
@@ -51,32 +55,54 @@ MODEL_CODE_VERSION = 1
 
 
 class BaseCaseForecaster(HorizonForecaster):
-    """Base case forecaster that predicts load from 1 week ago.
+    """Base case forecaster that uses lag features for predictions.
 
-    A simple baseline forecasting model that leverages weekly periodicity in energy
-    load patterns. For each prediction time point, it looks back exactly 1 week
-    (168 hours) to find the historical load value and uses it as the prediction.
+    A simple baseline forecasting model that leverages lag features created by LagTransform
+    to make predictions. This model serves as a naive baseline for comparison with more
+    sophisticated forecasting approaches, implementing the common assumption that energy
+    load patterns exhibit weekly periodicity.
 
-    This forecaster is particularly useful for:
-    - Establishing performance baselines for more complex models
-    - Quick estimates when sophisticated models are unavailable
-    - Educational purposes to demonstrate weekly load patterns
-    - Initial model validation and sanity checking
+    The forecaster constructs lag column names based on the configured lags (primary_lag and
+    fallback_lag hyperparameters) and the target column name. It prioritizes the primary lag
+    features (default: 7-day lag, e.g., 'load_lag_-P7D') but falls back to fallback lag
+    features (default: 14-day lag, e.g., 'load_lag_-P14D') when primary lag data is not available.
 
-    The model assigns the same predicted value to all quantiles, as it doesn't
-    provide uncertainty estimates beyond point predictions.
+    The confidence intervals are calculated using hourly standard deviations computed from
+    the lag data, providing uncertainty estimates for each prediction.
 
     Example:
         >>> from openstef_core.types import LeadTime, Quantile
         >>> from datetime import timedelta
+        >>>
+        >>> # Default configuration (7-day primary, 14-day fallback)
         >>> config = BaseCaseForecasterConfig(
         ...     quantiles=[Quantile(0.5), Quantile(0.1), Quantile(0.9)],
         ...     horizons=[LeadTime(timedelta(hours=1))],
-        ...     hyperparams=BaseCaseForecasterHyperParams(lookback_weeks=1)
         ... )
         >>> forecaster = BaseCaseForecaster(config)
-        >>> # forecaster.fit(training_data)
-        >>> # predictions = forecaster.predict(test_data)
+        >>>
+        >>> # Custom lag configuration
+        >>> custom_config = BaseCaseForecasterConfig(
+        ...     quantiles=[Quantile(0.5)],
+        ...     horizons=[LeadTime(timedelta(hours=1))],
+        ...     hyperparams=BaseCaseForecasterHyperParams(
+        ...         primary_lag=timedelta(days=7),
+        ...         fallback_lag=timedelta(days=21)
+        ...     )
+        ... )
+        >>> custom_forecaster = BaseCaseForecaster(custom_config)
+        >>>
+        >>> # Assumes data has lag columns like 'load_lag_-P7D', 'load_lag_-P14D'
+        >>> forecaster.fit(training_data)  # doctest: +SKIP
+        >>> predictions = forecaster.predict(test_data)  # doctest: +SKIP
+
+    Note:
+        The forecaster expects lag columns to be present in the input data, typically
+        created by applying LagTransform during preprocessing. The column names are
+        constructed as: {target_column}_lag_{ISO8601_duration}
+
+    See Also:
+        LagTransform: A transformation that creates lag features for time series forecasting.
     """
 
     _config: BaseCaseForecasterConfig
@@ -88,12 +114,13 @@ class BaseCaseForecaster(HorizonForecaster):
         """Initialize the base case forecaster.
 
         Args:
-            config: Configuration specifying quantiles and hyperparameters.
+            config: Configuration specifying quantiles, horizons, and lag hyperparameters.
+                   If None, uses default configuration with 7-day primary and 14-day fallback lags.
         """
-        self._config = config or BaseCaseForecasterConfig(
-            quantiles=[Quantile(0.5)],  # Default median quantile
-            horizons=[LeadTime(timedelta(hours=1))],  # Default 1-hour horizon
-        )
+        self._config = config or BaseCaseForecasterConfig()
+        self._lag_columns_detected: bool = False
+        self._primary_lag_target_column_name: str | None = None
+        self._fallback_lag_target_column_name: str | None = None
 
     @property
     @override
@@ -117,82 +144,162 @@ class BaseCaseForecaster(HorizonForecaster):
         if not isinstance(state, dict) or "version" not in state or state["version"] > MODEL_CODE_VERSION:
             raise ModelLoadingError("Invalid state for BaseCaseForecaster")
 
-        return self.__class__(config=BaseCaseForecasterConfig.model_validate(state["config"]))  # noqa: SLF001
+        return self.__class__(config=BaseCaseForecasterConfig.model_validate(state["config"]))
+
+    @staticmethod
+    def _construct_lag_column_name(target_column: str, lag: timedelta) -> str:
+        """Constructs the column name for the lag target feature.
+
+        Args:
+            target_column: The name of the target column
+            lag: The timedelta lag
+
+        Returns:
+            The lag feature column name
+        """
+        # Convert timedelta to ISO format (e.g., P7D becomes -P7D for negative lag)
+        iso_lag = timedelta_to_isoformat(-lag)
+        return f"{target_column}_lag_{iso_lag}"
 
     @property
     @override
     def is_fitted(self) -> bool:
-        return True
+        return self._lag_columns_detected
+
+    def _detect_lag_columns(self, data: ForecastInputDataset) -> None:
+        """Detect lag columns in the input data.
+
+        Looks for columns matching patterns like 'load_lag_-P7D', 'load_lag_-P14D', etc.
+
+        Args:
+            data: The input dataset containing features and target variable.
+
+        Raises:
+            MissingColumnsError: If both primary and fallback lag columns are not available.
+        """
+        self._primary_lag_target_column_name = self._construct_lag_column_name(
+            data.target_column, self._config.hyperparams.primary_lag
+        )
+
+        self._fallback_lag_target_column_name = self._construct_lag_column_name(
+            data.target_column, self._config.hyperparams.fallback_lag
+        )
+
+        # Check if we have at least one lag column available
+        has_primary = self._primary_lag_target_column_name in data.feature_names
+        has_fallback = self._fallback_lag_target_column_name in data.feature_names
+
+        if not has_primary and not has_fallback:
+            raise MissingColumnsError([self._primary_lag_target_column_name, self._fallback_lag_target_column_name])
+
+        # Mark that we have detected lag columns
+        self._lag_columns_detected = True
 
     @override
     def fit(self, data: ForecastInputDataset, data_val: ForecastInputDataset | None = None) -> None:
-        pass
+        # Detect lag columns during fitting
+        self._detect_lag_columns(data)
 
-    def _create_quantile_predictions(
-        self,
-        forecast_index: pd.DatetimeIndex,
-        historical_values: pd.Series,
-        hourly_stats: pd.DataFrame
-    ) -> pd.DataFrame:
-        """Create predictions for each quantile.
+    def _get_basecase_values(self, data: ForecastInputDataset) -> pd.Series:
+        """Get basecase values from available lag columns.
+
+        Prioritizes primary lag column (7-day), falls back to fallback lag column (14-day).
 
         Args:
-            forecast_index: The forecast period index.
-            historical_values: Historical values for each forecast timestamp.
-            hourly_stats: Hourly statistics for confidence intervals.
+            data: Input dataset containing lag features
 
         Returns:
-            Dictionary mapping quantile strings to prediction series.
+            Series with basecase values for prediction timestamps, or NaN series if no lag columns
         """
-        predictions_data = {}
+        forecast_data = data.input_data(start=data.forecast_start)
 
-        for quantile in self.config.quantiles:
-            # Calculate z-score for the quantile
-            z_score = norm.ppf(float(quantile))
+        # If no lag columns were detected, return NaN series
+        if not self._lag_columns_detected:
+            return pd.Series(float("nan"), index=forecast_data.index)
 
-            # Apply confidence interval: base_value + z_score * std
-            quantile_values = historical_values + z_score * hourly_stats["std"]
-            predictions_data[quantile.format()] = quantile_values
+        # Try primary lag column first
+        if self._primary_lag_target_column_name in data.feature_names:
+            primary_values = forecast_data[self._primary_lag_target_column_name]
 
-        return pd.DataFrame(
-            data=predictions_data,
-            index=forecast_index,
-        )
+            # If primary has gaps, fill with fallback where available
+            if self._fallback_lag_target_column_name and self._fallback_lag_target_column_name in forecast_data.columns:
+                fallback_values = forecast_data[self._fallback_lag_target_column_name]
+                return primary_values.fillna(fallback_values)  # pyright: ignore[reportUnknownMemberType]
+
+            return primary_values
+
+        # Fall back to fallback lag column if available
+        if self._fallback_lag_target_column_name in data.feature_names:
+            return forecast_data[self._fallback_lag_target_column_name]
+
+        # If we reach here, no lag columns are available
+        return pd.Series(float("nan"), index=forecast_data.index)
+
+    @staticmethod
+    def _calculate_hourly_std(basecase_values: pd.Series) -> pd.Series:
+        """Calculate standard deviation for each hour using basecase values.
+
+        Mimics the behavior of generate_basecase_confidence_interval from the old version.
+
+        Args:
+            basecase_values: Series containing the basecase values for calculating std.
+
+        Returns:
+            Series with hourly standard deviation values mapped to forecast timestamps.
+        """
+        if len(basecase_values.dropna()) == 0:
+            # If no valid basecase values, return zero std
+            return pd.Series(0.0, index=basecase_values.index)
+
+        # Create DataFrame with values and hours for grouping
+        basecase_value_with_hour = pd.DataFrame({
+            "values": basecase_values,
+            "hour": cast(pd.DatetimeIndex, basecase_values.index).hour,
+        }).dropna()  # pyright: ignore[reportUnknownMemberType]
+
+        if len(basecase_value_with_hour) == 0:
+            return pd.Series(0.0, index=basecase_values.index)
+
+        # Group by hour and calculate std
+        hourly_std = basecase_value_with_hour.groupby("hour")["values"].std().fillna(0.0)  # pyright: ignore[reportUnknownMemberType]
+
+        # Map std values to forecast timestamps
+        forecast_hours = cast(pd.DatetimeIndex, basecase_values.index).hour
+        return forecast_hours.map(hourly_std).fillna(0.0)  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
 
     @override
     def predict(self, data: ForecastInputDataset) -> ForecastDataset:
-        """Generate predictions using historical values from lookback period with confidence intervals.
+        """Generate predictions using lag features with confidence intervals.
 
         Args:
-            data: The forecast input dataset containing historical data and target column.
+            data: The forecast input dataset containing lag features.
 
         Returns:
             ForecastDataset containing quantile predictions for the forecast period.
         """
-        # Get forecast timestamps
-        forecast_index = data.input_data().index
+        # Ensure lag columns are available
+        self._detect_lag_columns(data)
 
-        historical_values_shifted = data.target_series().shift(periods=self._config.hyperparams.lookback_days, freq="D")
-        if data.forecast_start is not None:
-            historical_values_shifted = (
-                historical_values_shifted[historical_values_shifted.index > pd.Timestamp(data.forecast_start)]
-            )
+        # Get basecase values from lag columns
+        basecase_values = self._get_basecase_values(data)
 
-        historical_with_hour = historical_values_shifted.to_frame()
-        historical_with_hour["hour"] = cast(pd.DatetimeIndex, historical_with_hour.index).hour
+        # Calculate hourly standard deviation for confidence intervals
+        hourly_std = self._calculate_hourly_std(basecase_values)
 
-        # Compute mean and std for each hour
-        historical_with_hour["std"] = historical_with_hour.groupby([
-            historical_with_hour.index.date,
-            historical_with_hour.index.hour,
-        ])[data.target_column].transform("std").fillna(0)
+        # Create predictions for each quantile
+        predictions_data = {}
+        for quantile in self.config.quantiles:
+            # Calculate z-score for the quantile
+            z_score = norm.ppf(float(quantile))  # pyright: ignore[reportUnknownMemberType]
 
-        # Create quantile predictions
-        predictions_data = self._create_quantile_predictions(
-            forecast_index, historical_values_shifted, historical_with_hour
-        )
+            # Apply confidence interval: base_value + z_score * std
+            quantile_values = basecase_values + z_score * hourly_std
+            predictions_data[quantile.format()] = quantile_values
 
         return ForecastDataset(
-            data=predictions_data,
+            data=pd.DataFrame(
+                data=predictions_data,
+                index=basecase_values.index,
+            ),
             sample_interval=data.sample_interval,
         )

--- a/packages/openstef-models/tests/unit/models/forecasting/test_base_case_forecaster.py
+++ b/packages/openstef-models/tests/unit/models/forecasting/test_base_case_forecaster.py
@@ -1,0 +1,329 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the OpenSTEF project <short.term.energy.forecasts@alliander.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+from datetime import datetime, timedelta
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from openstef_core.datasets.validated_datasets import ForecastDataset, ForecastInputDataset
+from openstef_core.exceptions import NotFittedError
+from openstef_core.types import LeadTime, Quantile
+from openstef_models.models.forecasting.base_case_forecaster import (
+    BaseCaseForecaster,
+    BaseCaseForecasterConfig,
+    BaseCaseForecasterHyperParams,
+)
+from openstef_models.models.forecasting.multi_horizon_forecaster_adapter import MultiHorizonForecasterConfig
+
+
+@pytest.fixture
+def sample_forecast_input_dataset() -> ForecastInputDataset:
+    # Create 14 days of quarter-hourly data
+    num_samples = 14 * 24 * 4
+    dates = pd.date_range(
+        start=datetime.fromisoformat("2025-01-01T00:00:00"),
+        periods=num_samples,
+        freq="15min"
+    )
+
+    # 1's for 1st week and 2 for 2nd week
+    data = pd.DataFrame(
+        {"load": [1] * (num_samples // 2) + [2] * (len(dates) // 2)},
+        index=dates
+    )
+
+    return ForecastInputDataset(
+        data=data,
+        sample_interval=timedelta(minutes=15),
+        target_column="load",
+        forecast_start=datetime.fromisoformat("2025-01-08T00:00:00"),  # Middle of dataset
+    )
+
+
+@pytest.fixture
+def sample_forecaster_config() -> BaseCaseForecasterConfig:
+    """Create sample forecaster configuration with standard quantiles."""
+    return BaseCaseForecasterConfig(
+        quantiles=[Quantile(0.1), Quantile(0.5), Quantile(0.9)],
+        horizons=[LeadTime(timedelta(hours=6))],
+        hyperparams=BaseCaseForecasterHyperParams(lookback_days=7),
+    )
+
+
+def test_base_case_forecaster__fit_predict(
+    sample_forecaster_config: BaseCaseForecasterConfig,
+    sample_forecast_input_dataset: ForecastInputDataset,
+):
+    """Test that forecaster trains on data and produces predictions from 1 week ago."""
+    # Arrange
+    forecaster = BaseCaseForecaster(config=sample_forecaster_config)
+
+    # Act
+    forecaster.fit(sample_forecast_input_dataset)
+    result = forecaster.predict(sample_forecast_input_dataset)
+
+    # Assert
+    # Check that model is fitted and produces forecast
+    assert forecaster.is_fitted
+    assert isinstance(result, ForecastDataset)
+
+    # Should have predictions for all hours after forecast_start
+    forecast_start = datetime.fromisoformat("2025-01-08T00:00:00")
+    expected_hours = len([t for t in sample_forecast_input_dataset.index if t > forecast_start])
+    assert len(result.data) == expected_hours
+
+    # Check that predictions match values from exactly 1 week ago
+    first_prediction_time = result.data.index[0]  # First forecast timestamp
+    one_week_ago = first_prediction_time - timedelta(weeks=1)
+
+    # Get the historical value from 1 week ago
+    historical_value = sample_forecast_input_dataset.data.loc[one_week_ago, "load"]
+
+    # P50 (median) should match the historical value exactly
+    actual_values = result.data.iloc[0]  # First forecast row
+    assert actual_values["quantile_P50"] == historical_value
+
+    # P10 and P90 should be different from P50 due to confidence intervals
+    assert actual_values["quantile_P10"] != actual_values["quantile_P50"]
+    assert actual_values["quantile_P90"] != actual_values["quantile_P50"]
+
+    # P10 should be lower than P50, P90 should be higher than P50
+    assert actual_values["quantile_P10"] < actual_values["quantile_P50"]
+    assert actual_values["quantile_P90"] > actual_values["quantile_P50"]
+
+
+def test_base_case_forecaster__predict_without_historical_data():
+    """Test that forecaster handles missing historical data gracefully."""
+    # Arrange
+    # Create data with only 3 days (not enough for 1-week lookback)
+    short_data = pd.DataFrame(
+        {"load": [100.0, 110.0, 120.0]},
+        index=pd.date_range(
+            start=datetime.fromisoformat("2025-01-01T00:00:00"),
+            periods=3,
+            freq="1h"
+        )
+    )
+
+    input_dataset = ForecastInputDataset(
+        data=short_data,
+        sample_interval=timedelta(hours=1),
+        target_column="load",
+        forecast_start=datetime.fromisoformat("2025-01-01T01:00:00"),
+    )
+
+    config = BaseCaseForecasterConfig(
+        quantiles=[Quantile(0.5)],
+        horizons=[LeadTime(timedelta(hours=1))],
+        hyperparams=BaseCaseForecasterHyperParams(lookback_days=168),  # 7 days * 24 hours
+    )
+    forecaster = BaseCaseForecaster(config=config)
+    forecaster.fit(input_dataset)
+
+    # Act
+    result = forecaster.predict(input_dataset)
+
+    # Assert
+    # Should produce predictions but with NaN values (no historical data available)
+    # Data has 3 hours starting at 00:00, forecast_start at 01:00, so 2 hours after: 02:00, 03:00
+    # But actually data only goes to 02:00 (3 periods starting at 00:00: 00:00, 01:00, 02:00)
+    assert len(result.data) == 1  # 1 hour after forecast_start (only 02:00 available)
+    assert pd.isna(result.data.iloc[0]["quantile_P50"])  # Should be NaN
+
+
+def test_base_case_forecaster__predict_not_fitted_raises_error(
+    sample_forecaster_config: BaseCaseForecasterConfig,
+):
+    """Test that predicting without fitting raises NotFittedError."""
+    # Arrange
+    forecaster = BaseCaseForecaster(config=sample_forecaster_config)
+    dummy_data = pd.DataFrame(
+        {"load": [100.0]},
+        index=pd.date_range(
+            start=datetime.fromisoformat("2025-01-01T00:00:00"),
+            periods=1,
+            freq="1h"
+        )
+    )
+    input_dataset = ForecastInputDataset(
+        data=dummy_data,
+        sample_interval=timedelta(hours=1),
+        target_column="load"
+    )
+
+    # Act & Assert
+    with pytest.raises(NotFittedError, match="BaseCaseForecaster"):
+        forecaster.predict(input_dataset)
+
+
+def test_base_case_forecaster__state_serialize_restore(
+    sample_forecaster_config: BaseCaseForecasterConfig,
+    sample_forecast_input_dataset: ForecastInputDataset,
+):
+    """Test that forecaster state can be serialized and restored with preserved functionality."""
+    # Arrange
+    original_forecaster = BaseCaseForecaster(config=sample_forecaster_config)
+    original_forecaster.fit(sample_forecast_input_dataset)
+
+    # Act
+    # Serialize state and create new forecaster from state
+    state = original_forecaster.to_state()
+
+    restored_forecaster = BaseCaseForecaster(config=sample_forecaster_config)
+    restored_forecaster = restored_forecaster.from_state(state)
+
+    # Assert
+    # Check that restored forecaster produces identical predictions
+    assert restored_forecaster.is_fitted
+    original_result = original_forecaster.predict(sample_forecast_input_dataset)
+    restored_result = restored_forecaster.predict(sample_forecast_input_dataset)
+
+    pd.testing.assert_frame_equal(original_result.data, restored_result.data)
+    assert original_result.sample_interval == restored_result.sample_interval
+
+
+def test_base_case_forecaster__config_properties(sample_forecaster_config: BaseCaseForecasterConfig):
+    """Test that forecaster correctly exposes configuration properties."""
+    # Arrange
+    forecaster = BaseCaseForecaster(config=sample_forecaster_config)
+
+    # Assert
+    assert forecaster.config == sample_forecaster_config
+    assert forecaster.hyperparams == sample_forecaster_config.hyperparams
+    assert forecaster.hyperparams.lookback_days == 168  # 7 days * 24 hours
+
+
+def test_base_case_forecaster__different_lookback_hours():
+    """Test that forecaster respects different lookback_hours hyperparameter."""
+    # Arrange
+    # Create 4 weeks of data
+    weeks = 4
+    hours = weeks * 7 * 24
+    dates = pd.date_range(
+        start=datetime.fromisoformat("2025-01-01T00:00:00"),
+        periods=hours,
+        freq="1h"
+    )
+
+    # Create data with predictable values based on week number
+    load_values = []
+    for timestamp in dates:
+        week_number = (timestamp - dates[0]).days // 7 + 1
+        load_values.append(week_number * 100.0)  # Week 1: 100, Week 2: 200, etc.
+
+    data = pd.DataFrame({"load": load_values}, index=dates)
+    input_dataset = ForecastInputDataset(
+        data=data,
+        sample_interval=timedelta(hours=1),
+        target_column="load",
+        forecast_start=datetime.fromisoformat("2025-01-22T00:00:00"),  # Start of week 4
+    )
+
+    # Test with 14 days (336 hours) lookback
+    config_14days = BaseCaseForecasterConfig(
+        quantiles=[Quantile(0.5)],
+        horizons=[LeadTime(timedelta(hours=1))],
+        hyperparams=BaseCaseForecasterHyperParams(lookback_days=336),  # 14 days * 24 hours
+    )
+
+    forecaster = BaseCaseForecaster(config=config_14days)
+    forecaster.fit(input_dataset)
+
+    # Act
+    result = forecaster.predict(input_dataset)
+
+    # Assert
+    # Should predict values from 14 days ago (week 2 values = 200.0)
+    first_prediction = result.data.iloc[0]["quantile_P50"]
+    assert first_prediction == 200.0  # Week 2 value
+
+
+@pytest.fixture
+def multi_horizon_config() -> MultiHorizonForecasterConfig[BaseCaseForecasterConfig]:
+    """Create multi-horizon forecaster configuration for testing."""
+    return MultiHorizonForecasterConfig[BaseCaseForecasterConfig](
+        horizons=[LeadTime(timedelta(hours=3)), LeadTime(timedelta(hours=6))],
+        quantiles=[Quantile(0.5)],
+        forecaster_config=BaseCaseForecasterConfig(
+            quantiles=[Quantile(0.5)],
+            horizons=[LeadTime(timedelta(hours=1))],  # Will be overridden
+            hyperparams=BaseCaseForecasterHyperParams(lookback_days=168),  # 7 days * 24 hours
+        ),
+    )
+
+
+@pytest.fixture
+def multi_horizon_input_data() -> dict[LeadTime, ForecastInputDataset]:
+    """Create horizon-specific input data for multi-horizon testing."""
+    # Create 2 weeks of hourly data
+    hours = 14 * 24
+    dates = pd.date_range(
+        start=datetime.fromisoformat("2025-01-01T00:00:00"),
+        periods=hours,
+        freq="1h"
+    )
+
+    # Create different load patterns for different horizons
+    base_load = [100.0 + i for i in range(hours)]  # Increasing trend
+
+    horizon_3h_data = pd.DataFrame(
+        {"load": [val * 1.1 for val in base_load]},  # 10% higher
+        index=dates
+    )
+
+    horizon_6h_data = pd.DataFrame(
+        {"load": [val * 1.2 for val in base_load]},  # 20% higher
+        index=dates
+    )
+
+    return {
+        LeadTime(timedelta(hours=3)): ForecastInputDataset(
+            data=horizon_3h_data,
+            sample_interval=timedelta(hours=1),
+            target_column="load",
+            forecast_start=datetime.fromisoformat("2025-01-08T00:00:00"),
+        ),
+        LeadTime(timedelta(hours=6)): ForecastInputDataset(
+            data=horizon_6h_data,
+            sample_interval=timedelta(hours=1),
+            target_column="load",
+            forecast_start=datetime.fromisoformat("2025-01-08T00:00:00"),
+        ),
+    }
+
+
+def test_base_case_forecaster__minimal_config():
+    """Test that forecaster works with minimal configuration."""
+    # Arrange
+    config = BaseCaseForecasterConfig(
+        quantiles=[Quantile(0.5)],
+        horizons=[LeadTime(timedelta(hours=1))],
+    )
+    forecaster = BaseCaseForecaster(config=config)
+
+    # Create minimal test data
+    data = pd.DataFrame(
+        {"load": [100.0, 110.0]},
+        index=pd.date_range(
+            start=datetime.fromisoformat("2025-01-01T00:00:00"),
+            periods=2,
+            freq="1h"
+        )
+    )
+    input_dataset = ForecastInputDataset(
+        data=data,
+        sample_interval=timedelta(hours=1),
+        target_column="load"
+    )
+
+    # Act
+    forecaster.fit(input_dataset)
+
+    # Assert
+    assert forecaster.is_fitted
+    assert forecaster.config.hyperparams.lookback_days == 168  # Default value (7 days * 24 hours)
+    assert len(forecaster.config.quantiles) == 1  # Single quantile
+    assert forecaster.config.quantiles[0] == Quantile(0.5)  # Median

--- a/packages/openstef-models/tests/unit/models/forecasting/test_base_case_forecaster.py
+++ b/packages/openstef-models/tests/unit/models/forecasting/test_base_case_forecaster.py
@@ -86,9 +86,8 @@ def test_base_case_forecaster__fit_predict(
     assert isinstance(result, ForecastDataset)
 
     # Should have predictions for all periods from forecast_start onward
-    forecast_start = datetime.fromisoformat("2025-01-08T00:00:00")
-    expected_periods = len([t for t in sample_forecast_input_dataset.index if t >= forecast_start])
-    assert len(result.data) == expected_periods
+    expected_index = sample_forecast_input_dataset.input_data(start=sample_forecast_input_dataset.forecast_start).index
+    pd.testing.assert_index_equal(result.index, expected_index)
 
     # Check that predictions use lag features correctly
     # The forecaster should have detected the 7-day lag column


### PR DESCRIPTION
This pull request introduces a new baseline forecasting model, `BaseCaseForecaster`, to the OpenSTEF project. The model predicts energy load using lag features (typically 7-day and 14-day lags) and provides quantile-based confidence intervals. Comprehensive unit tests are included to verify its behavior, configuration, and error handling.

### New Base Case Forecasting Model

* Added `BaseCaseForecaster` in `base_case_forecaster.py`, which predicts future load using lag features (default: 7-day primary lag, 14-day fallback lag) and computes quantile confidence intervals based on hourly standard deviation. The forecaster auto-detects lag columns and falls back to the 14-day lag when the primary lag is unavailable, matching legacy behavior.
* Introduced configuration classes `BaseCaseForecasterConfig` and `BaseCaseForecasterHyperParams` to allow flexible lag and quantile setup.

### Unit Test Coverage

* Added a comprehensive test suite for `BaseCaseForecaster` in `test_base_case_forecaster.py`, covering fitting, prediction, fallback logic, error handling for missing lag columns, configuration properties, state serialization/restoration, and minimal configuration.

### Error Handling and Serialization

* Implemented error handling for missing lag columns, raising `MissingColumnsError` if neither primary nor fallback lag columns are available. [[1]](diffhunk://#diff-77189bbbd06c3d0932125b578b40128947f165aa7ae34c79aed6a5a41553e24eR1-R305) [[2]](diffhunk://#diff-77420773b8b7690563afd8a9893799a56568817dbb749813798a056fc21bd98cR1-R310)
* Added support for forecaster state serialization and restoration, enabling model persistence and reproducibility. [[1]](diffhunk://#diff-77189bbbd06c3d0932125b578b40128947f165aa7ae34c79aed6a5a41553e24eR1-R305) [[2]](diffhunk://#diff-77420773b8b7690563afd8a9893799a56568817dbb749813798a056fc21bd98cR1-R310)