### PR TITLE
feature: add helper methods to Quantile and ensure precision safety

### DIFF
--- a/packages/openstef-core/src/openstef_core/types.py
+++ b/packages/openstef-core/src/openstef_core/types.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import re
 from datetime import datetime, time, timedelta
 from datetime import timezone as dt_timezone
+from decimal import Decimal
 from enum import StrEnum
 from functools import total_ordering
 from typing import Any, Literal, Self, override
@@ -297,6 +298,10 @@ class AvailableAt(PydanticStringPrimitive):
 class Quantile(float):
     """A float subclass representing a quantile value between 0 and 1.
 
+    Uses ``Decimal`` arithmetic internally for all conversions
+    so that values like ``Quantile(0.999)`` round-trip exactly through
+    ``format()`` / ``parse()`` and ``to_percentile()`` / ``from_percentile()``.
+
     Example:
         Creating and using quantiles:
 
@@ -312,6 +317,9 @@ class Quantile(float):
         >>> # Non-integer quantiles
         >>> Quantile(0.025).format()
         'quantile_P2.5'
+        >>> # High-precision quantiles
+        >>> Quantile(0.999).format()
+        'quantile_P99.9'
     """
 
     def __new__(cls, value: float) -> Self:
@@ -344,23 +352,31 @@ class Quantile(float):
             serialization=core_schema.plain_serializer_function_ser_schema(float),
         )
 
+    def _percentile_decimal(self) -> Decimal:
+        """Return the percentile as an exact ``Decimal``.
+
+        Uses ``Decimal(str(...))`` to avoid IEEE-754 rounding artefacts
+        that occur with plain ``float * 100``.
+        """
+        return Decimal(str(float(self))) * 100
+
     def format(self) -> str:
         """Instance method to format the quantile as a string.
 
         Returns:
             Formatted quantile string in 'quantile_PXX' format.
         """
-        value = self * 100
+        value = self._percentile_decimal()
+        normalized = value.normalize()
 
         # Check if the value is a whole number
-        if value.is_integer():
-            return f"quantile_P{int(value):02d}"
-        # Format with one decimal place for non-integer values
-        return f"quantile_P{value:.1f}"
+        if normalized == int(normalized):
+            return f"quantile_P{int(normalized):02d}"
+        return f"quantile_P{normalized}"
 
-    @staticmethod
-    def parse(quantile_str: str) -> Quantile:
-        """Static method to parse a quantile string back to a Quantile object.
+    @classmethod
+    def parse(cls, quantile_str: str) -> Self:
+        """Parse a quantile string back to a Quantile object.
 
         Args:
             quantile_str: String in 'quantile_PXX' format.
@@ -374,8 +390,8 @@ class Quantile(float):
         if not quantile_str.startswith("quantile_P"):
             msg = f"Invalid quantile string: {quantile_str}"
             raise ValueError(msg)
-        value = float(quantile_str.split("_P")[1]) / 100
-        return Quantile(value)
+        value = Decimal(quantile_str.split("_P")[1]) / 100
+        return cls(float(value))
 
     @staticmethod
     def is_valid_quantile_string(quantile_str: str) -> bool:
@@ -387,8 +403,39 @@ class Quantile(float):
         Returns:
             True if the string is a valid quantile representation, False otherwise.
         """
-        pattern = r"^quantile_P(\d{1,2}(\.\d)?|100)$"
+        pattern = r"^quantile_P(\d{1,3}(\.\d+)?|100)$"
         return re.match(pattern, quantile_str) is not None
+
+    @classmethod
+    def from_percentile(cls, percentile: float) -> Self:
+        """Create a Quantile from a percentile value.
+
+        Args:
+            percentile: Percentile value between 0 and 100.
+
+        Returns:
+            Quantile corresponding to the given percentile.
+
+        Raises:
+            ValueError: If the percentile is not between 0 and 100.
+        """
+        min_percentile, max_percentile = 0, 100
+        if not (min_percentile <= percentile <= max_percentile):
+            msg = f"Percentile must be between 0 and 100, got {percentile}"
+            raise ValueError(msg)
+        return cls(float(Decimal(str(percentile)) / 100))
+
+    def to_percentile(self) -> float:
+        """Convert this Quantile to a percentile value.
+
+        Returns:
+            Percentile value corresponding to this Quantile.
+        """
+        return float(self._percentile_decimal())
+
+    def inverse(self) -> Self:
+        """Return the complementary quantile (``1 - self``)."""
+        return self.__class__(float(Decimal(1) - Decimal(str(self))))
 
 
 Q = Quantile  # Alias for easier imports

--- a/packages/openstef-core/src/openstef_core/types.py
+++ b/packages/openstef-core/src/openstef_core/types.py
@@ -320,6 +320,9 @@ class Quantile(float):
         >>> # Percentile conversion
         >>> Quantile.from_percentile(99.9).format()
         'quantile_P99.9'
+        >>> # Complementary quantiles
+        >>> Quantile(0.1).complementary()
+        0.9
     """
 
     def __new__(cls, value: float) -> Self:
