### PR TITLE
fix(STEF-3054): preserve preprocessing NaN in restore_target

### DIFF
--- a/packages/openstef-models/src/openstef_models/models/forecasting_model.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting_model.py
@@ -18,7 +18,6 @@ from typing import cast, override
 
 import numpy as np
 import pandas as pd
-
 from pydantic import Field, PrivateAttr
 
 from openstef_beam.evaluation import EvaluationConfig, EvaluationPipeline, SubsetMetric
@@ -39,6 +38,7 @@ from openstef_models.transforms.general.outlier_handler import OUTLIER_NAN_MASK_
 from openstef_models.utils.data_split import DataSplitter
 
 _logger = logging.getLogger(__name__)
+
 
 class ModelFitResult(BaseModel):
     """Result of fitting a forecasting model.

--- a/packages/openstef-models/src/openstef_models/models/forecasting_model.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting_model.py
@@ -18,6 +18,7 @@ from typing import cast, override
 
 import numpy as np
 import pandas as pd
+
 from pydantic import Field, PrivateAttr
 
 from openstef_beam.evaluation import EvaluationConfig, EvaluationPipeline, SubsetMetric
@@ -34,8 +35,10 @@ from openstef_core.mixins import HyperParams, Predictor, TransformPipeline
 from openstef_core.types import LeadTime, Quantile
 from openstef_models.explainability.mixins import ContributionsMixin, ExplainableForecaster
 from openstef_models.models.forecasting.forecaster import Forecaster
+from openstef_models.transforms.general.outlier_handler import OUTLIER_NAN_MASK_PREFIX
 from openstef_models.utils.data_split import DataSplitter
 
+_logger = logging.getLogger(__name__)
 
 class ModelFitResult(BaseModel):
     """Result of fitting a forecasting model.
