### PR TITLE
feature: Disabled data cutoff by default to be consistent with openstef 3.  And other minor improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,4 +124,4 @@ certificates/
 *.pkl
 
 # Benchmark outputs
-benchmark_results/
+benchmark_results*/

--- a/packages/openstef-models/src/openstef_models/models/forecasting_model.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting_model.py
@@ -129,8 +129,8 @@ class ForecastingModel(BaseModel, Predictor[TimeSeriesDataset, ForecastDataset])
     )
     cutoff_history: timedelta = Field(
         default=timedelta(days=0),
-        description="Amount of historical data to exclude from training due to incomplete features from lag-based "
-        "preprocessing. When using lag transforms (e.g., lag-14), the first N days contain NaN values. "
+        description="Amount of historical data to exclude from training and prediction due to incomplete features "
+        "from lag-based preprocessing. When using lag transforms (e.g., lag-14), the first N days contain NaN values. "
         "Set this to match your maximum lag duration (e.g., timedelta(days=14)). "
         "Default of 0 assumes no invalid rows are created by preprocessing.",
     )

--- a/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
+++ b/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
@@ -43,8 +43,11 @@ from openstef_models.transforms.time_domain import (
 from openstef_models.transforms.time_domain.lags_adder import LagsAdder
 from openstef_models.transforms.time_domain.rolling_aggregates_adder import AggregationFunction
 from openstef_models.transforms.validation import CompletenessChecker, FlatlineChecker, InputConsistencyChecker
-from openstef_models.transforms.weather_domain import DaylightFeatureAdder, RadiationDerivedFeaturesAdder
-from openstef_models.transforms.weather_domain.atmosphere_derived_features_adder import AtmosphereDerivedFeaturesAdder
+from openstef_models.transforms.weather_domain import (
+    AtmosphereDerivedFeaturesAdder,
+    DaylightFeatureAdder,
+    RadiationDerivedFeaturesAdder,
+)
 from openstef_models.utils.data_split import DataSplitter
 from openstef_models.utils.feature_selection import Exclude, FeatureSelection, Include
 from openstef_models.workflows.custom_forecasting_workflow import CustomForecastingWorkflow, ForecastingCallback
@@ -128,6 +131,15 @@ class ForecastingWorkflowConfig(BaseConfig):  # PredictionJob
         default=timedelta(days=14),
         description="Amount of historical data available at prediction time.",
     )
+    cutoff_history: timedelta = Field(
+        default=timedelta(days=0),
+        description="Amount of historical data to exclude from training and prediction due to incomplete features "
+        "from lag-based preprocessing. When using lag transforms (e.g., lag-14), the first N days contain NaN values. "
+        "Set this to match your maximum lag duration (e.g., timedelta(days=14)). "
+        "Default of 0 assumes no invalid rows are created by preprocessing. "
+        "Note: should be same as predict_history if you are using lags. We default to disabled to keep the same "
+        "behaviour as openstef 3.0.",
+    )
 
     # Feature engineering and validation
     completeness_threshold: float = Field(
@@ -162,7 +174,13 @@ class ForecastingWorkflowConfig(BaseConfig):  # PredictionJob
 
     # Data splitting strategy
     data_splitter: DataSplitter = Field(
-        default_factory=DataSplitter,
+        default=DataSplitter(
+            # Copied from OpenSTEF3 pipeline defaults
+            val_fraction=0.15,
+            test_fraction=0.0,
+            stratification_fraction=0.15,
+            min_days_for_stratification=4,
+        ),
         description="Configuration for splitting data into training, validation, and test sets.",
     )
 
@@ -192,6 +210,10 @@ class ForecastingWorkflowConfig(BaseConfig):  # PredictionJob
     model_selection_old_model_penalty: float = Field(
         default=1.2,
         description="Penalty to apply to the old model's metric to bias selection towards newer models.",
+    )
+
+    verbosity: Literal[0, 1, 2, 3, True] = Field(
+        default=1, description="Verbosity level. 0=silent, 1=warning, 2=info, 3=debug"
     )
 
     # Metadata
@@ -278,6 +300,7 @@ def create_forecasting_workflow(config: ForecastingWorkflowConfig) -> CustomFore
                 quantiles=config.quantiles,
                 horizons=config.horizons,
                 hyperparams=config.xgboost_hyperparams,
+                verbosity=config.verbosity,
             )
         )
         postprocessing = [QuantileSorter()]
