### PR TITLE
feature: add regex pattern matching in FeatureSelection and fix combine bug

### DIFF
--- a/packages/openstef-models/src/openstef_models/utils/feature_selection.py
+++ b/packages/openstef-models/src/openstef_models/utils/feature_selection.py
@@ -7,6 +7,7 @@ Provides standardized feature selection with include/exclude patterns.
 Transforms use this to consistently specify which features to operate on.
 """
 
+import re
 from typing import ClassVar, Self
 
 from pydantic import Field
@@ -17,29 +18,114 @@ from openstef_core.base_model import BaseConfig
 class FeatureSelection(BaseConfig):
     """Standardized feature selection with include/exclude patterns.
 
-    Defines which features a transform should operate on. Features can be
-    specified by inclusion (whitelist) or exclusion (blacklist), or both.
+    Supports both exact matching and regex pattern matching for feature selection.
+    Features can be specified by inclusion (whitelist) or exclusion (blacklist), or both.
     When both are specified, inclusion is applied first, then exclusion.
 
     Use `FeatureSelection.ALL` to select all available features.
+
+    Example:
+        >>> from openstef_models.utils.feature_selection import (
+        ...     FeatureSelection,
+        ...     Include,
+        ...     Exclude,
+        ... )
+        >>>
+        >>> # Select all features
+        >>> all_features = FeatureSelection.ALL
+        >>> all_features.resolve(['a', 'b', 'c'])
+        ['a', 'b', 'c']
+        >>>
+        >>> # Include only specific features (exact match)
+        >>> include_only = Include('a', 'b')
+        >>> include_only.resolve(['a', 'b', 'c', 'd'])
+        ['a', 'b']
+        >>>
+        >>> # Exclude specific features (exact match)
+        >>> exclude_some = Exclude('b', 'd')
+        >>> exclude_some.resolve(['a', 'b', 'c', 'd'])
+        ['a', 'c']
+        >>>
+        >>> # Regex matching
+        >>> regex_sel = FeatureSelection(include_regex={r'^b_.*'})
+        >>> regex_sel.resolve(['b_1', 'b_2', 'c_1'])
+        ['b_1', 'b_2']
+        >>>
+        >>> # Combine exact and regex
+        >>> combined = FeatureSelection(include={'a'}, include_regex={r'^b.*'})
+        >>> combined.resolve(['a', 'b1', 'b2', 'c'])
+        ['a', 'b1', 'b2']
     """
 
     include: set[str] | None = Field(
         default=None,
-        description=("List of feature names to include. Use None to include all features from the input dataset."),
+        description="Set of exact feature names to include. Use None to include all features.",
+        frozen=True,
+    )
+    include_regex: set[str] | None = Field(
+        default=None,
+        description="Set of regex patterns to include features. Use None to include all features.",
         frozen=True,
     )
     exclude: set[str] | None = Field(
         default=None,
-        description="List of feature names to exclude. Use None to exclude no features.",
+        description="Set of exact feature names to exclude. Use None to exclude no features.",
+        frozen=True,
+    )
+    exclude_regex: set[str] | None = Field(
+        default=None,
+        description="Set of regex patterns to exclude features. Use None to exclude no features.",
         frozen=True,
     )
 
     ALL: ClassVar[Self]
     NONE: ClassVar[Self]
 
+    @staticmethod
+    def _matches_regex(feature: str, patterns: set[str]) -> bool:
+        """Check if a feature matches any regex pattern in the set.
+
+        Args:
+            feature: Feature name to check.
+            patterns: Set of regex patterns to match against.
+
+        Returns:
+            True if feature matches any regex pattern.
+        """
+        return any(re.match(pattern, feature) for pattern in patterns)
+
+    def _should_include_feature(self, feature: str) -> bool:
+        """Check if a feature should be included based on include filters.
+
+        Args:
+            feature: Feature name to check.
+
+        Returns:
+            True if feature should be included.
+        """
+        if self.include is None and self.include_regex is None:
+            return True
+        exact_match = self.include is not None and feature in self.include
+        regex_match = self.include_regex is not None and self._matches_regex(feature, self.include_regex)
+        return exact_match or regex_match
+
+    def _should_exclude_feature(self, feature: str) -> bool:
+        """Check if a feature should be excluded based on exclude filters.
+
+        Args:
+            feature: Feature name to check.
+
+        Returns:
+            True if feature should be excluded.
+        """
+        if self.exclude is None and self.exclude_regex is None:
+            return False
+        exact_match = self.exclude is not None and feature in self.exclude
+        regex_match = self.exclude_regex is not None and self._matches_regex(feature, self.exclude_regex)
+        return exact_match or regex_match
+
     def resolve(self, features: list[str]) -> list[str]:
-        """Resolve the final list of features based on include and exclude lists.
+        """Resolve the final list of features based on include and exclude filters.
 
         Args:
             features: List of all available feature names.
@@ -50,8 +136,7 @@ class FeatureSelection(BaseConfig):
         return [
             feature
             for feature in features
-            if (self.include is None or feature in self.include)
-            and (self.exclude is None or feature not in self.exclude)
+            if self._should_include_feature(feature) and not self._should_exclude_feature(feature)
         ]
 
     def combine(self, other: Self | None) -> Self:
@@ -66,14 +151,19 @@ class FeatureSelection(BaseConfig):
         if other is None:
             return self
 
+        def _union(a: set[str] | None, b: set[str] | None) -> set[str] | None:
+            return None if a is None and b is None else (a or set()) | (b or set())
+
         return self.__class__(
-            include=((self.include or set()) | (other.include or set())),
-            exclude=((self.exclude or set()) | (other.exclude or set())),
+            include=_union(self.include, other.include),
+            include_regex=_union(self.include_regex, other.include_regex),
+            exclude=_union(self.exclude, other.exclude),
+            exclude_regex=_union(self.exclude_regex, other.exclude_regex),
         )
 
 
-FeatureSelection.ALL = FeatureSelection(include=None, exclude=None)
-FeatureSelection.NONE = FeatureSelection(include=set(), exclude=None)
+FeatureSelection.ALL = FeatureSelection(include=None, include_regex=None, exclude=None, exclude_regex=None)
+FeatureSelection.NONE = FeatureSelection(include=set(), include_regex=set(), exclude=None, exclude_regex=None)
 
 
 def Include(*features: str) -> FeatureSelection:  # noqa: N802
@@ -85,7 +175,7 @@ def Include(*features: str) -> FeatureSelection:  # noqa: N802
     Returns:
         FeatureSelection instance with specified features included.
     """
