### PR TITLE
fix: handling no valid data in flatliner check

### DIFF
--- a/packages/openstef-models/src/openstef_models/transforms/validation/flatline_checker.py
+++ b/packages/openstef-models/src/openstef_models/transforms/validation/flatline_checker.py
@@ -97,7 +97,10 @@ class FlatlineChecker(BaseConfig, TimeSeriesTransform):
         Returns:
             Boolean indicating whether or not there is a flatliner ongoing for the given data.
         """
-        latest_measurement_time = cast(pd.Timestamp, data.last_valid_index())
+        last_valid_index = data.last_valid_index()
+        if last_valid_index is None:  # type: ignore[reportUnnecessaryComparison]  # None if no valid data
+            return False
+        latest_measurement_time = cast(pd.Timestamp, last_valid_index)
         start_time = latest_measurement_time - self.flatliner_threshold
         latest_measurements = data[start_time:latest_measurement_time].dropna()
 

--- a/packages/openstef-models/tests/unit/transforms/validation/test_flatline_checker.py
+++ b/packages/openstef-models/tests/unit/transforms/validation/test_flatline_checker.py
@@ -98,6 +98,25 @@ def test_transform_does_not_raise_when_no_flatliner_detected() -> None:
         pytest.fail("FlatlinerDetectedError was raised unexpectedly.")
 
 
+def test_transform_does_not_raise_when_all_nan_load() -> None:
+    # Arrange
+    data = TimeSeriesDataset(
+        data=pd.DataFrame(
+            data={"load": [None, None, None, None]},
+            index=pd.date_range(datetime.fromisoformat("2025-01-01T00:00:00"), periods=4, freq="1h"),
+        ),
+        sample_interval=timedelta(hours=1),
+    )
+
+    transform = FlatlineChecker()
+
+    # Act & Assert
+    try:
+        transform.transform(data)
+    except FlatlinerDetectedError:
+        pytest.fail("FlatlinerDetectedError was raised unexpectedly.")
+
+
 def test_different_load_column_name() -> None:
     # Arrange
     data = TimeSeriesDataset(


### PR DESCRIPTION
Makes sure that checks from `presets` are failing on `CompletenessChecker` rather than on `FlatlinerChecker` with cryptic message: `TypeError: unsupported operand type(s) for -: 'NoneType' and 'datetime.timedelta'`.