### PR TITLE
fix: apply flatliner value to all quantiles

### DIFF
--- a/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
+++ b/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
@@ -451,13 +451,16 @@ def create_forecasting_workflow(
     elif config.model == "flatliner":
         preprocessing = []
         forecaster = FlatlinerForecaster(
-            quantiles=[Q(0.5)],
+            quantiles=config.quantiles,
             horizons=config.horizons,
             predict_median=config.predict_nonzero_flatliner,
         )
         postprocessing = [
             QuantileSorter(),
-            ConfidenceIntervalApplicator(quantiles=config.quantiles),
+            ConfidenceIntervalApplicator(
+                quantiles=config.quantiles,
+                add_quantiles_from_std=False,
+            ),
         ]
 
     else:


### PR DESCRIPTION
This pull request makes a targeted update to the flatliner forecasting workflow configuration. The main change is to ensure that the quantiles used by the `FlatlinerForecaster` and `ConfidenceIntervalApplicator` are now sourced from the user-provided configuration, and a specific behavior for adding quantiles from standard deviation is explicitly disabled.

**Forecasting workflow configuration updates:**

* The `quantiles` parameter for both `FlatlinerForecaster` and `ConfidenceIntervalApplicator` is now set from `config.quantiles` instead of being hardcoded, making the workflow more flexible and configurable. (`packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py` [packages/openstef-models/src/openstef_models/presets/forecasting_workflow.pyL454-R463](diffhunk://#diff-64a1e38462aac9581ce0cd24dd45e6c0de405f6a1ab401f02ac29d72886c2ee6L454-R463))
* The `ConfidenceIntervalApplicator` is now explicitly configured with `add_quantiles_from_std=False`, ensuring that quantiles are not supplemented from standard deviation calculations. (`packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py` [packages/openstef-models/src/openstef_models/presets/forecasting_workflow.pyL454-R463](diffhunk://#diff-64a1e38462aac9581ce0cd24dd45e6c0de405f6a1ab401f02ac29d72886c2ee6L454-R463))