### PR TITLE
Keep custom target column when calling `forecaster.predict()`

### DIFF
--- a/packages/openstef-models/src/openstef_models/models/forecasting/base_case_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/base_case_forecaster.py
@@ -157,6 +157,7 @@ class BaseCaseForecaster(Forecaster, ExplainableForecaster, ContributionsMixin):
                 index=forecast_index,
             ),
             sample_interval=data.sample_interval,
+            target_column=data.target_column,
         )
 
     @override

--- a/packages/openstef-models/src/openstef_models/models/forecasting/constant_median_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/constant_median_forecaster.py
@@ -106,6 +106,7 @@ class ConstantMedianForecaster(Forecaster, ExplainableForecaster, ContributionsM
                 index=forecast_index,
             ),
             sample_interval=data.sample_interval,
+            target_column=data.target_column,
         )
 
     @property

--- a/packages/openstef-models/src/openstef_models/models/forecasting/flatliner_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/flatliner_forecaster.py
@@ -90,6 +90,7 @@ class FlatlinerForecaster(Forecaster, ExplainableForecaster, ContributionsMixin)
                 index=forecast_index,
             ),
             sample_interval=data.sample_interval,
+            target_column=data.target_column,
         )
 
     @property

--- a/packages/openstef-models/src/openstef_models/models/forecasting/gblinear_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/gblinear_forecaster.py
@@ -290,6 +290,7 @@ class GBLinearForecaster(Forecaster, ExplainableForecaster, ContributionsMixin):
         return ForecastDataset(
             data=predictions,
             sample_interval=data.sample_interval,
+            target_column=data.target_column,
         )
 
     def predict_contributions(self, data: ForecastInputDataset) -> TimeSeriesDataset:

--- a/packages/openstef-models/src/openstef_models/models/forecasting/lgbm_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/lgbm_forecaster.py
@@ -291,6 +291,7 @@ class LGBMForecaster(Forecaster, ExplainableForecaster, ContributionsMixin):
                 columns=[quantile.format() for quantile in self.quantiles],
             ),
             sample_interval=data.sample_interval,
+            target_column=data.target_column,
         )
 
     def predict_contributions(self, data: ForecastInputDataset) -> TimeSeriesDataset:

--- a/packages/openstef-models/src/openstef_models/models/forecasting/lgbmlinear_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/lgbmlinear_forecaster.py
@@ -292,6 +292,7 @@ class LGBMLinearForecaster(Forecaster, ExplainableForecaster, ContributionsMixin
                 columns=[quantile.format() for quantile in self.quantiles],
             ),
             sample_interval=data.sample_interval,
+            target_column=data.target_column,
         )
 
     @override

--- a/packages/openstef-models/src/openstef_models/models/forecasting/median_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/median_forecaster.py
@@ -242,6 +242,7 @@ class MedianForecaster(Forecaster, ExplainableForecaster, ContributionsMixin):
             data=prediction_df.dropna().rename(columns={"median": self.quantiles[0].format()}),  # type: ignore
             sample_interval=data.sample_interval,
             forecast_start=data.forecast_start,
+            target_column=data.target_column,
         )
 
     @override

--- a/packages/openstef-models/src/openstef_models/models/forecasting/xgboost_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/xgboost_forecaster.py
@@ -361,6 +361,7 @@ class XGBoostForecaster(Forecaster, ExplainableForecaster, ContributionsMixin):
         return ForecastDataset(
             data=predictions,
             sample_interval=data.sample_interval,
+            target_column=data.target_column,
         )
 
     def predict_contributions(self, data: ForecastInputDataset) -> TimeSeriesDataset:


### PR DESCRIPTION
Fix: When calling a forecaster's `predict(input_data)` method, the target column from `input_data` was not carried over to the output `ForecastDataset`, so that the target column of the method's output is always the default "load" value. This led to errors in the downstream postprocessing.

Should fix #871.