### PR TITLE
fix(STEF-2549): Added none check for model end date from mlflow. Added experiment tags.

### DIFF
--- a/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
+++ b/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
@@ -231,7 +231,11 @@ class ForecastingWorkflowConfig(BaseConfig):  # PredictionJob
     # Metadata
     tags: dict[str, str] = Field(
         default_factory=dict,
-        description="Optional metadata tags for the model.",
+        description="Optional metadata tags for the model run.",
+    )
+    experiment_tags: dict[str, str] = Field(
+        default_factory=dict,
+        description="Optional metadata tags for experiment tracking.",
     )
 
 
@@ -410,4 +414,5 @@ def create_forecasting_workflow(config: ForecastingWorkflowConfig) -> CustomFore
         model_id=config.model_id,
         run_name=config.run_name,
         callbacks=callbacks,
+        experiment_tags=config.experiment_tags,
     )

--- a/packages/openstef-models/src/openstef_models/workflows/custom_forecasting_workflow.py
+++ b/packages/openstef-models/src/openstef_models/workflows/custom_forecasting_workflow.py
@@ -123,6 +123,10 @@ class CustomForecastingWorkflow(BaseModel):
     )
     model_id: ModelIdentifier = Field(...)
     run_name: str | None = Field(default=None, description="Optional name for this workflow run.")
+    experiment_tags: dict[str, str] = Field(
+        default_factory=dict,
+        description="Optional metadata tags for experiment tracking.",
+    )
 
     _logger: logging.Logger = PrivateAttr(default_factory=lambda: logging.getLogger(__name__))
 


### PR DESCRIPTION
This pull request enhances the experiment tracking capabilities by introducing support for separate experiment-level metadata tags throughout the forecasting workflow. It also improves robustness in handling MLflow run end times. The main changes are grouped below:

**Experiment tracking and metadata improvements:**

* Added a new `experiment_tags` field to `ForecastingWorkflowConfig` and `CustomForecastingWorkflow` to allow specifying optional metadata tags specifically for experiment tracking, separate from model run tags. [[1]](diffhunk://#diff-64a1e38462aac9581ce0cd24dd45e6c0de405f6a1ab401f02ac29d72886c2ee6L234-R238) [[2]](diffhunk://#diff-5d8d156e0223e3ef4954243822dd75e00035dca65718a524f70134aa6abb86a5R126-R129)
* Updated the workflow and callback logic to propagate `experiment_tags` through the workflow creation (`create_forecasting_workflow`) and ensure they are passed to MLflow when starting a run. [[1]](diffhunk://#diff-64a1e38462aac9581ce0cd24dd45e6c0de405f6a1ab401f02ac29d72886c2ee6R417) [[2]](diffhunk://#diff-10a8f849ee02ae6d71a92a00de80398031a721b1111595ee0afdaf70d16cfb91R119)

**Robustness improvements:**

* Improved handling of MLflow run end times in `mlflow_storage_callback.py` by checking for `None` values before calculating time differences, preventing potential errors if the end time is missing.