@@ -536,8 +539,8 @@ def restore_target[T: TimeSeriesDataset](
     """Restore the target column from the original dataset to the given dataset.
 
     Maps target values from the original dataset to the dataset using index alignment.
-    Preserves NaN values that were introduced by preprocessing (e.g., the OutlierHandler)
-    so that outlier rows can be excluded from training via ``dropna``.
+    Preserves NaN values that were introduced by the OutlierHandler (identified via
+    sentinel columns) so that outlier rows can be excluded from training.
 
     Args:
         dataset: Dataset to modify by adding the target column.
@@ -546,20 +549,32 @@ def restore_target[T: TimeSeriesDataset](
 
     Returns:
         Dataset with the target column restored from the original dataset,
-        except where preprocessing intentionally introduced NaN.
+        except where the OutlierHandler introduced NaN.
     """
     target_series = original_dataset.select_features([target_column]).select_version().data[target_column]
 
     def _transform_restore_target(df: pd.DataFrame) -> pd.DataFrame:
-        original_values = df.index.map(target_series)
+        original_values = df.index.map(target_series)  # pyright: ignore[reportUnknownMemberType]
         restored = pd.Series(original_values, index=df.index, name=target_column)
-        # Preserve NaNs introduced by preprocessing (e.g., the OutlierHandler):
-        # only when the target column already exists (not the case for prediction output).
-        if target_column in df.columns:
-            preprocessed_nan = df[target_column].isna()
-            original_nan = restored.isna()
-            introduced_nan = preprocessed_nan & ~original_nan
-            restored[introduced_nan] = np.nan
+
+        # Preserve NaN values introduced by the OutlierHandler for the target column.
+        sentinel_col = f"{OUTLIER_NAN_MASK_PREFIX}{target_column}__"
+        if sentinel_col in df.columns:
+            outlier_mask = df[sentinel_col].astype(bool)
+            if outlier_mask.any():
+                n_preserved = int(outlier_mask.sum())
+                _logger.warning(
+                    "Preserving %d NaN values in target column '%s' introduced by outlier handling.",
+                    n_preserved,
+                    target_column,
+                )
+                restored[outlier_mask] = np.nan
+
+        # Remove all outlier sentinel columns — they are not model features.
+        sentinel_cols = [c for c in df.columns if c.startswith(OUTLIER_NAN_MASK_PREFIX)]
+        if sentinel_cols:
+            df = df.drop(columns=sentinel_cols)
+
         return df.assign(**{target_column: restored})
 
     return dataset.pipe_pandas(_transform_restore_target)

--- a/packages/openstef-models/src/openstef_models/models/forecasting_model.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting_model.py
@@ -16,6 +16,7 @@ from datetime import datetime, timedelta
 from functools import partial
 from typing import cast, override
 
+import numpy as np
 import pandas as pd
 from pydantic import Field, PrivateAttr
 
@@ -535,7 +536,8 @@ def restore_target[T: TimeSeriesDataset](
     """Restore the target column from the original dataset to the given dataset.
 
     Maps target values from the original dataset to the dataset using index alignment.
-    Ensures the target column is present in the dataset for downstream processing.
+    Preserves NaN values that were introduced by preprocessing (e.g., the OutlierHandler)
+    so that outlier rows can be excluded from training via ``dropna``.
 
     Args:
         dataset: Dataset to modify by adding the target column.
@@ -543,12 +545,22 @@ def restore_target[T: TimeSeriesDataset](
         target_column: Name of the target column to restore.
 
     Returns:
-        Dataset with the target column restored from the original dataset.
+        Dataset with the target column restored from the original dataset,
+        except where preprocessing intentionally introduced NaN.
     """
     target_series = original_dataset.select_features([target_column]).select_version().data[target_column]
 
     def _transform_restore_target(df: pd.DataFrame) -> pd.DataFrame:
-        return df.assign(**{str(target_series.name): df.index.map(target_series)})  # pyright: ignore[reportUnknownMemberType]
+        original_values = df.index.map(target_series)
+        restored = pd.Series(original_values, index=df.index, name=target_column)
+        # Preserve NaNs introduced by preprocessing (e.g., the OutlierHandler):
+        # only when the target column already exists (not the case for prediction output).
+        if target_column in df.columns:
+            preprocessed_nan = df[target_column].isna()
+            original_nan = restored.isna()
+            introduced_nan = preprocessed_nan & ~original_nan
+            restored[introduced_nan] = np.nan
+        return df.assign(**{target_column: restored})
 
     return dataset.pipe_pandas(_transform_restore_target)
 

--- a/packages/openstef-models/src/openstef_models/transforms/general/__init__.py
+++ b/packages/openstef-models/src/openstef_models/transforms/general/__init__.py
@@ -22,12 +22,12 @@ from openstef_models.transforms.general.selector import Selector
 from openstef_models.transforms.general.shifter import Shifter
 
 __all__ = [
+    "OUTLIER_NAN_MASK_PREFIX",
     "DimensionalityReducer",
     "EmptyFeatureRemover",
     "Flagger",
     "Imputer",
     "NaNDropper",
-    "OUTLIER_NAN_MASK_PREFIX",
     "OutlierHandler",
     "SampleWeightConfig",
     "SampleWeighter",

--- a/packages/openstef-models/src/openstef_models/transforms/general/__init__.py
+++ b/packages/openstef-models/src/openstef_models/transforms/general/__init__.py
@@ -15,7 +15,7 @@ from openstef_models.transforms.general.empty_feature_remover import (
 from openstef_models.transforms.general.flagger import Flagger
 from openstef_models.transforms.general.imputer import Imputer
 from openstef_models.transforms.general.nan_dropper import NaNDropper
-from openstef_models.transforms.general.outlier_handler import OutlierHandler
+from openstef_models.transforms.general.outlier_handler import OUTLIER_NAN_MASK_PREFIX, OutlierHandler
 from openstef_models.transforms.general.sample_weighter import SampleWeightConfig, SampleWeighter
 from openstef_models.transforms.general.scaler import Scaler
 from openstef_models.transforms.general.selector import Selector
@@ -27,6 +27,7 @@ __all__ = [
     "Flagger",
     "Imputer",
     "NaNDropper",
+    "OUTLIER_NAN_MASK_PREFIX",
     "OutlierHandler",
     "SampleWeightConfig",
     "SampleWeighter",

--- a/packages/openstef-models/src/openstef_models/transforms/general/outlier_handler.py
+++ b/packages/openstef-models/src/openstef_models/transforms/general/outlier_handler.py
@@ -24,6 +24,8 @@ from openstef_models.utils.feature_selection import FeatureSelection
 type ClipMode = Literal["minmax", "standard"]
 type OutlierAction = Literal["clip", "nan"]
 
+OUTLIER_NAN_MASK_PREFIX = "__outlier_nan_"
+
 
 class OutlierHandler(BaseConfig, TimeSeriesTransform):
     """Transform that handles out-of-range values for selected features.
@@ -161,6 +163,13 @@ class OutlierHandler(BaseConfig, TimeSeriesTransform):
             out_of_range_mask = below_lower | above_upper
 
             transformed_data[features] = feature_data.where(~out_of_range_mask)
+
+            # Add sentinel columns so downstream transforms can identify which 
+            # NaN values were introduced by outlier handling.
+            for col in features:
+                col_mask = out_of_range_mask[col]
+                if col_mask.any():
+                    transformed_data[f"{OUTLIER_NAN_MASK_PREFIX}{col}__"] = col_mask
 
         return TimeSeriesDataset(data=transformed_data, sample_interval=data.sample_interval)
 

--- a/packages/openstef-models/src/openstef_models/transforms/general/outlier_handler.py
+++ b/packages/openstef-models/src/openstef_models/transforms/general/outlier_handler.py
@@ -164,7 +164,7 @@ class OutlierHandler(BaseConfig, TimeSeriesTransform):
 
             transformed_data[features] = feature_data.where(~out_of_range_mask)
 
-            # Add sentinel columns so downstream transforms can identify which 
+            # Add sentinel columns so downstream transforms can identify which
             # NaN values were introduced by outlier handling.
             for col in features:
                 col_mask = out_of_range_mask[col]

--- a/packages/openstef-models/tests/unit/models/test_forecasting_model.py
+++ b/packages/openstef-models/tests/unit/models/test_forecasting_model.py
@@ -19,7 +19,8 @@ from openstef_core.testing import assert_timeseries_equal, create_synthetic_fore
 from openstef_core.types import LeadTime, Quantile, override
 from openstef_models.models.forecasting.constant_median_forecaster import ConstantMedianForecaster
 from openstef_models.models.forecasting.forecaster import Forecaster
-from openstef_models.models.forecasting_model import ForecastingModel
+from openstef_models.models.forecasting_model import ForecastingModel, restore_target
+from openstef_models.transforms.general.outlier_handler import OUTLIER_NAN_MASK_PREFIX
 from openstef_models.transforms.postprocessing.quantile_sorter import QuantileSorter
 from openstef_models.transforms.time_domain.lags_adder import LagsAdder
 
@@ -256,29 +257,56 @@ def test_forecasting_model__pickle_roundtrip():
     assert_timeseries_equal(actual_predictions, expected_predictions)
 
 
-def test_restore_target__preserves_preprocessing_nans():
-    """Verify that restore_target preserves NaN introduced by preprocessing."""
-    from openstef_models.models.forecasting_model import restore_target
-
+def test_restore_target__preserves_outlier_nans_via_sentinel():
+    """Verify that restore_target preserves NaN marked by OutlierHandler sentinel columns."""
+    # Arrange
     index = pd.date_range("2025-01-01", periods=5, freq="1h")
     original_data = pd.DataFrame({"load": [100.0, 200.0, 300.0, 400.0, 500.0]}, index=index)
     original_dataset = TimeSeriesDataset(original_data, timedelta(hours=1))
 
-    # Simulate preprocessed data where the outlier handler NaN'd rows 1 and 3
+    # Simulate preprocessed data where the OutlierHandler NaN'd rows 1 and 3
+    # and added sentinel columns to mark them
+    preprocessed_data = pd.DataFrame(
+        {
+            "load": [100.0, np.nan, 300.0, np.nan, 500.0],
+            f"{OUTLIER_NAN_MASK_PREFIX}load__": [False, True, False, True, False],
+        },
+        index=index,
+    )
+    preprocessed_dataset = TimeSeriesDataset(preprocessed_data, timedelta(hours=1))
+
+    # Act
+    result = restore_target(dataset=preprocessed_dataset, original_dataset=original_dataset, target_column="load")
+
+    # Assert - rows 0, 2, 4 should have original values; rows 1, 3 should remain NaN
+    expected = pd.Series([100.0, np.nan, 300.0, np.nan, 500.0], index=index, name="load")
+    pd.testing.assert_series_equal(result.data["load"], expected)
+    # Sentinel column should be removed
+    assert f"{OUTLIER_NAN_MASK_PREFIX}load__" not in result.data.columns
+
+
+def test_restore_target__does_not_preserve_nan_without_sentinel():
+    """Verify that restore_target restores target values when no sentinel column exists."""
+    # Arrange
+    index = pd.date_range("2025-01-01", periods=5, freq="1h")
+    original_data = pd.DataFrame({"load": [100.0, 200.0, 300.0, 400.0, 500.0]}, index=index)
+    original_dataset = TimeSeriesDataset(original_data, timedelta(hours=1))
+
+    # Preprocessed data with NaN but NO sentinel column (e.g., from some other source)
     preprocessed_data = pd.DataFrame({"load": [100.0, np.nan, 300.0, np.nan, 500.0]}, index=index)
     preprocessed_dataset = TimeSeriesDataset(preprocessed_data, timedelta(hours=1))
 
+    # Act
     result = restore_target(dataset=preprocessed_dataset, original_dataset=original_dataset, target_column="load")
 
-    # Rows 0, 2, 4 should have original values; rows 1, 3 should remain NaN
-    expected = pd.Series([100.0, np.nan, 300.0, np.nan, 500.0], index=index, name="load")
+    # Assert - ALL values should be restored from original (NaN NOT preserved without sentinel)
+    expected = pd.Series([100.0, 200.0, 300.0, 400.0, 500.0], index=index, name="load")
     pd.testing.assert_series_equal(result.data["load"], expected)
 
 
 def test_restore_target__adds_target_when_not_present():
     """Verify that restore_target works when target column is missing (prediction output)."""
-    from openstef_models.models.forecasting_model import restore_target
-
+    # Arrange
     index = pd.date_range("2025-01-01", periods=3, freq="1h")
     original_data = pd.DataFrame({"load": [100.0, 200.0, 300.0]}, index=index)
     original_dataset = TimeSeriesDataset(original_data, timedelta(hours=1))
@@ -287,8 +315,9 @@ def test_restore_target__adds_target_when_not_present():
     prediction_data = pd.DataFrame({"quantile_P50": [105.0, 195.0, 310.0]}, index=index)
     prediction_dataset = TimeSeriesDataset(prediction_data, timedelta(hours=1))
 
+    # Act
     result = restore_target(dataset=prediction_dataset, original_dataset=original_dataset, target_column="load")
 
-    # Target should be added from original
+    # Assert - target column should be added with original values
     expected = pd.Series([100.0, 200.0, 300.0], index=index, name="load")
     pd.testing.assert_series_equal(result.data["load"], expected)

--- a/packages/openstef-models/tests/unit/models/test_forecasting_model.py
+++ b/packages/openstef-models/tests/unit/models/test_forecasting_model.py
@@ -260,15 +260,15 @@ def test_forecasting_model__pickle_roundtrip():
 def test_restore_target__preserves_outlier_nans_via_sentinel():
     """Verify that restore_target preserves NaN marked by OutlierHandler sentinel columns."""
     # Arrange
-    index = pd.date_range("2025-01-01", periods=6, freq="1h")
-    # Row 4 is originally NaN (missing data)
-    original_data = pd.DataFrame({"load": [100.0, 200.0, 300.0, 400.0, np.nan, 600.0]}, index=index)
+    index = pd.date_range("2025-01-01", periods=7, freq="1h")
+    # Row 5 is originally NaN (missing data)
+    original_data = pd.DataFrame({"load": [100.0, 200.0, 300.0, 400.0, 500.0, np.nan, 700.0]}, index=index)
     original_dataset = TimeSeriesDataset(original_data, timedelta(hours=1))
 
     preprocessed_data = pd.DataFrame(
         {
-            "load": [100.0, np.nan, 300.0, np.nan, np.nan, 600.0],
-            f"{OUTLIER_NAN_MASK_PREFIX}load__": [False, True, False, True, False, False],
+            "load": [100.0, np.nan, 300.0, np.nan, np.nan, np.nan, 700.0],
+            f"{OUTLIER_NAN_MASK_PREFIX}load__": [False, True, False, True, False, False, False],
         },
         index=index,
     )
@@ -277,8 +277,11 @@ def test_restore_target__preserves_outlier_nans_via_sentinel():
     # Act
     result = restore_target(dataset=preprocessed_dataset, original_dataset=original_dataset, target_column="load")
 
-    # Assert - Only rows with sentinel=True should preserve NaN; original NaN (row 4) should be restored
-    expected = pd.Series([100.0, np.nan, 300.0, np.nan, np.nan, 600.0], index=index, name="load")
+    # Assert
+    # - Rows 1, 3: remain NaN (outlier, sentinel=True)
+    # - Row 4: restored to 500.0 (sentinel=False, so original value is used)
+    # - Row 5: remains NaN (original is NaN)
+    expected = pd.Series([100.0, np.nan, 300.0, np.nan, 500.0, np.nan, 700.0], index=index, name="load")
     pd.testing.assert_series_equal(result.data["load"], expected)
     # Sentinel column should be removed
     assert f"{OUTLIER_NAN_MASK_PREFIX}load__" not in result.data.columns

--- a/packages/openstef-models/tests/unit/models/test_forecasting_model.py
+++ b/packages/openstef-models/tests/unit/models/test_forecasting_model.py
@@ -254,3 +254,41 @@ def test_forecasting_model__pickle_roundtrip():
     # Verify predictions match using pandas testing utilities
     actual_predictions = restored_model.predict(data=dataset)
     assert_timeseries_equal(actual_predictions, expected_predictions)
+
+
+def test_restore_target__preserves_preprocessing_nans():
+    """Verify that restore_target preserves NaN introduced by preprocessing."""
+    from openstef_models.models.forecasting_model import restore_target
+
+    index = pd.date_range("2025-01-01", periods=5, freq="1h")
+    original_data = pd.DataFrame({"load": [100.0, 200.0, 300.0, 400.0, 500.0]}, index=index)
+    original_dataset = TimeSeriesDataset(original_data, timedelta(hours=1))
+
+    # Simulate preprocessed data where the outlier handler NaN'd rows 1 and 3
+    preprocessed_data = pd.DataFrame({"load": [100.0, np.nan, 300.0, np.nan, 500.0]}, index=index)
+    preprocessed_dataset = TimeSeriesDataset(preprocessed_data, timedelta(hours=1))
+
+    result = restore_target(dataset=preprocessed_dataset, original_dataset=original_dataset, target_column="load")
+
+    # Rows 0, 2, 4 should have original values; rows 1, 3 should remain NaN
+    expected = pd.Series([100.0, np.nan, 300.0, np.nan, 500.0], index=index, name="load")
+    pd.testing.assert_series_equal(result.data["load"], expected)
+
+
+def test_restore_target__adds_target_when_not_present():
+    """Verify that restore_target works when target column is missing (prediction output)."""
+    from openstef_models.models.forecasting_model import restore_target
+
+    index = pd.date_range("2025-01-01", periods=3, freq="1h")
+    original_data = pd.DataFrame({"load": [100.0, 200.0, 300.0]}, index=index)
+    original_dataset = TimeSeriesDataset(original_data, timedelta(hours=1))
+
+    # Prediction output without target column
+    prediction_data = pd.DataFrame({"quantile_P50": [105.0, 195.0, 310.0]}, index=index)
+    prediction_dataset = TimeSeriesDataset(prediction_data, timedelta(hours=1))
+
+    result = restore_target(dataset=prediction_dataset, original_dataset=original_dataset, target_column="load")
+
+    # Target should be added from original
+    expected = pd.Series([100.0, 200.0, 300.0], index=index, name="load")
+    pd.testing.assert_series_equal(result.data["load"], expected)

--- a/packages/openstef-models/tests/unit/models/test_forecasting_model.py
+++ b/packages/openstef-models/tests/unit/models/test_forecasting_model.py
@@ -260,16 +260,15 @@ def test_forecasting_model__pickle_roundtrip():
 def test_restore_target__preserves_outlier_nans_via_sentinel():
     """Verify that restore_target preserves NaN marked by OutlierHandler sentinel columns."""
     # Arrange
-    index = pd.date_range("2025-01-01", periods=5, freq="1h")
-    original_data = pd.DataFrame({"load": [100.0, 200.0, 300.0, 400.0, 500.0]}, index=index)
+    index = pd.date_range("2025-01-01", periods=6, freq="1h")
+    # Row 4 is originally NaN (missing data)
+    original_data = pd.DataFrame({"load": [100.0, 200.0, 300.0, 400.0, np.nan, 600.0]}, index=index)
     original_dataset = TimeSeriesDataset(original_data, timedelta(hours=1))
 
-    # Simulate preprocessed data where the OutlierHandler NaN'd rows 1 and 3
-    # and added sentinel columns to mark them
     preprocessed_data = pd.DataFrame(
         {
-            "load": [100.0, np.nan, 300.0, np.nan, 500.0],
-            f"{OUTLIER_NAN_MASK_PREFIX}load__": [False, True, False, True, False],
+            "load": [100.0, np.nan, 300.0, np.nan, np.nan, 600.0],
+            f"{OUTLIER_NAN_MASK_PREFIX}load__": [False, True, False, True, False, False],
         },
         index=index,
     )
@@ -278,8 +277,8 @@ def test_restore_target__preserves_outlier_nans_via_sentinel():
     # Act
     result = restore_target(dataset=preprocessed_dataset, original_dataset=original_dataset, target_column="load")
 
-    # Assert - rows 0, 2, 4 should have original values; rows 1, 3 should remain NaN
-    expected = pd.Series([100.0, np.nan, 300.0, np.nan, 500.0], index=index, name="load")
+    # Assert - Only rows with sentinel=True should preserve NaN; original NaN (row 4) should be restored
+    expected = pd.Series([100.0, np.nan, 300.0, np.nan, np.nan, 600.0], index=index, name="load")
     pd.testing.assert_series_equal(result.data["load"], expected)
     # Sentinel column should be removed
     assert f"{OUTLIER_NAN_MASK_PREFIX}load__" not in result.data.columns

--- a/packages/openstef-models/tests/unit/transforms/general/test_outlier_handler.py
+++ b/packages/openstef-models/tests/unit/transforms/general/test_outlier_handler.py
@@ -10,7 +10,7 @@ import pytest
 
 from openstef_core.datasets import TimeSeriesDataset
 from openstef_core.exceptions import NotFittedError
-from openstef_models.transforms.general import OutlierHandler
+from openstef_models.transforms.general import OUTLIER_NAN_MASK_PREFIX, OutlierHandler
 from openstef_models.utils.feature_selection import FeatureSelection
 
 
@@ -94,6 +94,7 @@ def test_outlier_handler__nan_behavior(
     expected_a: list[float],
     expected_b: list[float],
 ):
+
     # Arrange
     # Initialize handler with NaN outlier handling
     outlier_handler = OutlierHandler(
@@ -118,7 +119,9 @@ def test_outlier_handler__nan_behavior(
         index=test_dataset.index,
     )
 
-    pd.testing.assert_frame_equal(transformed_dataset.data, expected_df)
+    # Compare only the feature columns (sentinel columns are tested separately)
+    feature_cols = [c for c in transformed_dataset.data.columns if not c.startswith(OUTLIER_NAN_MASK_PREFIX)]
+    pd.testing.assert_frame_equal(transformed_dataset.data[feature_cols], expected_df)
 
 
 def test_outlier_handler__handles_missing_features(
@@ -156,3 +159,72 @@ def test_outlier_handler__transform_without_fit(test_dataset: TimeSeriesDataset)
     # Act & Assert
     with pytest.raises(NotFittedError):
         outlier_handler.transform(test_dataset)
+
+
+def test_outlier_handler__nan_action_adds_sentinel_columns():
+    """Test that NaN action adds sentinel mask columns for features with outliers."""
+
+    # Arrange - train on narrow range so test data has outliers
+    train_data = pd.DataFrame(
+        {"load": [100.0, 110.0, 105.0, 108.0, 103.0], "temp": [20.0, 21.0, 20.5, 20.8, 20.3]},
+        index=pd.date_range("2025-01-01", periods=5, freq="1h"),
+    )
+    train_dataset = TimeSeriesDataset(train_data, timedelta(hours=1))
+
+    # Test data with outliers in load (well outside mean±2*std) but not in temp
+    test_data = pd.DataFrame(
+        {"load": [105.0, 500.0, -200.0], "temp": [20.5, 20.8, 20.3]},
+        index=pd.date_range("2025-01-06", periods=3, freq="1h"),
+    )
+    test_dataset = TimeSeriesDataset(test_data, timedelta(hours=1))
+
+    handler = OutlierHandler(
+        selection=FeatureSelection(include={"load", "temp"}),
+        mode="standard",
+        outlier_action="nan",
+    )
+
+    # Act
+    handler.fit(train_dataset)
+    result = handler.transform(test_dataset)
+
+    # Assert - sentinel column exists for load (has outliers)
+    assert f"{OUTLIER_NAN_MASK_PREFIX}load__" in result.data.columns
+    mask = result.data[f"{OUTLIER_NAN_MASK_PREFIX}load__"]
+    assert mask.iloc[0] is np.bool_(False)  # 105.0 is within range
+    assert mask.iloc[1] is np.bool_(True)  # 500.0 is outlier
+    assert mask.iloc[2] is np.bool_(True)  # -200.0 is outlier
+
+    # Sentinel column for temp should NOT exist (no outliers in temp)
+    assert f"{OUTLIER_NAN_MASK_PREFIX}temp__" not in result.data.columns
+
+
+def test_outlier_handler__clip_action_does_not_add_sentinel_columns():
+    """Test that clip action does not add sentinel columns."""
+
+    # Arrange
+    train_data = pd.DataFrame(
+        {"load": [100.0, 110.0, 105.0]},
+        index=pd.date_range("2025-01-01", periods=3, freq="1h"),
+    )
+    train_dataset = TimeSeriesDataset(train_data, timedelta(hours=1))
+
+    test_data = pd.DataFrame(
+        {"load": [500.0]},
+        index=pd.date_range("2025-01-06", periods=1, freq="1h"),
+    )
+    test_dataset = TimeSeriesDataset(test_data, timedelta(hours=1))
+
+    handler = OutlierHandler(
+        selection=FeatureSelection(include={"load"}),
+        mode="standard",
+        outlier_action="clip",
+    )
+
+    # Act
+    handler.fit(train_dataset)
+    result = handler.transform(test_dataset)
+
+    # Assert - no sentinel columns for clip action
+    sentinel_cols = [c for c in result.data.columns if c.startswith(OUTLIER_NAN_MASK_PREFIX)]
+    assert sentinel_cols == []


### PR DESCRIPTION
## Problem

`restore_target` unconditionally restored all target values from the original dataset, undoing any NaN introduced by the `OutlierHandler`. This meant that even when `nan_on_outlier_features` included the target column, outlier rows were never excluded from training.

## Solution: Sentinel Columns

The `OutlierHandler` now adds boolean sentinel columns (`__outlier_nan_<feature>__`) when using `outlier_action="nan"`, explicitly marking which values were NaN'd as outliers.

`restore_target` checks for the sentinel column of the target feature:
- If `__outlier_nan_load__` exists and is `True` → preserve the NaN (don't restore original value)
- After restoring, all sentinel columns are removed from the dataset (they are not model features)

This is explicit — no inference about which NaN values to preserve. Only NaN values explicitly flagged by the OutlierHandler are kept.

## Testing

- 4 new unit tests (OutlierHandler sentinel column behavior + restore_target sentinel handling)
- All 369 openstef-models tests pass