### PR TITLE
fix(deps): pin xgboost <3.2 to prevent breaking changes in custom objectives

### DIFF
--- a/packages/openstef-models/pyproject.toml
+++ b/packages/openstef-models/pyproject.toml
@@ -43,11 +43,11 @@ optional-dependencies.lgbm = [
 ]
 
 optional-dependencies.xgb-cpu = [
-  "xgboost>=3,<4; sys_platform=='darwin'",
-  "xgboost-cpu>=3,<4; sys_platform=='linux' or sys_platform=='win32'",
+  "xgboost>=3,<3.2; sys_platform=='darwin'",
+  "xgboost-cpu>=3,<3.2; sys_platform=='linux' or sys_platform=='win32'",
 ]
 
-optional-dependencies.xgb-gpu = [ "xgboost>=3,<4" ]
+optional-dependencies.xgb-gpu = [ "xgboost>=3,<3.2" ]
 
 urls.Documentation = "https://openstef.github.io/openstef/index.html"
 urls.Homepage = "https://lfenergy.org/projects/openstef/"

--- a/uv.lock
+++ b/uv.lock
@@ -2952,9 +2952,9 @@ requires-dist = [
     { name = "pycountry", specifier = ">=24.6.1" },
     { name = "scikit-learn", specifier = ">=1.7.1,<1.8" },
     { name = "scipy", specifier = ">=1.16.3,<2" },
-    { name = "xgboost", marker = "sys_platform == 'darwin' and extra == 'xgb-cpu'", specifier = ">=3,<4" },
-    { name = "xgboost", marker = "extra == 'xgb-gpu'", specifier = ">=3,<4" },
-    { name = "xgboost-cpu", marker = "(sys_platform == 'linux' and extra == 'xgb-cpu') or (sys_platform == 'win32' and extra == 'xgb-cpu')", specifier = ">=3,<4" },
+    { name = "xgboost", marker = "sys_platform == 'darwin' and extra == 'xgb-cpu'", specifier = ">=3,<3.2" },
+    { name = "xgboost", marker = "extra == 'xgb-gpu'", specifier = ">=3,<3.2" },
+    { name = "xgboost-cpu", marker = "(sys_platform == 'linux' and extra == 'xgb-cpu') or (sys_platform == 'win32' and extra == 'xgb-cpu')", specifier = ">=3,<3.2" },
 ]
 provides-extras = ["lgbm", "xgb-cpu", "xgb-gpu"]
 


### PR DESCRIPTION
Closing in favour of #866 which landed a proper code fix. The XGBoost version pin is no longer needed.