### PR TITLE
feat(STEF-2869): add nan_features to workflow configs

### DIFF
--- a/packages/openstef-meta/src/openstef_meta/presets/forecasting_workflow.py
+++ b/packages/openstef-meta/src/openstef_meta/presets/forecasting_workflow.py
@@ -224,6 +224,10 @@ class EnsembleForecastingWorkflowConfig(BaseConfig):
         default=FeatureSelection(include=None, exclude=None),
         description="Feature selection for which features to clip.",
     )
+    nan_features: FeatureSelection = Field(
+        default_factory=lambda: FeatureSelection.NONE,
+        description="Feature selection for which out-of-range values are replaced with NaN instead of clipped.",
+    )
     forecaster_sample_weights: dict[str, SampleWeightConfig] = Field(
         default={
             "gblinear": SampleWeightConfig(method="inverse_frequency"),
@@ -355,6 +359,7 @@ def _feature_standardizers(
             OutlierHandler(
                 selection=Include(config.energy_price_column).combine(config.clip_features), mode="standard"
             ),
+            OutlierHandler(selection=config.nan_features, mode="standard", outlier_action="nan"),
             Scaler(selection=Exclude(config.target_column), method="standard"),
             EmptyFeatureRemover(),
         ],

--- a/packages/openstef-meta/src/openstef_meta/presets/forecasting_workflow.py
+++ b/packages/openstef-meta/src/openstef_meta/presets/forecasting_workflow.py
@@ -221,11 +221,11 @@ class EnsembleForecastingWorkflowConfig(BaseConfig):
         description="If not None, rolling aggregate(s) of load will be used as features in the model.",
     )
     clip_features: FeatureSelection = Field(
-        default_factory=lambda: FeatureSelection.ALL,
+        default=FeatureSelection.ALL,
         description="Feature selection for which features to clip to their learned range.",
     )
     nan_features: FeatureSelection = Field(
-        default_factory=lambda: FeatureSelection.NONE,
+        default=FeatureSelection.NONE,
         description="Feature selection for which features to replace out-of-range values with NaN. "
         "Defaults to no features (disabled).",
     )

--- a/packages/openstef-meta/src/openstef_meta/presets/forecasting_workflow.py
+++ b/packages/openstef-meta/src/openstef_meta/presets/forecasting_workflow.py
@@ -224,7 +224,7 @@ class EnsembleForecastingWorkflowConfig(BaseConfig):
         default=FeatureSelection.ALL,
         description="Feature selection for which features to clip to their learned range.",
     )
