### PR TITLE
Fix standard lag generation when working with multi-horizon data

### DIFF
--- a/packages/openstef-models/src/openstef_models/transforms/time_domain/lags_adder.py
+++ b/packages/openstef-models/src/openstef_models/transforms/time_domain/lags_adder.py
@@ -93,9 +93,9 @@ class LagsAdder(BaseConfig, TimeSeriesTransform):
         return self._lags
 
     @property
-    def max_horizon(self) -> timedelta:
-        """Longest forecast horizon to determine minimum lag requirements."""
-        return max(horizon.value for horizon in self.horizons)
+    def min_horizon(self) -> timedelta:
+        """Shortest forecast horizon to determine minimum lag requirements."""
+        return min(horizon.value for horizon in self.horizons)
 
     def _add_lags(self, new_lags: list[timedelta]) -> None:
         self._lags = sorted(set(self._lags + new_lags), reverse=True)
@@ -111,8 +111,8 @@ class LagsAdder(BaseConfig, TimeSeriesTransform):
 
         # Add trivial lags (minute-based and day-based) if enabled
         if self.add_trivial_lags:
-            lags.extend(generate_minute_lags(max_horizon=self.max_horizon))
-            lags.extend(generate_day_lags(max_horizon=self.max_horizon, max_day_lags=self.max_day_lags))
+            lags.extend(generate_minute_lags(min_horizon=self.min_horizon))
+            lags.extend(generate_day_lags(min_horizon=self.min_horizon, max_day_lags=self.max_day_lags))
 
         # Add explicit lags if provided
         if self.custom_lags is not None:
@@ -138,7 +138,7 @@ class LagsAdder(BaseConfig, TimeSeriesTransform):
         # Generate autocorrelation-based lags
         autocorr_lags = generate_autocorr_lags(
             signal=target_series,
-            max_horizon=self.max_horizon,
+            min_horizon=self.min_horizon,
         )
 
         # Update lags with autocorr lags
@@ -262,14 +262,14 @@ class LagsAdder(BaseConfig, TimeSeriesTransform):
         return super().__setstate__(state)
 
 
-def generate_minute_lags(max_horizon: timedelta) -> list[timedelta]:
+def generate_minute_lags(min_horizon: timedelta) -> list[timedelta]:
     """Generate minute-based lag features for short-term forecasting.
 
     Creates hourly lags (1-23 hours) and sub-hourly lags (15, 30, 45 minutes)
     that are valid for the given forecast horizon.
 
     Args:
-        max_horizon: Maximum forecast horizon - only lags >= this will be included.
+        min_horizon: Minimum forecast horizon - only lags >= this will be included.
 
     Returns:
         List of timedeltas representing valid minute-based lags, sorted descending.
@@ -280,20 +280,20 @@ def generate_minute_lags(max_horizon: timedelta) -> list[timedelta]:
     base_lags = pd.Index(hourly_lags).union(pd.Index(subhourly_lags))
 
     # Filter: only lags that are far enough in the past (>= forecast horizon)
-    valid_lags = cast(pd.TimedeltaIndex, base_lags[base_lags >= max_horizon])
+    valid_lags = cast(pd.TimedeltaIndex, base_lags[base_lags >= min_horizon])
 
     # Convert to Python timedelta list (no duplicates possible)
     return list(valid_lags.to_pytimedelta())
 
 
-def generate_day_lags(max_horizon: timedelta, max_day_lags: int) -> list[timedelta]:
+def generate_day_lags(min_horizon: timedelta, max_day_lags: int) -> list[timedelta]:
     """Generate day-based lag features for capturing daily and weekly patterns.
 
     Creates daily lags from the minimum required days up to the maximum allowed,
     useful for capturing day-of-week and weekly seasonality.
 
     Args:
