### PR TITLE
fix(STEF-2802): anchor mlflow gitignore patterns to repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,5 +127,5 @@ certificates/
 benchmark_results*/
 
 # Mlflow
-mlflow
-mlflow_artifacts_local
+/mlflow
+/mlflow_artifacts_local


### PR DESCRIPTION
## Problem

The bare \`mlflow\` pattern in \`.gitignore\` (added in #793 / v4.0.0.a17) matches anywhere in the directory tree. Hatchling uses \`.gitignore\` for VCS-based file exclusion during wheel builds, so \`packages/openstef-models/src/openstef_models/integrations/mlflow/\` was silently dropped from the built wheel.

This caused \`openstef_models.integrations.mlflow\` to be unavailable at runtime since a17 — breaking any downstream code that imports \`MLFlowStorage\`.

## Fix

Root-anchor the patterns: \`mlflow\` → \`/mlflow\`, \`mlflow_artifacts_local\` → \`/mlflow_artifacts_local\`. This limits the match to only the top-level directories (local MLflow data) and no longer excludes the source module.

Also fixes the missing trailing newline.