### PR TITLE
fix: handle both 1D and 2D input shapes in XGBoost custom objectives

### DIFF
--- a/packages/openstef-models/src/openstef_models/utils/loss_functions.py
+++ b/packages/openstef-models/src/openstef_models/utils/loss_functions.py
@@ -85,12 +85,10 @@ def arctan_loss_multi_objective(
         - Implementation: https://github.com/LaurensSluyterman/XGBoost_quantile_regression
     """
     # Resize the predictions and targets.
-    n_items = len(y_true)
     n_quantiles = len(quantiles)
-    n_rows = n_items // n_quantiles
-    y_pred = np.reshape(y_pred, (n_rows, n_quantiles))
-    y_true = np.reshape(y_true, (n_rows, n_quantiles))
-    sample_weight = np.reshape(sample_weight, (n_rows, -1)) if sample_weight is not None else None
+    y_pred = np.reshape(y_pred, (-1, n_quantiles))
+    y_true = np.reshape(y_true, (-1, n_quantiles))
+    sample_weight = sample_weight[:, np.newaxis] if sample_weight is not None else None
 
     # Calculate the differences
     u = y_true - y_pred
@@ -181,12 +179,10 @@ def pinball_loss_multi_objective(
         - Implementation reference: https://gist.github.com/Nikolay-Lysenko/06769d701c1d9c9acb9a66f2f9d7a6c7
     """
     # Resize the predictions and targets.
-    n_items = len(y_true)
     n_quantiles = len(quantiles)
-    n_rows = n_items // n_quantiles
-    y_pred = np.reshape(y_pred, (n_rows, n_quantiles))
-    y_true = np.reshape(y_true, (n_rows, n_quantiles))
-    sample_weight = np.reshape(sample_weight, (n_rows, -1)) if sample_weight is not None else None
+    y_pred = np.reshape(y_pred, (-1, n_quantiles))
+    y_true = np.reshape(y_true, (-1, n_quantiles))
+    sample_weight = sample_weight[:, np.newaxis] if sample_weight is not None else None
 
     # Extract quantile values into array for vectorized operations
     quantile_values = np.array(quantiles)  # shape: (n_quantiles,)


### PR DESCRIPTION
## Summary

Fixes compatibility with XGBoost 3.2, which changed the shape of arrays passed to custom objectives via the sklearn interface. With `multi_strategy="one_output_per_tree"`, `y_true` and `y_pred` are now passed as 2D `(n_samples, n_quantiles)` arrays instead of 1D flattened arrays of length `n_samples * n_quantiles`.

Closes #865 

## Root Cause

The old reshape logic in both objective functions assumed 1D input:

```python
n_items = len(y_true)
n_quantiles = len(quantiles)
n_rows = n_items // n_quantiles  # ← breaks with 2D input
y_pred = np.reshape(y_pred, (n_rows, n_quantiles))
y_true = np.reshape(y_true, (n_rows, n_quantiles))
sample_weight = np.reshape(sample_weight, (n_rows, -1)) if sample_weight is not None else None
```

With 2D input, `len(y_true)` returns `n_samples` (not `n_samples * n_quantiles`), so `n_rows = n_samples // n_quantiles` is wrong, causing the reshape to fail or produce incorrect results.

The below image shows running a minimal script using XGBoost 3.1:
<img width="1222" height="284" alt="Screenshot 2026-05-04 at 21 19 23" src="https://github.com/user-attachments/assets/ef4e031c-9cd0-426c-a3cf-16ac7ef8b7c8" />

The below image shows running the same minimal script using XGBoost 3.2:
<img width="1208" height="475" alt="Screenshot 2026-05-04 at 21 22 12" src="https://github.com/user-attachments/assets/8a4a6a42-6554-452c-9906-742cd8152c2c" />

## Fix

Replaced with shape-agnostic normalisation in `arctan_loss_multi_objective` and `pinball_loss_multi_objective`:

```python
n_quantiles = len(quantiles)
y_pred = np.reshape(y_pred, (-1, n_quantiles))
y_true = np.reshape(y_true, (-1, n_quantiles))
sample_weight = sample_weight[:, np.newaxis] if sample_weight is not None else None
```

`np.reshape(arr, (-1, n_quantiles))` is a no-op when the array is already `(n_samples, n_quantiles)` and correctly reshapes a 1D flat array, maintaining backward compatibility with XGBoost <3.2.

## Investigation Notes

- **`mean_pinball_loss`**: already used `np.reshape(y_pred, [-1, n_quantiles])` which handles both shapes correctly — no change needed
- **`metrics_probabilistic.py`**: no changes needed, `sample_weight_eval_set` verified working correctly with XGBoost 3.2
- **`xgboost_forecaster.py`**: no changes needed
- **`pyproject.toml`**: already at `>=3,<4` on this branch — no change needed