### PR TITLE
fix: timezone handling for offset in AvailableAt apply() (matching apply_index())

### DIFF
--- a/packages/openstef-core/src/openstef_core/types.py
+++ b/packages/openstef-core/src/openstef_core/types.py
@@ -226,9 +226,14 @@ class AvailableAt(PydanticStringPrimitive):
     def apply(self, date: datetime) -> datetime:
         """Apply this availability offset to a reference date.
 
-        The time-of-day is interpreted in ``self.tzinfo`` (falls back to
-        ``date.tzinfo``).  The result is returned in the reference date's
-        timezone, or naive when the reference date is naive.
+        The day offset is interpreted in ``self.tzinfo`` (falls back to
+        ``date.tzinfo``), so "D-1" means "the previous calendar day in
+        that timezone".  The time-of-day is also placed in that timezone.
+        The result is returned in the reference date's timezone, or naive
+        when the reference date is naive.
+
+        This matches the vectorised :meth:`apply_index` semantics, which
+        converts to ``self.tzinfo`` before extracting the calendar day.
 
         Args:
             date: The reference date to apply the availability offset to.
@@ -237,10 +242,16 @@ class AvailableAt(PydanticStringPrimitive):
             The datetime when data is available, in the reference date's
             timezone (or naive when the reference date is naive).
         """
-        result_date = (date + timedelta(days=self.day_offset)).date()
+        source_tz = self.tzinfo or date.tzinfo
+
+        # Convert reference date to source timezone before extracting the
+        # calendar day.  This ensures "D-1" means "previous day in the
+        # AvailableAt's timezone", consistent with apply_index().
+        working_date = date.astimezone(source_tz) if source_tz is not None and date.tzinfo is not None else date
+
+        result_date = (working_date + timedelta(days=self.day_offset)).date()
         naive_result = datetime.combine(result_date, self.time_of_day)
 
-        source_tz = self.tzinfo or date.tzinfo
         if source_tz is None:
             return naive_result
 

--- a/packages/openstef-core/tests/unit/test_types.py
+++ b/packages/openstef-core/tests/unit/test_types.py
@@ -196,9 +196,11 @@ _AMS = pytz.timezone("Europe/Amsterdam")
         pytest.param(
             AvailableAt(day_offset=-1, time_of_day=time(6, 0), tzinfo=UTC),
             _AMS.localize(datetime(2026, 3, 6)),  # noqa: DTZ001
-            # 06:00 UTC = 07:00 CET (March 5 is still winter time, UTC+1)
-            _AMS.localize(datetime(2026, 3, 5, 7, 0)),  # noqa: DTZ001
-            id="utc_stdlib_tz_ams_ref_returns_ams",
+            # Reference is Mar 6 00:00 CET = Mar 5 23:00 UTC.
+            # Day extracted in UTC (self.tzinfo) → Mar 5, D-1 → Mar 4.
+            # 06:00 UTC on Mar 4 = 07:00 CET (winter time, UTC+1)
+            _AMS.localize(datetime(2026, 3, 4, 7, 0)),  # noqa: DTZ001
+            id="utc_tz_ams_ref_extracts_day_in_utc",
         ),
         pytest.param(
             AvailableAt(day_offset=-1, time_of_day=time(6, 0)),
@@ -226,6 +228,22 @@ _AMS = pytz.timezone("Europe/Amsterdam")
             datetime(2026, 3, 29, tzinfo=UTC),
             datetime(2026, 3, 28, 5, 0, tzinfo=UTC),
             id="ams_to_utc_before_dst_switch",
+        ),
+        # UTC 23:00 ref = CET midnight next day. Day must be extracted in AMS tz.
+        # Jan 10 23:00 UTC = Jan 11 00:00 CET. D-1 → Jan 10. 14:30 CET = 13:30 UTC.
+        pytest.param(
+            AvailableAt(day_offset=-1, time_of_day=time(14, 30), tzinfo=_AMS),
+            datetime(2026, 1, 10, 23, 0, tzinfo=UTC),
+            datetime(2026, 1, 10, 13, 30, tzinfo=UTC),
+            id="ams_d1_ref_utc_23h_cross_day_boundary",
+        ),
+        # D0 with UTC 23:00 ref. Jan 10 23:00 UTC = Jan 11 00:00 CET.
+        # D0 → Jan 11. 23:59 CET = 22:59 UTC.
+        pytest.param(
+            AvailableAt(day_offset=0, time_of_day=time(23, 59), tzinfo=_AMS),
+            datetime(2026, 1, 10, 23, 0, tzinfo=UTC),
+            datetime(2026, 1, 11, 22, 59, tzinfo=UTC),
+            id="ams_d0_ref_utc_23h_cross_day_boundary",
         ),
     ],
 )
