### PR TITLE
feature: add get window versioned in backtest to allow backtesting with versioned data.

### DIFF
--- a/packages/openstef-beam/src/openstef_beam/backtesting/backtest_pipeline.py
+++ b/packages/openstef-beam/src/openstef_beam/backtesting/backtest_pipeline.py
@@ -24,7 +24,6 @@ from openstef_beam.backtesting.backtest_forecaster.mixins import BacktestBatchFo
 from openstef_beam.backtesting.restricted_horizon_timeseries import RestrictedHorizonVersionedTimeSeries
 from openstef_core.base_model import BaseConfig
 from openstef_core.datasets import VersionedTimeSeriesDataset, VersionedTimeSeriesPart
-from openstef_core.datasets.mixins import VersionedTimeSeriesMixin
 
 _logger = logging.getLogger(__name__)
 
@@ -182,14 +181,14 @@ class BacktestPipeline:
             sample_interval=self.config.prediction_sample_interval,
         )
 
-    def _process_train_event(self, event: BacktestEvent, dataset: VersionedTimeSeriesMixin) -> None:
+    def _process_train_event(self, event: BacktestEvent, dataset: VersionedTimeSeriesDataset) -> None:
         """Process a single training event."""
         horizon_dataset = RestrictedHorizonVersionedTimeSeries(dataset=dataset, horizon=event.timestamp)
         self.forecaster.fit(horizon_dataset)
         _logger.debug("Processed train event", extra={"event": event})
 
     def _process_single_prediction(
-        self, event: BacktestEvent, dataset: VersionedTimeSeriesMixin
+        self, event: BacktestEvent, dataset: VersionedTimeSeriesDataset
     ) -> list[VersionedTimeSeriesPart]:
         """Process a single prediction event.
 
@@ -211,7 +210,7 @@ class BacktestPipeline:
             return []
 
     def _process_batch_prediction(
-        self, batch_events: list[BacktestEvent], dataset: VersionedTimeSeriesMixin
+        self, batch_events: list[BacktestEvent], dataset: VersionedTimeSeriesDataset
     ) -> list[VersionedTimeSeriesPart]:
         """Process a batch of prediction events and return valid predictions.
 
