### PR TITLE
fix(STEF-2802): skip RollingAggregatesAdder when no aggregation functions

### DIFF
--- a/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
+++ b/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
@@ -305,10 +305,16 @@ def create_forecasting_workflow(config: ForecastingWorkflowConfig) -> CustomFore
         DaylightFeatureAdder(
             coordinate=config.location.coordinate,
         ),
-        RollingAggregatesAdder(
-            feature=config.target_column,
-            aggregation_functions=config.rolling_aggregate_features,
-            horizons=config.horizons,
+        *(
+            [
+                RollingAggregatesAdder(
+                    feature=config.target_column,
+                    aggregation_functions=config.rolling_aggregate_features,
+                    horizons=config.horizons,
+                ),
+            ]
+            if config.rolling_aggregate_features
+            else []
         ),
     ]
     feature_standardizers = [


### PR DESCRIPTION
## Problem

\`RollingAggregatesAdder\` is always added to the forecasting workflow pipeline, even when \`rolling_aggregate_features\` is empty (e.g., for ato_regions and grid_losses origins). While \`transform()\` has an early-return guard for empty aggregation functions, \`fit()\` does not — causing \`pandas.rolling().agg([])\` to raise \`ValueError: No objects to concatenate\`.

## Fix

Conditionally add \`RollingAggregatesAdder\` to the feature_adders list in \`create_forecasting_workflow()\` only when \`config.rolling_aggregate_features\` is non-empty. When empty, the transform is simply not created, avoiding the crash entirely.

## Impact

- Fixes crash for origins configured with \`rolling_aggregate_features=[]\`
- No behavior change for origins that use rolling aggregates
- 313 model tests pass