@@ -290,14 +308,18 @@ def test_available_at_apply_index_cross_tz_dst():
     """apply_index with AMS tzinfo on UTC index shifts correctly across DST."""
     # Index in UTC, AvailableAt in Europe/Amsterdam
     index = pd.to_datetime([
+        "2026-03-28T23:00:00+00:00",  # cutoff = Mar 28 06:00 CET = 05:00 UTC
+        "2026-03-29T00:00:00+00:00",  # cutoff = Mar 28 06:00 CET = 05:00 UTC
         "2026-03-29T12:00:00+00:00",  # cutoff = Mar 28 06:00 CET = 05:00 UTC
-        "2026-03-30T12:00:00+00:00",  # cutoff = Mar 29 06:00 CEST = 04:00 UTC
+        "2026-03-30T00:00:00+00:00",  # cutoff = Mar 29 06:00 CEST = 04:00 UTC
     ])
     at = AvailableAt(day_offset=-1, time_of_day=time(6, 0), tzinfo=_AMS)
 
     result = at.apply_index(index)
 
     expected = pd.to_datetime([
+        "2026-03-28T05:00:00+00:00",
+        "2026-03-28T05:00:00+00:00",
         "2026-03-28T05:00:00+00:00",
         "2026-03-29T04:00:00+00:00",
     ])
@@ -308,6 +330,8 @@ def test_available_at_apply_index_cross_tz_dst():
 def test_available_at_apply_index_matches_apply():
     """apply_index results should match element-wise apply() calls."""
     index = pd.to_datetime([
+        "2026-03-27T23:00:00+00:00",
+        "2026-03-28T00:00:00+00:00",
         "2026-03-28T12:00:00+00:00",
         "2026-03-29T12:00:00+00:00",
         "2026-03-30T12:00:00+00:00",


### PR DESCRIPTION
This pull request updates the semantics and implementation of the `AvailableAt.apply` method to ensure that day offsets are interpreted in the correct timezone, matching the behavior of the vectorized `apply_index` method. The changes also update and expand the test suite to cover edge cases involving timezone boundaries and daylight saving transitions.

Key changes:

**Core logic and semantics:**

* The docstring and implementation of `AvailableAt.apply` in `types.py` have been updated so that the day offset is always interpreted in `self.tzinfo` (or falls back to `date.tzinfo`), ensuring consistency with `apply_index`. Now, the reference date is converted to the source timezone before applying the day offset, so "D-1" always means "the previous calendar day in that timezone". [[1]](diffhunk://#diff-a5fdd3bb0fdb7e7fda4a88fd6ed02992f205ca1d03765b5be5ebf87867b04239L229-R236) [[2]](diffhunk://#diff-a5fdd3bb0fdb7e7fda4a88fd6ed02992f205ca1d03765b5be5ebf87867b04239L240-L243)

**Test suite improvements:**

* Existing tests in `test_types.py` have been updated to reflect the corrected timezone logic, particularly for cases where the reference and target timezones differ. For example, the expected result for a UTC offset with an Amsterdam reference has been changed to match the new semantics.
* New test cases have been added to explicitly verify behavior when crossing day boundaries between UTC and Amsterdam timezones, both for D-1 and D0 offsets, ensuring correctness around midnight and DST transitions.
* Additional test cases have been added to the vectorized `apply_index` tests to verify correct shifting across DST changes and to ensure that element-wise `apply` matches the vectorized results. [[1]](diffhunk://#diff-760276c5b93cc79ab4961be4ec33d2302f37c2e109d3ef990201de188d8b836bR311-R322) [[2]](diffhunk://#diff-760276c5b93cc79ab4961be4ec33d2302f37c2e109d3ef990201de188d8b836bR333-R334)