@@ -248,7 +247,7 @@ class BacktestPipeline:
     def _process_events(
         self,
         event_factory: BacktestEventGenerator,
-        dataset: VersionedTimeSeriesMixin,
+        dataset: VersionedTimeSeriesDataset,
         batch_size: int | None,
         *,
         show_progress: bool = True,

--- a/packages/openstef-beam/src/openstef_beam/backtesting/restricted_horizon_timeseries.py
+++ b/packages/openstef-beam/src/openstef_beam/backtesting/restricted_horizon_timeseries.py
@@ -10,8 +10,7 @@ by the old implementation. These will redirect to the new V4 implementation.
 
 from datetime import datetime
 
-from openstef_core.datasets import TimeSeriesDataset
-from openstef_core.datasets.mixins import VersionedTimeSeriesMixin
+from openstef_core.datasets import TimeSeriesDataset, VersionedTimeSeriesDataset
 
 
 class RestrictedHorizonVersionedTimeSeries:
@@ -21,7 +20,7 @@ class RestrictedHorizonVersionedTimeSeries:
     while using the new V4 classes underneath.
     """
 
-    def __init__(self, dataset: VersionedTimeSeriesMixin, horizon: datetime) -> None:
+    def __init__(self, dataset: VersionedTimeSeriesDataset, horizon: datetime) -> None:
         """Initialize with dataset and horizon.
 
         Args:
@@ -43,6 +42,16 @@ class RestrictedHorizonVersionedTimeSeries:
             DataFrame with data from the specified window.
         """
         return self.dataset.filter_by_range(start=start, end=end).select_version(available_before=available_before)
+
+    def get_window_versioned(
+        self, start: datetime, end: datetime, available_before: datetime | None = None
+    ) -> VersionedTimeSeriesDataset:
+        """Get data window with horizon restriction.
+
+        Returns:
+            DataFrame with data from the specified window.
+        """
+        return self.dataset.filter_by_range(start=start, end=end, available_before=available_before)
 
 
 __all__ = [

--- a/packages/openstef-core/src/openstef_core/datasets/mixins.py
+++ b/packages/openstef-core/src/openstef_core/datasets/mixins.py
@@ -90,12 +90,16 @@ class VersionedTimeSeriesMixin(TimeSeriesMixin):
     """
 
     @abstractmethod
-    def filter_by_range(self, start: datetime | None = None, end: datetime | None = None) -> Self:
+    def filter_by_range(
+        self, start: datetime | None = None, end: datetime | None = None, available_before: datetime | None = None
+    ) -> Self:
         """Filter the dataset to include only data within the specified time range.
 
         Args:
             start: The inclusive start time of the range. If None, no start boundary is applied.
             end: The exclusive end time of the range. If None, no end boundary is applied.
+            available_before: Optional cutoff time for data availability. If provided, only data
+                available before this time will be included.
 
         Returns:
             A new instance of the same type containing only data within [start, end).

--- a/packages/openstef-core/src/openstef_core/datasets/versioned_timeseries/dataset.py
+++ b/packages/openstef-core/src/openstef_core/datasets/versioned_timeseries/dataset.py
@@ -217,12 +217,16 @@ class VersionedTimeSeriesDataset(VersionedTimeSeriesMixin, StoreableDatasetMixin
         return cls(data_parts=[part])
 
     @override
-    def filter_by_range(self, start: datetime | None = None, end: datetime | None = None) -> Self:
+    def filter_by_range(
+        self, start: datetime | None = None, end: datetime | None = None, available_before: datetime | None = None
+    ) -> Self:
         start_idx, end_idx = unsafe_sorted_range_slice_idxs(data=cast(pd.Series, self.index), start=start, end=end)
         index = self.index[start_idx:end_idx]
 
         return self.__class__(
-            data_parts=[part.filter_by_range(start, end) for part in self.data_parts],
+            data_parts=[
+                part.filter_by_range(start, end, available_before=available_before) for part in self.data_parts
+            ],
             index=index,
         )
 

--- a/packages/openstef-core/src/openstef_core/datasets/versioned_timeseries/dataset_part.py
+++ b/packages/openstef-core/src/openstef_core/datasets/versioned_timeseries/dataset_part.py
@@ -148,9 +148,14 @@ class VersionedTimeSeriesPart(VersionedTimeSeriesMixin, StoreableDatasetMixin):
         self.feature_names = list(set(self.data.columns) - {self.timestamp_column, self.available_at_column})
 
     @override
-    def filter_by_range(self, start: datetime | None = None, end: datetime | None = None) -> Self:
+    def filter_by_range(
+        self, start: datetime | None = None, end: datetime | None = None, available_before: datetime | None = None
+    ) -> Self:
         start_idx, end_idx = unsafe_sorted_range_slice_idxs(data=self.data[self.timestamp_column], start=start, end=end)
         data_filtered = self.data.iloc[start_idx:end_idx]
+        if available_before is not None:
+            data_filtered = data_filtered[data_filtered[self.available_at_column] <= available_before]
+
         return self._copy_with_data(data_filtered)
 
     @override


### PR DESCRIPTION
This pull request refactors the backtesting pipeline and related classes to consistently use the `VersionedTimeSeriesDataset` type instead of the more generic `VersionedTimeSeriesMixin`. It also extends dataset filtering capabilities to support filtering by data availability time (`available_before`). These changes improve type safety, clarity, and enable more precise control over the data used in backtesting.

**Type consistency and API improvements:**

* Updated all relevant method signatures and class initializations in `backtest_pipeline.py` and `restricted_horizon_timeseries.py` to use `VersionedTimeSeriesDataset` instead of `VersionedTimeSeriesMixin`, ensuring consistent and explicit typing throughout the backtesting code. [[1]](diffhunk://#diff-8f02d2a7d37fc84fb8dd733c9163dbf5822740f67c34f3d45ee9bc1e10ece6c8L27) [[2]](diffhunk://#diff-8f02d2a7d37fc84fb8dd733c9163dbf5822740f67c34f3d45ee9bc1e10ece6c8L185-R191) [[3]](diffhunk://#diff-8f02d2a7d37fc84fb8dd733c9163dbf5822740f67c34f3d45ee9bc1e10ece6c8L214-R213) [[4]](diffhunk://#diff-8f02d2a7d37fc84fb8dd733c9163dbf5822740f67c34f3d45ee9bc1e10ece6c8L251-R250) [[5]](diffhunk://#diff-bb3c82239a31a3e75a87b6852ba41fce5e3afe3bde23f9751dc19ec6533d4c22L13-R13) [[6]](diffhunk://#diff-bb3c82239a31a3e75a87b6852ba41fce5e3afe3bde23f9751dc19ec6533d4c22L24-R23)

**Filtering enhancements:**

* Extended the `filter_by_range` method in `VersionedTimeSeriesMixin`, `VersionedTimeSeriesDataset`, and `VersionedTimeSeriesPart` to accept an optional `available_before` parameter, allowing data to be filtered by its availability timestamp in addition to the time range. [[1]](diffhunk://#diff-b2ca566b22af6ef0f99010b58f0b2ee413623ad638222fd899c3d6e18fec8c0fL93-R102) [[2]](diffhunk://#diff-36e49b60f274fc309d63b96b7e995a59e4f61611aa20b73916a7311207d690b9L220-R229) [[3]](diffhunk://#diff-8c26a969e69c2b6c52c40308272c2066a45cb9c4b63d237c6f841ea811f0ccbaL151-R158)
* Added a new method `get_window_versioned` to `RestrictedHorizonVersionedTimeSeries` to return a filtered `VersionedTimeSeriesDataset` using both time range and availability restriction.

These changes collectively improve the robustness and flexibility of the backtesting pipeline by enforcing stricter typing and enabling more granular data selection.