-        max_horizon: Maximum forecast horizon - only lags >= this will be included.
+        min_horizon: Minimum forecast horizon - only lags >= this will be included.
         max_day_lags: Maximum number of days to look back (typically 14 for two weekly cycles).
 
     Returns:
@@ -301,7 +301,7 @@ def generate_day_lags(max_horizon: timedelta, max_day_lags: int) -> list[timedel
         Empty list if minimum required days exceeds max_day_lags.
     """
     # Calculate minimum days needed to exceed the horizon (timedelta division returns float)
-    min_days = math.ceil(max_horizon / timedelta(days=1))
+    min_days = math.ceil(min_horizon / timedelta(days=1))
 
     # If min_days exceeds the configured maximum, no day lags are possible
     if min_days > max_day_lags:
@@ -316,7 +316,7 @@ def generate_day_lags(max_horizon: timedelta, max_day_lags: int) -> list[timedel
 
 def generate_autocorr_lags(
     signal: pd.Series,
-    max_horizon: timedelta,
+    min_horizon: timedelta,
     height_threshold: float = 0.1,
     max_lag_hours: int = 4,
 ) -> list[timedelta]:
@@ -328,13 +328,13 @@ def generate_autocorr_lags(
 
     Args:
         signal: Time series data to analyze (typically the target variable).
-        max_horizon: Maximum forecast horizon - only lags >= this will be included.
+        min_horizon: Minimum forecast horizon - only lags >= this will be included.
         height_threshold: Minimum autocorrelation value to recognize as a peak.
             Higher values = fewer, more significant peaks. Default 0.1.
         max_lag_hours: Maximum lag time in hours to search for peaks. Default 4 hours.
 
     Returns:
-        List of lag timedeltas corresponding to autocorrelation peaks, filtered by max_horizon.
+        List of lag timedeltas corresponding to autocorrelation peaks, filtered by min_horizon.
         Returns empty list if scipy is not available, data is insufficient, or has no variance.
 
     """
@@ -382,7 +382,7 @@ def generate_autocorr_lags(
     lag_minutes_array = peaks * 15
 
     # Convert to timedelta and filter by horizon
-    lags = [timedelta(minutes=int(m)) for m in lag_minutes_array if timedelta(minutes=int(m)) >= max_horizon]
+    lags = [timedelta(minutes=int(m)) for m in lag_minutes_array if timedelta(minutes=int(m)) >= min_horizon]
 
-    logger.debug("Found %d autocorrelation-based lags for max_horizon=%s", len(lags), max_horizon)
+    logger.debug("Found %d autocorrelation-based lags for min_horizon=%s", len(lags), min_horizon)
     return sorted(lags, reverse=True)

--- a/packages/openstef-models/tests/unit/transforms/time_domain/test_lags_adder.py
+++ b/packages/openstef-models/tests/unit/transforms/time_domain/test_lags_adder.py
@@ -493,9 +493,10 @@ def test_add_lags_for_multiple_horizons():
         sample_interval=sample_interval,
         horizons=np.tile([lt.value for lt in horizons], num_samples).tolist(),
     )
+    assert dataset.horizons is not None
     lags_adder = LagsAdder(
         history_available=timedelta(hours=4),
-        horizons=dataset.horizons if dataset.horizons is not None else [LeadTime(value=sample_interval)],
+        horizons=dataset.horizons,
     )
 
     # Act

--- a/packages/openstef-models/tests/unit/transforms/time_domain/test_lags_adder.py
+++ b/packages/openstef-models/tests/unit/transforms/time_domain/test_lags_adder.py
@@ -20,7 +20,7 @@ from openstef_models.transforms.time_domain.lags_adder import (
 
 
 @pytest.mark.parametrize(
-    ("max_horizon", "expected_lags"),
+    ("min_horizon", "expected_lags"),
     [
         pytest.param(
             timedelta(minutes=15),
@@ -44,21 +44,21 @@ from openstef_models.transforms.time_domain.lags_adder import (
         ),
     ],
 )
-def test_generate_minute_lags_filters_by_horizon(max_horizon: timedelta, expected_lags: int):
+def test_generate_minute_lags_filters_by_horizon(min_horizon: timedelta, expected_lags: int):
     # Arrange
     # (parameters provided)
 
     # Act
-    result = generate_minute_lags(max_horizon)
+    result = generate_minute_lags(min_horizon)
 
     # Assert
     assert len(result) == expected_lags
-    # All lags must meet the horizon requirement (>= max_horizon)
-    assert all(lag >= max_horizon for lag in result)
+    # All lags must meet the horizon requirement (>= min_horizon)
+    assert all(lag >= min_horizon for lag in result)
 
 
 @pytest.mark.parametrize(
-    ("max_horizon", "max_day_lags", "expected_lags"),
+    ("min_horizon", "max_day_lags", "expected_lags"),
     [
         pytest.param(
             timedelta(hours=24),
@@ -93,13 +93,13 @@ def test_generate_minute_lags_filters_by_horizon(max_horizon: timedelta, expecte
     ],
 )
 def test_generate_day_lags_respects_horizon_and_max(
-    max_horizon: timedelta, max_day_lags: int, expected_lags: list[timedelta]
+    min_horizon: timedelta, max_day_lags: int, expected_lags: list[timedelta]
 ):
     # Arrange
     # (parameters provided)
 
     # Act
-    result = generate_day_lags(max_horizon, max_day_lags)
+    result = generate_day_lags(min_horizon, max_day_lags)
 
     # Assert
     assert result == expected_lags
@@ -115,7 +115,7 @@ def _create_periodic_signal(num_samples: int = 600) -> pd.Series:
 
 
 @pytest.mark.parametrize(
-    ("max_horizon", "expected_lags"),
+    ("min_horizon", "expected_lags"),
     [
         pytest.param(
             timedelta(minutes=15),
@@ -135,7 +135,7 @@ def _create_periodic_signal(num_samples: int = 600) -> pd.Series:
         ),
     ],
 )
-def test_generate_autocorr_lags_finds_expected_peaks(max_horizon: timedelta, expected_lags: list[timedelta]):
+def test_generate_autocorr_lags_finds_expected_peaks(min_horizon: timedelta, expected_lags: list[timedelta]):
     """Test autocorrelation with known periodic signal produces expected lags.
 
     Signal combines 1h and 2h periods. Autocorrelation detects peaks at these periods
@@ -146,14 +146,14 @@ def test_generate_autocorr_lags_finds_expected_peaks(max_horizon: timedelta, exp
     signal = _create_periodic_signal(num_samples=600)
 
     # Act
-    result = generate_autocorr_lags(signal=signal, max_horizon=max_horizon)
+    result = generate_autocorr_lags(signal=signal, min_horizon=min_horizon)
 
     # Assert - should find expected lags based on signal periodicity
     assert result == expected_lags
 
 
 @pytest.mark.parametrize(
-    ("signal", "max_horizon"),
+    ("signal", "min_horizon"),
     [
         pytest.param(
             pd.Series(np.random.default_rng(42).standard_normal(50)),
@@ -167,12 +167,12 @@ def test_generate_autocorr_lags_finds_expected_peaks(max_horizon: timedelta, exp
         ),
     ],
 )
-def test_generate_autocorr_lags_returns_empty_for_edge_cases(signal: pd.Series, max_horizon: timedelta):
+def test_generate_autocorr_lags_returns_empty_for_edge_cases(signal: pd.Series, min_horizon: timedelta):
     # Arrange
     # (parameters provided)
 
     # Act
-    result = generate_autocorr_lags(signal, max_horizon)
+    result = generate_autocorr_lags(signal, min_horizon)
 
     # Assert - should return empty list for edge cases
     assert result == []
@@ -474,3 +474,61 @@ def test_lags_adder__fallback_multiple_lags():
     # Assert — both lag columns filled from load[5] = 6
     assert transformed.data["load_lag_P1D"].iloc[13] == pytest.approx(6.0)
     assert transformed.data["load_lag_P2D"].iloc[14] == pytest.approx(6.0)
+
+
+def test_add_lags_for_multiple_horizons():
+    """Test that lags are calculated correctly for multiple horizons."""
+    # Arrange (time series dataset with four different horizons)
+    sample_interval = timedelta(minutes=15)
+    num_samples = 96  # 1 day of 15-min data
+    horizons = [
+        LeadTime(timedelta(hours=1)),
+        LeadTime(timedelta(hours=2)),
+        LeadTime(timedelta(hours=3)),
+        LeadTime(timedelta(hours=4)),
+    ]
+    dataset = create_timeseries_dataset(
+        index=pd.date_range("2025-01-01", periods=num_samples, freq=sample_interval).repeat(len(horizons)),
+        load=np.repeat(np.arange(num_samples, dtype=float), len(horizons)).tolist(),
+        sample_interval=sample_interval,
+        horizons=np.tile([lt.value for lt in horizons], num_samples).tolist(),
+    )
+    lags_adder = LagsAdder(
+        history_available=timedelta(hours=4),
+        horizons=dataset.horizons if dataset.horizons is not None else [LeadTime(value=sample_interval)],
+    )
+
+    # Act
+    transformed = lags_adder.transform(dataset)
+
+    # Assert - check each horizon has correct lags based on its lead time and `history_available`.
+    # `transformed` must exactly contain all lag columns >= 1 hour (smallest lag) and <= 4 hours
+    # (available history).
+    expected_lags = {
+        "load_lag_PT1H": timedelta(hours=1),
+        "load_lag_PT2H": timedelta(hours=2),
+        "load_lag_PT3H": timedelta(hours=3),
+        "load_lag_PT4H": timedelta(hours=4),
+    }
+    expected_features = ["load", *expected_lags.keys()]
+    assert transformed.feature_names == expected_features
+    for horizon in horizons:
+        transformed_for_horizon = transformed.select_horizon(horizon)
+        for lag_col, lag_duration in expected_lags.items():
+            if lag_duration >= horizon.value:
+                num_expected_shifts = int(lag_duration / sample_interval)
+                shifted_original_column = transformed_for_horizon.data["load"].shift(num_expected_shifts)
+                expected_values = shifted_original_column[
+                    shifted_original_column.index.isin(transformed_for_horizon.index)
+                ].to_numpy()
+            else:
+                # If the lag is smaller than the horizon, all values must be NaN.
+                expected_values = np.full(
+                    shape=len(transformed_for_horizon.index),
+                    fill_value=np.nan,
+                )
+            assert np.array_equal(
+                transformed_for_horizon.data[lag_col].to_numpy(),
+                expected_values,
+                equal_nan=True,
+            )


### PR DESCRIPTION
When adding standard (trivial) lags to a multi-horizon dataset, currently the longest horizon determines the smallest available lag. As an example, assume we have two horizons, 1 hour and 1 day. Using this logic, no lag smaller than 1 day is added to the dataset. This means that for the forecasting model, the data for BOTH horizons looks exactly like the data for the 1-day horizon.

Instead, the shortest horizon should determine the smallest available lag. This means that in the above example, the following behavior should be observed:
 - All lags smaller than 1 hour are never available and therefore not added to the dataset.
 - All lags larger than 1 hour but smaller than 1 day are available for the 1-hour horizon, but not for the 1-day horizon. Therefore, the corresponding lag columns are filled partially, depending on the horizon.
 - All lags larger than 1 day are always available, so the corresponding columns are filled completely (except of course any transient behavior at the beginning).

This PR proposes to basically just exchange `max_horizon` by `min_horizon` as a simple fix.
I also added a test to verify the expected behavior end-to-end.