@@ -433,7 +436,7 @@ class Quantile(float):
         """
         return float(self._percentile_decimal())
 
-    def inverse(self) -> Self:
+    def complementary(self) -> Self:
         """Return the complementary quantile (``1 - self``)."""
         return self.__class__(float(Decimal(1) - Decimal(str(self))))
 

--- a/packages/openstef-core/src/openstef_core/types.py
+++ b/packages/openstef-core/src/openstef_core/types.py
@@ -317,8 +317,8 @@ class Quantile(float):
         >>> # Non-integer quantiles
         >>> Quantile(0.025).format()
         'quantile_P2.5'
-        >>> # High-precision quantiles
-        >>> Quantile(0.999).format()
+        >>> # Percentile conversion
+        >>> Quantile.from_percentile(99.9).format()
         'quantile_P99.9'
     """
 

--- a/packages/openstef-core/tests/unit/test_types.py
+++ b/packages/openstef-core/tests/unit/test_types.py
@@ -410,8 +410,7 @@ def test_quantile_from_percentile_rejects_out_of_range():
 
 def test_quantile_to_percentile_precision():
     """to_percentile() must return exact values despite IEEE-754 float traps."""
-    assert Quantile(0.999).to_percentile() == 99.9
-    assert Quantile(0.1).to_percentile() == 10.0
+    assert str(Quantile(0.999).to_percentile()) == "99.9"
 
 
 @pytest.mark.parametrize(

--- a/packages/openstef-core/tests/unit/test_types.py
+++ b/packages/openstef-core/tests/unit/test_types.py
@@ -452,5 +452,5 @@ def test_quantile_is_valid_quantile_string(quantile_str: str, expected: bool):
         pytest.param(0.999, 0.001, id="q99.9"),
     ],
 )
-def test_quantile_inverse(quantile_value: float, expected_complement: float):
+def test_quantile_complementary(quantile_value: float, expected_complement: float):
     assert Quantile(quantile_value).complementary() == Quantile(expected_complement)

--- a/packages/openstef-core/tests/unit/test_types.py
+++ b/packages/openstef-core/tests/unit/test_types.py
@@ -361,3 +361,90 @@ def test_quantile_serialization_no_warnings():
     assert '"0.05"' in data
     assert '"0.5"' in data
     assert '"global"' in data
+
+
+@pytest.mark.parametrize(
+    ("quantile_value", "expected_format"),
+    [
+        pytest.param(0.5, "quantile_P50", id="integer_percentile"),
+        pytest.param(0.025, "quantile_P2.5", id="fractional_percentile"),
+        pytest.param(0.9999, "quantile_P99.99", id="multi_decimal_precision"),
+    ],
+)
+def test_quantile_format(quantile_value: float, expected_format: str):
+    assert Quantile(quantile_value).format() == expected_format
+
+
+@pytest.mark.parametrize(
+    ("value"),
+    [0.025, 0.1, 0.5, 0.999, 0.9999],
+)
+def test_quantile_format_parse_roundtrip(value: float):
+    """format() → parse() must recover the original value exactly."""
+    q = Quantile(value)
+    assert Quantile.parse(q.format()) == q
+
+
+def test_quantile_parse_rejects_invalid():
+    with pytest.raises(ValueError, match="Invalid quantile string"):
+        Quantile.parse("not_a_quantile")
+
+
+@pytest.mark.parametrize(
+    ("percentile", "expected_quantile"),
+    [
+        pytest.param(50, 0.5, id="integer_percentile"),
+        pytest.param(99.9, 0.999, id="fractional_percentile"),
+        pytest.param(2.5, 0.025, id="small_fractional"),
+    ],
+)
+def test_quantile_from_percentile(percentile: float, expected_quantile: float):
+    result = Quantile.from_percentile(percentile)
+    assert result == Quantile(expected_quantile)
+
+
+def test_quantile_from_percentile_rejects_out_of_range():
+    with pytest.raises(ValueError, match="Percentile must be between 0 and 100"):
+        Quantile.from_percentile(101)
+
+
+def test_quantile_to_percentile_precision():
+    """to_percentile() must return exact values despite IEEE-754 float traps."""
+    assert Quantile(0.999).to_percentile() == 99.9
+    assert Quantile(0.1).to_percentile() == 10.0
+
+
+@pytest.mark.parametrize(
+    ("percentile"),
+    [2.5, 10, 50, 99.9, 99.99],
+)
+def test_quantile_percentile_roundtrip(percentile: float):
+    """from_percentile() → to_percentile() must recover the original value."""
+    assert Quantile.from_percentile(percentile).to_percentile() == percentile
+
+
+@pytest.mark.parametrize(
+    ("quantile_value"),
+    [-1.0, 1.1],
+)
+def test_quantile_rejects_out_of_range(quantile_value: float):
+    with pytest.raises(ValueError, match="Quantile must be between 0 and 1"):
+        Quantile(quantile_value)
+
+
+@pytest.mark.parametrize(
+    ("quantile_str", "expected"),
+    [
+        ("quantile_P50", True),
+        ("quantile_P99.99", True),
+        ("not_quantile", False),
+    ],
+)
+def test_quantile_is_valid_quantile_string(quantile_str: str, expected: bool):
+    assert Quantile.is_valid_quantile_string(quantile_str) == expected
+
+
+def test_quantile_inverse():
+    assert Quantile(0.1).inverse() == Quantile(0.9)
+    assert Quantile(0.025).inverse() == Quantile(0.975)
+    assert Quantile(0.5).inverse() == Quantile(0.5)