-    return FeatureSelection(include={*features}, exclude=None)
+    return FeatureSelection(include={*features}, include_regex=None, exclude=None, exclude_regex=None)
 
 
 def Exclude(*features: str) -> FeatureSelection:  # noqa: N802
@@ -97,4 +187,28 @@ def Exclude(*features: str) -> FeatureSelection:  # noqa: N802
     Returns:
         FeatureSelection instance with specified features excluded.
     """
-    return FeatureSelection(include=None, exclude={*features})
+    return FeatureSelection(include=None, include_regex=None, exclude={*features}, exclude_regex=None)
+
+
+def IncludeRegex(*patterns: str) -> FeatureSelection:  # noqa: N802
+    """Helper to create a FeatureSelection that includes features matching regex patterns.
+
+    Args:
+        *patterns: Regex patterns to include.
+
+    Returns:
+        FeatureSelection instance with specified patterns included.
+    """
+    return FeatureSelection(include=None, include_regex={*patterns}, exclude=None, exclude_regex=None)
+
+
+def ExcludeRegex(*patterns: str) -> FeatureSelection:  # noqa: N802
+    """Helper to create a FeatureSelection that excludes features matching regex patterns.
+
+    Args:
+        *patterns: Regex patterns to exclude.
+
+    Returns:
+        FeatureSelection instance with specified patterns excluded.
+    """
+    return FeatureSelection(include=None, include_regex=None, exclude=None, exclude_regex={*patterns})

--- a/packages/openstef-models/tests/unit/utils/test_feature_selection.py
+++ b/packages/openstef-models/tests/unit/utils/test_feature_selection.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the OpenSTEF project <openstef@lfenergy.org>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for the FeatureSelection utility."""
+
+from openstef_models.utils.feature_selection import (
+    Exclude,
+    ExcludeRegex,
+    FeatureSelection,
+    Include,
+    IncludeRegex,
+)
+
+
+def test_feature_selection_all():
+    """Test FeatureSelection.ALL selects all features."""
+    features = ["a", "b", "c"]
+    assert FeatureSelection.ALL.resolve(features) == features
+
+
+def test_feature_selection_none():
+    """Test FeatureSelection.NONE selects no features."""
+    features = ["a", "b", "c"]
+    assert FeatureSelection.NONE.resolve(features) == []
+
+
+def test_feature_selection_include():
+    """Test including specific features."""
+    selection = Include("a", "c")
+    assert selection.resolve(["a", "b", "c", "d"]) == ["a", "c"]
+
+
+def test_feature_selection_exclude():
+    """Test excluding specific features."""
+    selection = Exclude("b", "d")
+    assert selection.resolve(["a", "b", "c", "d"]) == ["a", "c"]
+
+
+def test_feature_selection_include_and_exclude():
+    """Test combination of include and exclude."""
+    selection = FeatureSelection(include={"a", "b", "c"}, exclude={"b"})
+    assert selection.resolve(["a", "b", "c", "d"]) == ["a", "c"]
+
+
+def test_feature_selection_combine_both_none():
+    """Test combining two ALL selections preserves None."""
+    combined = FeatureSelection.ALL.combine(FeatureSelection.ALL)
+    assert combined.include is None
+    assert combined.exclude is None
+    assert combined.resolve(["a", "b", "c"]) == ["a", "b", "c"]
+
+
+def test_feature_selection_combine_include_sets():
+    """Test combining include sets."""
+    sel1 = Include("a", "b")
+    sel2 = Include("c", "d")
+    combined = sel1.combine(sel2)
+    assert set(combined.resolve(["a", "b", "c", "d", "e"])) == {"a", "b", "c", "d"}
+
+
+def test_feature_selection_combine_mixed():
+    """Test combining selections with different patterns."""
+    sel1 = FeatureSelection(include={"a", "b"}, exclude={"b"})
+    sel2 = FeatureSelection(include={"c"}, exclude={"a"})
+    combined = sel1.combine(sel2)
+    assert combined.include == {"a", "b", "c"}
+    assert combined.exclude == {"a", "b"}
+    assert combined.resolve(["a", "b", "c", "d"]) == ["c"]  # exclusion applied last
+
+
+def test_regex_include_pattern():
+    """Test including features by regex pattern."""
+    selection = IncludeRegex(r"^temp_.*")
+    features = ["temp_sensor", "temp_valve", "pressure_sensor", "humidity"]
+    assert selection.resolve(features) == ["temp_sensor", "temp_valve"]
+
+
+def test_regex_exclude_pattern():
+    """Test excluding features by regex pattern."""
+    selection = ExcludeRegex(r".*_old$")
+    features = ["temp_new", "pressure_old", "humidity_current", "wind_old"]
+    assert selection.resolve(features) == ["temp_new", "humidity_current"]
+
+
+def test_regex_include_and_exclude():
+    """Test combination of include and exclude regex patterns."""
+    selection = FeatureSelection(include_regex={r"^temp_.*", r"^pressure_.*"}, exclude_regex={r".*_old$"})
+    features = ["temp_sensor", "temp_old", "pressure_valve", "humidity_sensor", "pressure_old"]
+    assert selection.resolve(features) == ["temp_sensor", "pressure_valve"]
+
+
+def test_exact_and_regex_include():
+    """Test combining exact and regex include patterns."""
+    selection = FeatureSelection(include={"a"}, include_regex={r"^b.*"})
+    features = ["a", "b1", "b2", "c"]
+    assert set(selection.resolve(features)) == {"a", "b1", "b2"}
+
+
+def test_exact_and_regex_exclude():
+    """Test combining exact and regex exclude patterns."""
+    selection = FeatureSelection(exclude={"a"}, exclude_regex={r"^b.*"})
+    features = ["a", "b1", "b2", "c"]
+    assert selection.resolve(features) == ["c"]
+
+
+def test_combine_exact_and_regex():
+    """Test combining selections with exact and regex patterns."""
+    sel1 = Include("a", "b")
+    sel2 = IncludeRegex(r"^c.*")
+    combined = sel1.combine(sel2)
+    features = ["a", "b", "c1", "c2", "d"]
+    assert set(combined.resolve(features)) == {"a", "b", "c1", "c2"}
+
+
+def test_combine_all_types():
+    """Test combining all types of patterns."""
+    sel1 = FeatureSelection(include={"a"}, exclude_regex={r".*_old$"})
+    sel2 = FeatureSelection(include_regex={r"^temp_.*"}, exclude={"a"})
+    combined = sel1.combine(sel2)
+    features = ["a", "temp_sensor", "temp_old", "pressure"]
+    # include: {a} + regex temp_.*
+    # exclude: {a} + regex .*_old$
+    # So: a excluded, temp_sensor included, temp_old excluded
+    assert combined.resolve(features) == ["temp_sensor"]