@@ -294,7 +317,8 @@ def create_forecasting_workflow(config: ForecastingWorkflowConfig) -> CustomFore
                 quantiles=config.quantiles,
                 horizons=config.horizons,
                 hyperparams=config.gblinear_hyperparams,
-            )
+                verbosity=config.verbosity,
+            ),
         )
         postprocessing = []
     elif config.model == "flatliner":
@@ -338,7 +362,7 @@ def create_forecasting_workflow(config: ForecastingWorkflowConfig) -> CustomFore
             postprocessing=TransformPipeline(transforms=postprocessing),
             target_column=config.target_column,
             data_splitter=config.data_splitter,
-            cutoff_history=config.predict_history,
+            cutoff_history=config.cutoff_history,
             # Evaluation
             evaluation_metrics=config.evaluation_metrics,
             # Other

--- a/packages/openstef-models/src/openstef_models/transforms/weather_domain/__init__.py
+++ b/packages/openstef-models/src/openstef_models/transforms/weather_domain/__init__.py
@@ -9,9 +9,12 @@ datasets, including meteorological data preprocessing and weather-based feature
 engineering for improved forecasting accuracy.
 """
 
+from openstef_models.transforms.weather_domain.atmosphere_derived_features_adder import (
+    AtmosphereDerivedFeaturesAdder,
+)
 from openstef_models.transforms.weather_domain.daylight_feature_adder import DaylightFeatureAdder
 from openstef_models.transforms.weather_domain.radiation_derived_features_adder import (
     RadiationDerivedFeaturesAdder,
 )
 
-__all__ = ["DaylightFeatureAdder", "RadiationDerivedFeaturesAdder"]
+__all__ = ["AtmosphereDerivedFeaturesAdder", "DaylightFeatureAdder", "RadiationDerivedFeaturesAdder"]


### PR DESCRIPTION
This pull request introduces several improvements and configuration changes to the forecasting workflow and related modules, focusing on better handling of historical data exclusions, improved verbosity control, and consistent feature import structure. The most notable changes are the addition of a configurable cutoff for historical data to exclude incomplete lag features, updates to default data splitting strategies, and enhanced model verbosity settings.

**Configuration and Workflow Enhancements:**

* Added a new `cutoff_history` field to `ForecastingWorkflowConfig` and updated its usage throughout the workflow to allow exclusion of historical data with incomplete lag-based features, aligning training and prediction logic. (F89051d4L131R131, F89051d4L362R362, [packages/openstef-models/src/openstef_models/models/forecasting_model.pyL132-R133](diffhunk://#diff-538a0b7604196ca0aecc36889d00cb76cfb96910fa4593cc35c8e5979d4251f9L132-R133))
* Updated the default `data_splitter` in `ForecastingWorkflowConfig` to use OpenSTEF3 pipeline defaults for validation and stratification, improving consistency and reproducibility. (F89051d4L174R174)
* Introduced a `verbosity` parameter to `ForecastingWorkflowConfig`, enabling fine-grained control over model logging and diagnostics, and propagated this setting to model instantiation. (F89051d4L212R212, F89051d4L300R300, F89051d4L317R317)

**Code Structure and Imports:**

* Refactored imports in `forecasting_workflow.py` and `weather_domain/__init__.py` to consistently expose `AtmosphereDerivedFeaturesAdder`, ensuring it is available for workflow construction and feature engineering. [[1]](diffhunk://#diff-64a1e38462aac9581ce0cd24dd45e6c0de405f6a1ab401f02ac29d72886c2ee6L46-R50) [[2]](diffhunk://#diff-13d1c2bca3d673f2150a3834c3b250dcd399acac2d20c3a5fcd19270992f352fR12-R20)

**Benchmark Example Updates:**

* Moved the creation of `backtest_config` outside of the workflow factory in the Liander 2024 XGBoost benchmark example, simplifying configuration and improving clarity. [[1]](diffhunk://#diff-99b6f9facef55120137081182b76f28a5f068dc8c1be2ce26526a88d794dad9aR79-R90) [[2]](diffhunk://#diff-99b6f9facef55120137081182b76f28a5f068dc8c1be2ce26526a88d794dad9aL102-L113)
* Added an option to toggle MLFlow storage in the benchmark example, allowing for easier experimentation with or without artifact tracking.