--- a/packages/openstef-core/tests/unit/test_types.py
+++ b/packages/openstef-core/tests/unit/test_types.py
@@ -443,7 +443,14 @@ def test_quantile_is_valid_quantile_string(quantile_str: str, expected: bool):
     assert Quantile.is_valid_quantile_string(quantile_str) == expected
 
 
-def test_quantile_inverse():
-    assert Quantile(0.1).inverse() == Quantile(0.9)
-    assert Quantile(0.025).inverse() == Quantile(0.975)
-    assert Quantile(0.5).inverse() == Quantile(0.5)
+@pytest.mark.parametrize(
+    ("quantile_value", "expected_complement"),
+    [
+        pytest.param(0.1, 0.9, id="q10"),
+        pytest.param(0.025, 0.975, id="q2.5"),
+        pytest.param(0.5, 0.5, id="q50"),
+        pytest.param(0.999, 0.001, id="q99.9"),
+    ],
+)
+def test_quantile_inverse(quantile_value: float, expected_complement: float):
+    assert Quantile(quantile_value).complementary() == Quantile(expected_complement)


### PR DESCRIPTION
This pull request significantly improves the precision and robustness of the `Quantile` type in `openstef_core/types.py` by switching to `Decimal` arithmetic for all conversions and string formatting, and by adding new utility methods. Comprehensive unit tests have been added to ensure correct behavior and to cover edge cases.

**Precision improvements and new features for `Quantile`:**

* Switched all internal arithmetic in `Quantile` to use `Decimal`, ensuring that values like `Quantile(0.999)` round-trip exactly through `format()`, `parse()`, `to_percentile()`, and `from_percentile()` without floating-point rounding errors. [[1]](diffhunk://#diff-a5fdd3bb0fdb7e7fda4a88fd6ed02992f205ca1d03765b5be5ebf87867b04239R17) [[2]](diffhunk://#diff-a5fdd3bb0fdb7e7fda4a88fd6ed02992f205ca1d03765b5be5ebf87867b04239R301-R304) [[3]](diffhunk://#diff-a5fdd3bb0fdb7e7fda4a88fd6ed02992f205ca1d03765b5be5ebf87867b04239R355-R379)
* Added new methods: `from_percentile`, `to_percentile`, and `inverse`, providing convenient and precise conversions between quantiles and percentiles, and to compute the complementary quantile.
* Improved the `format` and `parse` methods to handle arbitrary decimal precision and to use `Decimal` for exact string conversions. [[1]](diffhunk://#diff-a5fdd3bb0fdb7e7fda4a88fd6ed02992f205ca1d03765b5be5ebf87867b04239R355-R379) [[2]](diffhunk://#diff-a5fdd3bb0fdb7e7fda4a88fd6ed02992f205ca1d03765b5be5ebf87867b04239L377-R394)
* Updated the quantile string validation regex to support up to three digits and arbitrary decimal places, e.g., `quantile_P99.99`.

**Testing and validation:**

* Added comprehensive unit tests for all new and updated `Quantile` methods, including round-trip conversions, edge cases, error handling, and the new `inverse` method.