### PR DESCRIPTION
This pull request adds support for regex-based feature selection to the `FeatureSelection` utility, allowing users to include or exclude features by exact name or by regex pattern. It also introduces helper functions for regex-based selection and comprehensive unit tests to ensure correct behavior for all combinations of exact and regex filters.

**Feature selection enhancements:**

* Added `include_regex` and `exclude_regex` fields to the `FeatureSelection` class, enabling selection of features using regex patterns as well as exact matches. Updated the logic in `resolve()` to apply these filters, and added helper methods for regex matching. [[1]](diffhunk://#diff-bf263aad2dccf92468dfa549a3749af652d585e052dbaca99db841d2492aeb14L20-R128) [[2]](diffhunk://#diff-bf263aad2dccf92468dfa549a3749af652d585e052dbaca99db841d2492aeb14L53-R139)
* Introduced helper functions `IncludeRegex` and `ExcludeRegex` to easily create `FeatureSelection` instances that use regex patterns for inclusion or exclusion.
* Updated the `combine()` method to correctly merge both exact and regex include/exclude sets from two `FeatureSelection` instances.
* Improved documentation and added usage examples in the class docstring to illustrate the new functionality.

**Testing improvements:**

* Added a new test module `test_feature_selection.py` with comprehensive unit tests covering all combinations of exact and regex include/exclude patterns and their combinations, ensuring robust and correct feature selection behavior.