### PR TITLE
fix(STEF-3036): flatliner feature_importances shape mismatch

### DIFF
--- a/packages/openstef-models/src/openstef_models/models/forecasting/flatliner_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/flatliner_forecaster.py
@@ -95,10 +95,11 @@ class FlatlinerForecaster(Forecaster, ExplainableForecaster, ContributionsMixin)
     @property
     @override
     def feature_importances(self) -> pd.DataFrame:
+        columns = [quantile.format() for quantile in self.quantiles]
         return pd.DataFrame(
-            data=[0.0],
+            data=[[0.0] * len(columns)],
             index=["load"],
-            columns=[quantile.format() for quantile in self.quantiles],
+            columns=columns,
         )
 
     @override

--- a/packages/openstef-models/tests/unit/models/forecasting/test_flatliner_forecaster.py
+++ b/packages/openstef-models/tests/unit/models/forecasting/test_flatliner_forecaster.py
@@ -44,6 +44,7 @@ def test_feature_importances_shape_matches_quantiles():
     assert list(importances.index) == ["load"]
     assert (importances == 0.0).all().all()  # NOSONAR python:S1244 - flatliner returns exact 0.0
 
+
 def test_predict_returns_median_when_predict_median_is_true(sample_forecast_input_dataset: ForecastInputDataset):
     """Test that the forecaster predicts the median of load measurements when predict_median is True."""
     # Arrange

--- a/packages/openstef-models/tests/unit/models/forecasting/test_flatliner_forecaster.py
+++ b/packages/openstef-models/tests/unit/models/forecasting/test_flatliner_forecaster.py
@@ -42,8 +42,7 @@ def test_feature_importances_shape_matches_quantiles():
     assert isinstance(importances, pd.DataFrame)
     assert list(importances.columns) == [q.format() for q in quantiles]
     assert list(importances.index) == ["load"]
-    assert (importances == 0.0).all().all()
-
+    assert (importances == 0.0).all().all()  # NOSONAR python:S1244 - flatliner returns exact 0.0
 
 def test_predict_returns_median_when_predict_median_is_true(sample_forecast_input_dataset: ForecastInputDataset):
     """Test that the forecaster predicts the median of load measurements when predict_median is True."""

--- a/packages/openstef-models/tests/unit/models/forecasting/test_flatliner_forecaster.py
+++ b/packages/openstef-models/tests/unit/models/forecasting/test_flatliner_forecaster.py
@@ -32,6 +32,19 @@ def test_is_fitted_always_true(config: FlatlinerForecaster):
     assert forecaster.is_fitted
 
 
+def test_feature_importances_shape_matches_quantiles():
+    """Feature importances must have one column per quantile."""
+    quantiles = [Quantile(0.1), Quantile(0.3), Quantile(0.5), Quantile(0.7), Quantile(0.9)]
+    forecaster = FlatlinerForecaster(quantiles=quantiles, horizons=[LeadTime(timedelta(hours=1))])
+
+    importances = forecaster.feature_importances
+
+    assert isinstance(importances, pd.DataFrame)
+    assert list(importances.columns) == [q.format() for q in quantiles]
+    assert list(importances.index) == ["load"]
+    assert (importances == 0.0).all().all()
+
+
 def test_predict_returns_median_when_predict_median_is_true(sample_forecast_input_dataset: ForecastInputDataset):
     """Test that the forecaster predicts the median of load measurements when predict_median is True."""
     # Arrange


### PR DESCRIPTION
## Summary

`FlatlinerForecaster.feature_importances` built a DataFrame with a single scalar value but N quantile column labels, raising:

```
ValueError: Shape of passed values is (1, 1), indices imply (1, N)
```

whenever `len(quantiles) > 1`.

This crashes the MLflow callback's feature-importance plotting during flatliner-fallback training, which means the flatliner model is **never persisted**. Downstream the prediction service then falls back to serving the previous (non-flatliner) model, so the flatliner fallback is silently broken for any model with more than one quantile.

## Reproduction (TDD)

Added regression test `test_feature_importances_shape_matches_quantiles` that:
- Constructs a `FlatlinerForecaster` with 5 quantiles
- Asserts `.feature_importances` has columns matching the configured quantiles

The test fails on `release/v4.0.0` and passes after the fix.

## Fix

Build the row as a 2D list of zeros sized to the quantile count.

## Verification

- `uv run poe lint` ✅
- `uv run poe format` ✅
- `uv run poe type` ✅ (0 errors, 0 warnings)
- `uv run --package openstef-models pytest packages/openstef-models/tests/unit/models/forecasting/test_flatliner_forecaster.py` ✅ (4 passed)

## Ticket
STEF-3036