-    nan_features: FeatureSelection = Field(
+    nan_on_outlier_features: FeatureSelection = Field(
         default=FeatureSelection.NONE,
         description="Feature selection for which features to replace out-of-range values with NaN. "
         "Defaults to no features (disabled).",
@@ -358,8 +358,8 @@ def _feature_standardizers(
         list[Transform[TimeSeriesDataset, TimeSeriesDataset]],
         [
             *(
-                [OutlierHandler(mode="standard", selection=config.nan_features, outlier_action="nan")]
-                if config.nan_features != FeatureSelection.NONE
+                [OutlierHandler(mode="standard", selection=config.nan_on_outlier_features, outlier_action="nan")]
+                if config.nan_on_outlier_features != FeatureSelection.NONE
                 else []
             ),
             OutlierHandler(

--- a/packages/openstef-meta/src/openstef_meta/presets/forecasting_workflow.py
+++ b/packages/openstef-meta/src/openstef_meta/presets/forecasting_workflow.py
@@ -221,12 +221,13 @@ class EnsembleForecastingWorkflowConfig(BaseConfig):
         description="If not None, rolling aggregate(s) of load will be used as features in the model.",
     )
     clip_features: FeatureSelection = Field(
-        default=FeatureSelection(include=None, exclude=None),
-        description="Feature selection for which features to clip.",
+        default_factory=lambda: FeatureSelection.ALL,
+        description="Feature selection for which features to clip to their learned range.",
     )
     nan_features: FeatureSelection = Field(
         default_factory=lambda: FeatureSelection.NONE,
-        description="Feature selection for which out-of-range values are replaced with NaN instead of clipped.",
+        description="Feature selection for which features to replace out-of-range values with NaN. "
+        "Defaults to no features (disabled).",
     )
     forecaster_sample_weights: dict[str, SampleWeightConfig] = Field(
         default={
@@ -356,10 +357,15 @@ def _feature_standardizers(
     return cast(
         list[Transform[TimeSeriesDataset, TimeSeriesDataset]],
         [
-            OutlierHandler(
-                selection=Include(config.energy_price_column).combine(config.clip_features), mode="standard"
+            *(
+                [OutlierHandler(mode="standard", selection=config.nan_features, outlier_action="nan")]
+                if config.nan_features != FeatureSelection.NONE
+                else []
             ),
-            OutlierHandler(selection=config.nan_features, mode="standard", outlier_action="nan"),
+            OutlierHandler(
+                selection=Include(config.energy_price_column).combine(config.clip_features),
+                mode="standard",
+            ),
             Scaler(selection=Exclude(config.target_column), method="standard"),
             EmptyFeatureRemover(),
         ],

--- a/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
+++ b/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
@@ -220,7 +220,7 @@ class ForecastingWorkflowConfig(BaseConfig):  # PredictionJob
         default=FeatureSelection.ALL,
         description="Feature selection for which features to clip to their learned range.",
     )
-    nan_features: FeatureSelection = Field(
+    nan_on_outlier_features: FeatureSelection = Field(
         default=FeatureSelection.NONE,
         description="Feature selection for which features to replace out-of-range values with NaN. "
         "Defaults to no features (disabled).",
@@ -377,8 +377,8 @@ def create_forecasting_workflow(
     if config.model == "xgboost":
         nan_outlier_handlers = [
             *(
-                [OutlierHandler(mode="standard", selection=config.nan_features, outlier_action="nan")]
-                if config.nan_features != FeatureSelection.NONE
+                [OutlierHandler(mode="standard", selection=config.nan_on_outlier_features, outlier_action="nan")]
+                if config.nan_on_outlier_features != FeatureSelection.NONE
                 else []
             ),
         ]

--- a/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
+++ b/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
@@ -220,6 +220,10 @@ class ForecastingWorkflowConfig(BaseConfig):  # PredictionJob
         default=FeatureSelection(include=None, exclude=None),
         description="Feature selection for which features to clip.",
     )
+    nan_features: FeatureSelection = Field(
+        default_factory=lambda: FeatureSelection.NONE,
+        description="Feature selection for which out-of-range values are replaced with NaN instead of clipped.",
+    )
     sample_weight_config: SampleWeightConfig = Field(
         default_factory=lambda data: SampleWeightConfig(weight_exponent=1.0)
         if data.get("model") == "gblinear"
@@ -357,6 +361,7 @@ def create_forecasting_workflow(
     ]
     feature_standardizers = [
         OutlierHandler(selection=Include(config.energy_price_column).combine(config.clip_features), mode="standard"),
+        OutlierHandler(selection=config.nan_features, mode="standard", outlier_action="nan"),
         Scaler(selection=Exclude(config.target_column), method="standard"),
         SampleWeighter(
             target_column=config.target_column,

--- a/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
+++ b/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
@@ -217,12 +217,13 @@ class ForecastingWorkflowConfig(BaseConfig):  # PredictionJob
         description="If not None, rolling aggregate(s) of load will be used as features in the model.",
     )
     clip_features: FeatureSelection = Field(
-        default=FeatureSelection(include=None, exclude=None),
-        description="Feature selection for which features to clip.",
+        default_factory=lambda: FeatureSelection.ALL,
+        description="Feature selection for which features to clip to their learned range.",
     )
     nan_features: FeatureSelection = Field(
         default_factory=lambda: FeatureSelection.NONE,
-        description="Feature selection for which out-of-range values are replaced with NaN instead of clipped.",
+        description="Feature selection for which features to replace out-of-range values with NaN. "
+        "Defaults to no features (disabled).",
     )
     sample_weight_config: SampleWeightConfig = Field(
         default_factory=lambda data: SampleWeightConfig(weight_exponent=1.0)
@@ -360,8 +361,11 @@ def create_forecasting_workflow(
         ),
     ]
     feature_standardizers = [
-        OutlierHandler(selection=Include(config.energy_price_column).combine(config.clip_features), mode="standard"),
-        OutlierHandler(selection=config.nan_features, mode="standard", outlier_action="nan"),
+        OutlierHandler(
+            selection=Include(config.energy_price_column).combine(config.clip_features),
+            mode="standard",
+            outlier_action="clip",
+        ),
         Scaler(selection=Exclude(config.target_column), method="standard"),
         SampleWeighter(
             target_column=config.target_column,
@@ -371,12 +375,20 @@ def create_forecasting_workflow(
     ]
 
     if config.model == "xgboost":
+        nan_outlier_handlers = [
+            *(
+                [OutlierHandler(mode="standard", selection=config.nan_features, outlier_action="nan")]
+                if config.nan_features != FeatureSelection.NONE
+                else []
+            ),
+        ]
         preprocessing = [
             *checks,
             *feature_aligners,
             *feature_adders,
             HolidayFeatureAdder(country_code=config.location.country_code),
             DatetimeFeaturesAdder(onehot_encode=False),
+            *nan_outlier_handlers,
             *feature_standardizers,
         ]
         forecaster = XGBoostForecaster(

--- a/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
+++ b/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
@@ -217,11 +217,11 @@ class ForecastingWorkflowConfig(BaseConfig):  # PredictionJob
         description="If not None, rolling aggregate(s) of load will be used as features in the model.",
     )
     clip_features: FeatureSelection = Field(
-        default_factory=lambda: FeatureSelection.ALL,
+        default=FeatureSelection.ALL,
         description="Feature selection for which features to clip to their learned range.",
     )
     nan_features: FeatureSelection = Field(
-        default_factory=lambda: FeatureSelection.NONE,
+        default=FeatureSelection.NONE,
         description="Feature selection for which features to replace out-of-range values with NaN. "
         "Defaults to no features (disabled).",
     )


### PR DESCRIPTION
Add nan_features field to ForecastingWorkflowConfig and EnsembleForecastingWorkflowConfig. When set, a second OutlierHandler with outlier_action='nan' replaces out-of-range values with NaN instead of clipping them to bounds. Default is NONE (no features).