### PR TITLE
fix: Fixed various warnings during tests.

### DIFF
--- a/packages/openstef-core/src/openstef_core/datasets/multi_horizon_dataset.py
+++ b/packages/openstef-core/src/openstef_core/datasets/multi_horizon_dataset.py
@@ -52,11 +52,11 @@ class MultiHorizon[T: TimeSeriesDataset](UserDict[LeadTime, T], TimeSeriesMixin,
         >>> # Create sample datasets for two horizons
         >>> data_1h = pd.DataFrame({
         ...     'load': [100, 110],
-        ... }, index=pd.date_range('2025-01-01', periods=2, freq='1H'))
+        ... }, index=pd.date_range('2025-01-01', periods=2, freq='1h'))
         >>> dataset_1h = TimeSeriesDataset(data_1h, sample_interval=timedelta(hours=1))
         >>> data_24h = pd.DataFrame({
         ...     'load': [120, 130],
-        ... }, index=pd.date_range('2025-01-01', periods=2, freq='1H'))
+        ... }, index=pd.date_range('2025-01-01', periods=2, freq='1h'))
         >>> dataset_24h = TimeSeriesDataset(data_24h, sample_interval=timedelta(hours=1))
         >>> # Create MultiHorizon mapping
         >>> horizons = MultiHorizon({

--- a/packages/openstef-models/src/openstef_models/models/forecasting/gblinear_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/gblinear_forecaster.py
@@ -184,7 +184,7 @@ class GBLinearForecaster(HorizonForecaster):
             feature_selector=self._config.hyperparams.feature_selector,
             updater=self._config.hyperparams.updater,
             quantile_alpha=[float(q) for q in self._config.quantiles],
-            top_k=self._config.hyperparams.top_k,
+            top_k=self._config.hyperparams.top_k if self._config.hyperparams.feature_selector == "thrifty" else None,
         )
 
     @property

--- a/packages/openstef-models/src/openstef_models/utils/loss_functions.py
+++ b/packages/openstef-models/src/openstef_models/utils/loss_functions.py
@@ -50,9 +50,10 @@ def pinball_loss_magnitude_weighted_multi_objective(
             to different samples in the loss computation.
 
     Returns:
-        tuple: (gradient, hessian) arrays flattened for XGBoost multi-output format
-            - gradient: First derivative scaled by error magnitude, normalized by n_quantiles
-            - hessian: Constant positive values for numerical stability, normalized by n_quantiles
+        tuple: (gradient, hessian) arrays in 2D format for XGBoost multi-output
+            - gradient: First derivative scaled by error magnitude, shape (n_samples, n_quantiles)
+            - hessian: Constant positive values for numerical stability, shape (n_samples, n_quantiles)
+            Both arrays are normalized by n_quantiles for consistent loss values.
 
     Mathematical Formulation:
         Standard pinball loss gradient: ∇L = (τ - I(error < 0))
@@ -101,8 +102,8 @@ def pinball_loss_magnitude_weighted_multi_objective(
         gradient *= sample_weight
         hessian *= sample_weight
 
-    # Normalize by number of quantiles for consistent loss value.
-    return gradient.flatten() / n_quantiles, hessian.flatten() / n_quantiles
+    # Shape: (n_samples, n_quantiles) for proper multi-output format
+    return gradient / n_quantiles, hessian / n_quantiles
 
 
 def arctan_loss_multi_objective(
@@ -135,9 +136,10 @@ def arctan_loss_multi_objective(
            to standard pinball loss but reduce second derivative magnitude.
 
     Returns:
-        tuple: (gradient, hessian) arrays flattened and normalized for XGBoost multi-output
-            - gradient: First derivative of arctan pinball loss, normalized by n_quantiles
-            - hessian: Second derivative of arctan pinball loss, normalized by n_quantiles
+        tuple: (gradient, hessian) arrays in 2D format for XGBoost multi-output
+            - gradient: First derivative of arctan pinball loss, shape (n_samples, n_quantiles)
+            - hessian: Second derivative of arctan pinball loss, shape (n_samples, n_quantiles)
+            Both arrays are normalized by n_quantiles for consistent optimization dynamics.
 
     Mathematical Formulation:
         Loss function: L^(arctan)_τ,s(u) = (τ - 0.5 + arctan(u/s)/π) * u + s/π
@@ -201,8 +203,8 @@ def arctan_loss_multi_objective(
         grad *= sample_weight
         hess *= sample_weight
 
-    # Flatten arrays back to original XGBoost format
-    return -grad.flatten() / n_quantiles, hess.flatten() / n_quantiles
+    # Shape: (n_samples, n_quantiles) for proper multi-output format
+    return -grad / n_quantiles, hess / n_quantiles
 
 
 def pinball_loss_multi_objective(
@@ -237,9 +239,10 @@ def pinball_loss_multi_objective(
             to different samples in the loss computation.
 
     Returns:
-        tuple: (gradient, hessian) arrays flattened for XGBoost multi-output format
-            - gradient: First derivative of pinball loss, normalized by n_quantiles
-            - hessian: Constant positive values for numerical stability, normalized by n_quantiles
+        tuple: (gradient, hessian) arrays in 2D format for XGBoost multi-output
+            - gradient: First derivative of pinball loss, shape (n_samples, n_quantiles)
+            - hessian: Constant positive values for numerical stability, shape (n_samples, n_quantiles)
+            Both arrays are normalized by n_quantiles for consistent loss values.
 
     Mathematical Formulation:
         Standard pinball loss gradient: ∇L = -τ * I(error < 0) + (1 - τ) * I(error >= 0)
@@ -281,8 +284,8 @@ def pinball_loss_multi_objective(
         gradient *= sample_weight
         hessian *= sample_weight
 
-    # Normalize by number of quantiles for consistent loss value.
-    return gradient.flatten() / n_quantiles, hessian.flatten() / n_quantiles
+    # Shape: (n_samples, n_quantiles) for proper multi-output format
+    return gradient / n_quantiles, hessian / n_quantiles
 
 
 type ObjectiveFunctionType = Literal["pinball_loss_magnitude_weighted", "pinball_loss", "arctan_loss"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,12 @@ markers = [
   "integration: marks integration tests",
   "slow: marks slow-running tests",
 ]
+filterwarnings = [
+  # Ignore fork() deprecation warning from multiprocessing on macOS
+  # This warning occurs when pytest (multi-threaded) spawns processes using fork()
+  # Using spawn instead breaks test infrastructure (fixtures not picklable)
+  "ignore:This process.*is multi-threaded.*use of fork.*may lead to deadlocks:DeprecationWarning",
+]
 
 [tool.coverage.report]
 fail_under = 20
@@ -244,7 +250,7 @@ args = [
 
 [tool.poe.tasks.doctests]
 help = "Run all docstring examples via pytest’s doctest plugin"
-cmd = "pytest --numprocesses=auto --doctest-modules packages/*/src --maxfail=1 --disable-warnings"
+cmd = "pytest --numprocesses=auto --doctest-modules packages/*/src --maxfail=1"
 
 [tool.poe.tasks.report]
 help = "Generate coverage report. Will use data from a previous cover command."


### PR DESCRIPTION
This pull request refactors the custom quantile loss functions used for XGBoost multi-output forecasting to consistently return gradients and Hessians in 2D array format (shape `(n_samples, n_quantiles)`), rather than flattened 1D arrays. It also updates all associated docstrings, test cases, and validation logic to match the new format, improving clarity and correctness for downstream consumers. Additionally, it fixes a bug in the GBLinearForecaster's feature selection logic and updates integration tests to avoid R² warnings with small datasets.

**Loss function API and documentation improvements:**

* All custom loss functions (`pinball_loss_multi_objective`, `arctan_loss_multi_objective`, and `pinball_loss_magnitude_weighted_multi_objective` in `loss_functions.py`) now return gradients and Hessians as 2D arrays, with updated docstrings explaining the new shapes and normalization. [[1]](diffhunk://#diff-4b74bf8fb91af0e8d92f246a3a6ba11fab16e2e84a0753c65780109288efa5b6L53-R56) [[2]](diffhunk://#diff-4b74bf8fb91af0e8d92f246a3a6ba11fab16e2e84a0753c65780109288efa5b6L104-R106) [[3]](diffhunk://#diff-4b74bf8fb91af0e8d92f246a3a6ba11fab16e2e84a0753c65780109288efa5b6L138-R142) [[4]](diffhunk://#diff-4b74bf8fb91af0e8d92f246a3a6ba11fab16e2e84a0753c65780109288efa5b6L204-R207) [[5]](diffhunk://#diff-4b74bf8fb91af0e8d92f246a3a6ba11fab16e2e84a0753c65780109288efa5b6L240-R245) [[6]](diffhunk://#diff-4b74bf8fb91af0e8d92f246a3a6ba11fab16e2e84a0753c65780109288efa5b6L284-R288)

**Test suite updates for new loss function format:**

* All relevant unit tests in `test_loss_functions.py` have been updated to expect and validate 2D array outputs, including shape assertions, comparison logic, and flattening for certain checks. This ensures robust coverage and compatibility with the new loss function API. [[1]](diffhunk://#diff-01027f1060f6baf5f4ac70361a8adb112671ec1deb466e098b2878eda42437ccL35-R39) [[2]](diffhunk://#diff-01027f1060f6baf5f4ac70361a8adb112671ec1deb466e098b2878eda42437ccL62-R69) [[3]](diffhunk://#diff-01027f1060f6baf5f4ac70361a8adb112671ec1deb466e098b2878eda42437ccL92-R96) [[4]](diffhunk://#diff-01027f1060f6baf5f4ac70361a8adb112671ec1deb466e098b2878eda42437ccL110-R118) [[5]](diffhunk://#diff-01027f1060f6baf5f4ac70361a8adb112671ec1deb466e098b2878eda42437ccL171-R175) [[6]](diffhunk://#diff-01027f1060f6baf5f4ac70361a8adb112671ec1deb466e098b2878eda42437ccL188-R193) [[7]](diffhunk://#diff-01027f1060f6baf5f4ac70361a8adb112671ec1deb466e098b2878eda42437ccL205-R211) [[8]](diffhunk://#diff-01027f1060f6baf5f4ac70361a8adb112671ec1deb466e098b2878eda42437ccL252-R260) [[9]](diffhunk://#diff-01027f1060f6baf5f4ac70361a8adb112671ec1deb466e098b2878eda42437ccL274-R293) [[10]](diffhunk://#diff-01027f1060f6baf5f4ac70361a8adb112671ec1deb466e098b2878eda42437ccL304-R315) [[11]](diffhunk://#diff-01027f1060f6baf5f4ac70361a8adb112671ec1deb466e098b2878eda42437ccR337-R356)

**Forecaster logic bug fix:**

* In `gblinear_forecaster.py`, the `top_k` hyperparameter is now only set when the feature selector is `"thrifty"`, preventing unintended behavior for other selectors.

**Integration test robustness improvements:**

* Integration tests in `test_mlflow_storage_callback.py` now disable train/val/test splitting for small datasets to avoid R² warnings, using `DataSplitStrategy` and `StratifiedTrainTestSplitter` with zero test fractions. [[1]](diffhunk://#diff-642fa57a1247d98901dc85b55459667fa2f780907295108dce1b2ccf57dea474R15) [[2]](diffhunk://#diff-642fa57a1247d98901dc85b55459667fa2f780907295108dce1b2ccf57dea474R107-R115) [[3]](diffhunk://#diff-642fa57a1247d98901dc85b55459667fa2f780907295108dce1b2ccf57dea474R256-R263)

**Minor docstring and example corrections:**

* The pandas frequency string in the `MultiHorizon` dataset example is corrected from `'1H'` to `'1h'` for consistency with pandas conventions.