### PR TITLE
feature: completeness and input validation checks for ConstantQuantileForecaster

### DIFF
--- a/packages/openstef-models/src/openstef_models/models/forecasting/constant_quantile_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/constant_quantile_forecaster.py
@@ -88,10 +88,9 @@ class ConstantQuantileForecaster(Forecaster, ExplainableForecaster, Contribution
 
     @override
     def fit(self, data: ForecastInputDataset, data_val: ForecastInputDataset | None = None) -> None:
-        target_series = data.target_series.dropna()
-        if target_series.empty:
+        if data.target_series.isna().all():
             raise InputValidationError("Training data must contain at least one non-NaN value in the target column.")
-        self._quantile_values = {quantile: target_series.quantile(quantile) for quantile in self.quantiles}
+        self._quantile_values = {quantile: data.target_series.quantile(quantile) for quantile in self.quantiles}
 
     @override
     def predict(self, data: ForecastInputDataset) -> ForecastDataset:

--- a/packages/openstef-models/src/openstef_models/models/forecasting/constant_quantile_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/constant_quantile_forecaster.py
@@ -14,7 +14,7 @@ import pandas as pd
 from pydantic import Field, PrivateAttr
 
 from openstef_core.datasets.validated_datasets import ForecastDataset, ForecastInputDataset, TimeSeriesDataset
-from openstef_core.exceptions import NotFittedError
+from openstef_core.exceptions import InputValidationError, NotFittedError
 from openstef_core.mixins.predictor import HyperParams
 from openstef_core.types import Any, LeadTime, Quantile
 from openstef_models.explainability.mixins import ContributionsMixin, ExplainableForecaster
@@ -88,7 +88,10 @@ class ConstantQuantileForecaster(Forecaster, ExplainableForecaster, Contribution
 
     @override
     def fit(self, data: ForecastInputDataset, data_val: ForecastInputDataset | None = None) -> None:
-        self._quantile_values = {quantile: data.target_series.quantile(quantile) for quantile in self.quantiles}
+        target_series = data.target_series.dropna()
+        if target_series.empty:
+            raise InputValidationError("Training data must contain at least one non-NaN value in the target column.")
+        self._quantile_values = {quantile: target_series.quantile(quantile) for quantile in self.quantiles}
 
     @override
     def predict(self, data: ForecastInputDataset) -> ForecastDataset:

--- a/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
+++ b/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
@@ -197,6 +197,10 @@ class ForecastingWorkflowConfig(BaseConfig):  # PredictionJob
         default=0.5,
         description="Minimum fraction of data that should be available for making a regular forecast.",
     )
+    completeness_threshold_target_constant_quantile: float = Field(
+        default=0.03,
+        description="Minimum fraction of target data that should be available for making a constant quantile forecast.",
+    )
     flatliner_threshold: timedelta = Field(
         default=timedelta(hours=24),
         description="Number of minutes that the load has to be constant to detect a flatliner.",
@@ -506,7 +510,12 @@ def create_forecasting_workflow(
         )
         postprocessing = []
     elif config.model == "constant_quantile":
-        preprocessing = []
+        preprocessing = [
+            CompletenessChecker(
+                columns=[config.target_column],
+                completeness_threshold=config.completeness_threshold_target_constant_quantile,
+            ),
+        ]
         forecaster = ConstantQuantileForecaster(
             quantiles=config.quantiles,
             horizons=config.horizons,

--- a/packages/openstef-models/tests/unit/models/forecasting/test_constant_quantile_forecaster.py
+++ b/packages/openstef-models/tests/unit/models/forecasting/test_constant_quantile_forecaster.py
@@ -5,6 +5,7 @@
 import math
 from datetime import datetime, timedelta
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -17,16 +18,9 @@ from openstef_models.models.forecasting.constant_quantile_forecaster import (
 )
 
 
-@pytest.fixture
-def sample_forecast_input_dataset() -> ForecastInputDataset:
-    """Create sample input dataset for forecaster training and prediction.
-
-    Returns:
-        ForecastInputDataset with load values [90, 100, 110, 120, 130] spanning 5 hours,
-        designed for predictable quantile calculation.
-    """
+def create_forecast_input_dataset(values: list[float]) -> ForecastInputDataset:
     data = pd.DataFrame(
-        {"load": [90.0, 100.0, 110.0, 120.0, 130.0]},
+        {"load": values},
         index=pd.date_range(datetime.fromisoformat("2025-01-01T00:00:00"), periods=5, freq="1h"),
     )
     return ForecastInputDataset(
@@ -47,13 +41,23 @@ def sample_forecaster() -> ConstantQuantileForecaster:
     )
 
 
-def test_constant_median_forecaster__fit_predict(
+@pytest.mark.parametrize(
+    ("values", "expected_quantile_values"),
+    [
+        pytest.param([90.0, 100.0, 110.0, 120.0, 130.0], [99, 115, 131], id="simple"),
+        pytest.param([100.0, 100.0, 100.0, 100.0, 100.0], [105, 105, 105], id="constant"),
+        pytest.param([90.0, 100.0, np.nan, 120.0, 130.0], [98, 115, 132], id="single_nan"),
+    ],
+)
+def test_constant_quantile_forecaster__fit_predict(
+    values: list[float],
+    expected_quantile_values: list[float],
     sample_forecaster: ConstantQuantileForecaster,
-    sample_forecast_input_dataset: ForecastInputDataset,
 ):
     """Test that forecaster trains on data and produces constant predictions with added hyperparameter."""
     # Arrange
     forecaster = sample_forecaster.model_copy(deep=True)
+    sample_forecast_input_dataset = create_forecast_input_dataset(values)
 
     # Act
     forecaster.fit(sample_forecast_input_dataset)
@@ -65,18 +69,27 @@ def test_constant_median_forecaster__fit_predict(
     assert isinstance(result, ForecastDataset)
     assert len(result.data) == 7  # Only forecasts after forecast_start (2025-01-01T02:00:00)
 
-    # Check quantile values: quantiles of [90, 100, 110, 120, 130] plus constant 5.0
-    expected_p10 = 99.0  # 94 + 5
-    expected_median = 115.0  # 110 + 5
-    expected_p90 = 131.0  # 126 + 5
-
+    expected_p10, expected_median, expected_p90 = expected_quantile_values
     actual_values = result.data.iloc[0]  # First forecast row
+    assert np.isfinite(actual_values).all()
     assert math.isclose(actual_values["quantile_P10"], expected_p10)
     assert math.isclose(actual_values["quantile_P50"], expected_median)
     assert math.isclose(actual_values["quantile_P90"], expected_p90)
 
 
-def test_constant_median_forecaster__predict_not_fitted_raises_error(
+def test_constant_quantile_forecaster__fit_with_all_nan_target_raises_error(sample_forecaster: ConstantQuantileForecaster):
+    """Test that fitting with all NaN target values raises InputValidationError."""
+    # Arrange
+    forecaster = sample_forecaster.model_copy(deep=True)
+    nan_values = [float("nan")] * 5
+    sample_forecast_input_dataset = create_forecast_input_dataset(nan_values)
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="Training data must contain at least one non-NaN value in the target column."):
+        forecaster.fit(sample_forecast_input_dataset)
+
+
+def test_constant_quantile_forecaster__predict_not_fitted_raises_error(
     sample_forecaster: ConstantQuantileForecaster,
 ):
     """Test that predicting without fitting raises ModelNotFittedError."""

--- a/packages/openstef-models/tests/unit/models/forecasting/test_constant_quantile_forecaster.py
+++ b/packages/openstef-models/tests/unit/models/forecasting/test_constant_quantile_forecaster.py
@@ -87,7 +87,9 @@ def test_constant_quantile_forecaster__fit_with_all_nan_target_raises_error(
     sample_forecast_input_dataset = create_forecast_input_dataset(nan_values)
 
     # Act & Assert
-    with pytest.raises(ValueError, match=r"Training data must contain at least one non-NaN value in the target column."):
+    with pytest.raises(
+        ValueError, match=r"Training data must contain at least one non-NaN value in the target column."
+    ):
         forecaster.fit(sample_forecast_input_dataset)
 
 

--- a/packages/openstef-models/tests/unit/models/forecasting/test_constant_quantile_forecaster.py
+++ b/packages/openstef-models/tests/unit/models/forecasting/test_constant_quantile_forecaster.py
@@ -77,7 +77,9 @@ def test_constant_quantile_forecaster__fit_predict(
     assert math.isclose(actual_values["quantile_P90"], expected_p90)
 
 
-def test_constant_quantile_forecaster__fit_with_all_nan_target_raises_error(sample_forecaster: ConstantQuantileForecaster):
+def test_constant_quantile_forecaster__fit_with_all_nan_target_raises_error(
+    sample_forecaster: ConstantQuantileForecaster,
+):
     """Test that fitting with all NaN target values raises InputValidationError."""
     # Arrange
     forecaster = sample_forecaster.model_copy(deep=True)
@@ -85,7 +87,7 @@ def test_constant_quantile_forecaster__fit_with_all_nan_target_raises_error(samp
     sample_forecast_input_dataset = create_forecast_input_dataset(nan_values)
 
     # Act & Assert
-    with pytest.raises(ValueError, match="Training data must contain at least one non-NaN value in the target column."):
+    with pytest.raises(ValueError, match=r"Training data must contain at least one non-NaN value in the target column."):
         forecaster.fit(sample_forecast_input_dataset)
 
 


### PR DESCRIPTION
This pull request improves the robustness and configurability of the `ConstantQuantileForecaster` by introducing stricter input validation, adding a new configuration option for data completeness, and enhancing the unit tests for better coverage and clarity. The main themes are input validation, workflow configuration, and test improvements.

**Input validation improvements:**
* The `fit` method of `ConstantQuantileForecaster` now raises an `InputValidationError` if the training data's target column contains only NaN values, ensuring the model is never trained on invalid data.
* The relevant exception import was added to the top of the file.

**Workflow configuration enhancements:**
* Added a new configuration field `completeness_threshold_target_constant_quantile` to `ForecastingWorkflowConfig`, allowing users to specify the minimum required fraction of non-NaN target values for the constant quantile model.
* Updated the forecasting workflow to use a `CompletenessChecker` with the new threshold for the `constant_quantile` model, improving data quality checks before training.

**Test improvements:**
* Refactored and expanded unit tests for `ConstantQuantileForecaster`:
  - Added parameterized tests to cover various input scenarios, including all-NaN targets and mixed NaN/non-NaN data, and verified correct exception handling for invalid input. [[1]](diffhunk://#diff-5c1083a1f2d0245b703568914112c47831bbed73b4c61fff4d7713d0bfc90713L20-R23) [[2]](diffhunk://#diff-5c1083a1f2d0245b703568914112c47831bbed73b4c61fff4d7713d0bfc90713L50-R60) [[3]](diffhunk://#diff-5c1083a1f2d0245b703568914112c47831bbed73b4c61fff4d7713d0bfc90713L68-R94)
  - Improved test clarity and maintainability by introducing a helper function for creating input datasets and using `numpy` for numerical assertions. [[1]](diffhunk://#diff-5c1083a1f2d0245b703568914112c47831bbed73b4c61fff4d7713d0bfc90713R8) [[2]](diffhunk://#diff-5c1083a1f2d0245b703568914112c47831bbed73b4c61fff4d7713d0bfc90713L20-R23)