### PR TITLE
feature: Add sample weighted rCRPS

### DIFF
--- a/packages/openstef-beam/src/openstef_beam/benchmarking/benchmarks/liander2024.py
+++ b/packages/openstef-beam/src/openstef_beam/benchmarking/benchmarks/liander2024.py
@@ -25,7 +25,13 @@ from openstef_beam.benchmarking.models.benchmark_target import BenchmarkTarget
 from openstef_beam.benchmarking.storage.base import BenchmarkStorage
 from openstef_beam.benchmarking.target_provider import SimpleTargetProvider
 from openstef_beam.evaluation import EvaluationConfig, Window
-from openstef_beam.evaluation.metric_providers import MetricProvider, PeakMetricProvider, RCRPSProvider, RMAEProvider
+from openstef_beam.evaluation.metric_providers import (
+    MetricProvider,
+    PeakMetricProvider,
+    RCRPSProvider,
+    RCRPSSampleWeightedProvider,
+    RMAEProvider,
+)
 from openstef_core.types import AvailableAt, Quantile
 
 type Liander2024Category = Literal["mv_feeder", "station_installation", "transformer", "solar_park", "wind_park"]
@@ -69,6 +75,7 @@ class Liander2024TargetProvider(SimpleTargetProvider[BenchmarkTarget, list[Liand
                 limit_neg=target.lower_limit if target.lower_limit is not None else 0.0,
                 beta=2,
             ),
+            RCRPSSampleWeightedProvider(lower_quantile=0.01, upper_quantile=0.99),
         ]
 
     @override
@@ -123,6 +130,21 @@ LIANDER2024_ANALYSIS_CONFIG = AnalysisConfig(
             metric="rCRPS",
             window=Window(lag=timedelta(hours=0), size=timedelta(days=30)),
         ),
+        WindowedMetricVisualization(
+            name="rCRPS_sample_weighted_windowed_7D",
+            metric="rCRPS_sample_weighted",
+            window=Window(lag=timedelta(hours=0), size=timedelta(days=7)),
+        ),
+        WindowedMetricVisualization(
+            name="rCRPS_sample_weighted_windowed_21D",
+            metric="rCRPS_sample_weighted",
+            window=Window(lag=timedelta(hours=0), size=timedelta(days=21)),
+        ),
+        WindowedMetricVisualization(
+            name="rCRPS_sample_weighted_windowed_30D",
+            metric="rCRPS_sample_weighted",
+            window=Window(lag=timedelta(hours=0), size=timedelta(days=30)),
+        ),
         GroupedTargetMetricVisualization(
             name="rMAE_grouped",
             metric="rMAE",
@@ -131,6 +153,10 @@ LIANDER2024_ANALYSIS_CONFIG = AnalysisConfig(
         GroupedTargetMetricVisualization(
             name="rCRPS_grouped",
             metric="rCRPS",
+        ),
+        GroupedTargetMetricVisualization(
+            name="rCRPS_sample_weighted_grouped",
+            metric="rCRPS_sample_weighted",
         ),
         GroupedTargetMetricVisualization(name="best_f2", metric="effective_F2.0", selector_metric="effective_F2.0"),
         GroupedTargetMetricVisualization(


### PR DESCRIPTION
This pull request introduces a new metric provider, `RCRPSSampleWeightedProvider`, to enhance probabilistic forecast evaluation in the Liander2024 benchmark. The changes integrate this metric into both the computation and visualization pipelines, enabling more robust and sample-weighted rCRPS analysis alongside existing metrics.

**Metric Provider Addition and Integration:**

* Added `RCRPSSampleWeightedProvider` to `metric_providers.py`, which computes a sample-weighted version of rCRPS for probabilistic forecasts. This provider allows for normalization and weighting based on quantile bounds and sample properties.
* Registered `RCRPSSampleWeightedProvider` in the Liander2024 benchmark so it is included in the list of metrics computed for each target. [[1]](diffhunk://#diff-96d1093068a1a85447c8f2ca8e472dbe09f66f66cd7048bb14460ad1bf022babL28-R34) [[2]](diffhunk://#diff-96d1093068a1a85447c8f2ca8e472dbe09f66f66cd7048bb14460ad1bf022babR78)

**Visualization Enhancements:**

* Added new windowed metric visualizations for `rCRPS_sample_weighted` over 7, 21, and 30 day windows, enabling time-based analysis of this new metric.
* Added grouped visualizations for `rCRPS_sample_weighted` to support aggregate analysis across different target groups.