### PR TITLE
fix(STEF-3054): exclude __-prefixed columns from feature_names

### DIFF
--- a/packages/openstef-core/src/openstef_core/datasets/timeseries_dataset.py
+++ b/packages/openstef-core/src/openstef_core/datasets/timeseries_dataset.py
@@ -49,7 +49,7 @@ class TimeSeriesDataset(TimeSeriesMixin, DatasetMixin):  # noqa: PLR0904 - impor
     Columns whose names start with a double underscore (``__``) are treated as
     internal/system columns: they are kept in ``data`` so transforms can pass
     them along, but are excluded from ``feature_names`` so feature-aware
-    transforms (e.g. scalers) ignore them.
+    transforms ignore them.
 
     The dataset guarantees:
         - Data is sorted by timestamp in ascending order

--- a/packages/openstef-core/src/openstef_core/datasets/timeseries_dataset.py
+++ b/packages/openstef-core/src/openstef_core/datasets/timeseries_dataset.py
@@ -46,6 +46,11 @@ class TimeSeriesDataset(TimeSeriesMixin, DatasetMixin):  # noqa: PLR0904 - impor
     - If an available_at column exists, data is versioned by availability time
     - Otherwise, data is treated as a regular time series
 
+    Columns whose names start with a double underscore (``__``) are treated as
+    internal/system columns: they are kept in ``data`` so transforms can pass
+    them along, but are excluded from ``feature_names`` so feature-aware
+    transforms (e.g. scalers) ignore them.
+
     The dataset guarantees:
         - Data is sorted by timestamp in ascending order
         - Consistent sampling interval across all data points
@@ -133,7 +138,7 @@ class TimeSeriesDataset(TimeSeriesMixin, DatasetMixin):  # noqa: PLR0904 - impor
         self.horizon_column = horizon_column
         self.available_at_column = available_at_column
         self._sample_interval = sample_interval
-        self._internal_columns = set()
+        self._internal_columns = {col for col in data.columns if col.startswith("__")}
         data.index.name = self.index_name
 
         # Check input data frequency matches sample_interval, only if there are enough data points to infer frequency
@@ -156,7 +161,7 @@ class TimeSeriesDataset(TimeSeriesMixin, DatasetMixin):  # noqa: PLR0904 - impor
             self._horizons = None
         else:
             self._version_column = None
-            self._feature_names = data.columns.to_list()
+            self._feature_names = [col for col in data.columns if col not in self._internal_columns]
             self._horizons = None
 
         # Ensure invariants: data is sorted by timestamp

--- a/packages/openstef-models/tests/unit/transforms/general/test_outlier_handler.py
+++ b/packages/openstef-models/tests/unit/transforms/general/test_outlier_handler.py
@@ -198,6 +198,10 @@ def test_outlier_handler__nan_action_adds_sentinel_columns():
     # Sentinel column for temp should NOT exist (no outliers in temp)
     assert f"{OUTLIER_NAN_MASK_PREFIX}temp__" not in result.data.columns
 
+    # Sentinel columns are excluded from feature_names (internal columns convention)
+    assert f"{OUTLIER_NAN_MASK_PREFIX}load__" not in result.feature_names
+    assert set(result.feature_names) == {"load", "temp"}
+
 
 def test_outlier_handler__clip_action_does_not_add_sentinel_columns():
     """Test that clip action does not add sentinel columns."""


### PR DESCRIPTION
## Problem

The OutlierHandler emits sentinel columns (e.g. `__outlier_nan_load_lag_P7D__`) when it NaN's values. These columns were included in `TimeSeriesDataset.feature_names`, causing feature-aware transforms (Scaler) to fit on them during training. At predict time, when no outliers are detected, the sentinel columns are absent → sklearn's feature-name validation crashes:

```
ValueError: The feature names should match those that were passed during fit.
Feature names seen at fit time, yet now missing:
- __outlier_nan_load_lag_P7D__
```

## Fix

`TimeSeriesDataset` now treats any column whose name starts with `__` as an internal column (same mechanism as `horizon`/`available_at` columns). These are:
- Kept in `data` so transforms can pass them through the pipeline
- Excluded from `feature_names` so feature-aware transforms ignore them

This makes the sentinel column approach work correctly: they flow through the pipeline untouched, are consumed by `restore_target` at the end, and never interfere with the Scaler or model.

## Changes

- **openstef-core/timeseries_dataset.py**: Initialize `_internal_columns` with any `__`-prefixed columns; also apply in the non-versioned branch
- **test_outlier_handler.py**: Assert sentinel columns are excluded from `feature_names`
