### PR TITLE
Fix: Correct timedelta conversion in train-test split.

### DIFF
--- a/openstef/model_selection/model_selection.py
+++ b/openstef/model_selection/model_selection.py
@@ -168,7 +168,7 @@ def split_data_train_validation_test(
         data_.index.unique().sort_values()[1] - data_.index.unique().sort_values()[0]
     )  # Delta t, assumed to be constant throughout DataFrame
     delta = timedelta(
-        seconds=delta.seconds
+        seconds=delta.total_seconds()
     )  # Convert from pandas timedelta to original python timedelta
 
     # Determine which dates are in testset


### PR DESCRIPTION
This implementation also works when the delta in the data timestamps is >= 1 day.

Fixes https://github.com/OpenSTEF/openstef/issues/823.