### PR TITLE
chore(deps): add dependabot config with grouped daily updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,10 @@
 #
 # Goals:
 #  - Reduce PR volume (was ~1 PR per package per advisory) by grouping
-#    patch+minor bumps weekly.
-#  - Keep security visible: separate `applies-to: security-updates`
-#    groups so they don't get buried in dev bundles.
+#    patch+minor bumps into daily bundles.
+#  - Keep security visible and fast: separate `applies-to: security-updates`
+#    groups land within ~24h on the daily cadence rather than waiting
+#    up to a week.
 #  - Major bumps stay individual — they often need code changes.
 #
 # Block layout:
@@ -17,7 +18,7 @@
 #    members put sphinx/jupyter under `dependencies`, so the
 #    production/development filter doesn't separate them usefully —
 #    everything in these roots is treated as docs/example tooling.
-#  - Block 3: GitHub Actions, single grouped weekly PR.
+#  - Block 3: GitHub Actions, single grouped daily PR.
 
 version: 2
 
@@ -33,8 +34,7 @@ updates:
       - "/packages/openstef-meta"
       - "/packages/openstef-models"
     schedule:
-      interval: weekly
-      day: monday
+      interval: daily
       time: "06:00"
       timezone: Europe/Amsterdam
     open-pull-requests-limit: 10
@@ -72,8 +72,7 @@ updates:
       - "/docs"
       - "/examples"
     schedule:
-      interval: weekly
-      day: monday
+      interval: daily
       time: "06:00"
       timezone: Europe/Amsterdam
     open-pull-requests-limit: 5
@@ -102,8 +101,7 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
-      day: monday
+      interval: daily
       time: "06:00"
       timezone: Europe/Amsterdam
     open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: 2026 Contributors to the OpenSTEF project <openstef@lfenergy.org>
+# SPDX-License-Identifier: MPL-2.0
+
+# Dependabot configuration for the OpenSTEF uv workspace.
+#
+# Goals:
+#  - Reduce PR volume (was ~1 PR per package per advisory) by grouping
+#    patch+minor bumps weekly.
+#  - Keep security visible: separate `applies-to: security-updates`
+#    groups so they don't get buried in dev bundles.
+#  - Major bumps stay individual — they often need code changes.
+#
+# Block layout:
+#  - Block 1: published packages (root + packages/*). Splits runtime
+#    (`project.dependencies`) from dev (`dependency-groups.dev`).
+#  - Block 2: internal tooling (docs/, examples/). These workspace
+#    members put sphinx/jupyter under `dependencies`, so the
+#    production/development filter doesn't separate them usefully —
+#    everything in these roots is treated as docs/example tooling.
+#  - Block 3: GitHub Actions, single grouped weekly PR.
+
+version: 2
+
+updates:
+  # ---------------------------------------------------------------------
+  # Block 1 — Published packages (runtime + dev tooling at root)
+  # ---------------------------------------------------------------------
+  - package-ecosystem: pip
+    directories:
+      - "/"
+      - "/packages/openstef-beam"
+      - "/packages/openstef-core"
+      - "/packages/openstef-meta"
+      - "/packages/openstef-models"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Amsterdam
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: scope
+    labels:
+      - dependencies
+      - python:uv
+    groups:
+      python-security:
+        applies-to: security-updates
+        update-types:
+          - patch
+          - minor
+      python-runtime:
+        applies-to: version-updates
+        dependency-type: production
+        update-types:
+          - patch
+          - minor
+      python-dev:
+        applies-to: version-updates
+        dependency-type: development
+        update-types:
+          - patch
+          - minor
+
+  # ---------------------------------------------------------------------
+  # Block 2 — Internal tooling: docs and examples
+  # ---------------------------------------------------------------------
+  - package-ecosystem: pip
+    directories:
+      - "/docs"
+      - "/examples"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Amsterdam
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps-docs)"
+      include: scope
+    labels:
+      - dependencies
+      - python:uv
+      - documentation
+    groups:
+      python-tooling-security:
+        applies-to: security-updates
+        update-types:
+          - patch
+          - minor
+      python-tooling:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor
+
+  # ---------------------------------------------------------------------
+  # Block 3 — GitHub Actions
+  # ---------------------------------------------------------------------
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Amsterdam
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+      include: scope
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      actions-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Replaces Dependabot's default per-package PR behaviour with a curated config that scans all uv workspace roots and bundles patch/minor updates into a handful of weekly PRs.

The repo currently has **7 open individual Dependabot PRs** and 30 open security alerts, mostly concentrated in docs/notebook tooling (jupyter-server, mistune, pillow, etc.). The default config opens one PR per package per advisory — this config groups them so review volume becomes manageable.

## What changes

Three update blocks:

### Block 1 — Published packages (`/`, `packages/*`)
- `python-security` — security patches/minors bundled (visible, separate from dev noise)
- `python-runtime` — production `project.dependencies` patch/minor
- `python-dev` — `dependency-groups.dev` patch/minor

### Block 2 — Internal tooling (`docs/`, `examples/`)
- `python-tooling-security`
- `python-tooling`

These workspace members put sphinx/jupyter under `dependencies`, so the production/development filter doesn't separate them usefully. Treating both as a single tooling bucket avoids muddling sphinx/jupyter bumps into the runtime group.

### Block 3 — GitHub Actions
- Single grouped weekly PR (all actions are SHA-pinned, each bump reviewed for SHA regardless of update type).

## Behaviour

- **Major bumps stay individual** — they often need code changes.
- Schedule: weekly Monday 06:00 Europe/Amsterdam.
- PR caps: 10 for published, 5 for tooling/actions.
- Commit prefixes: `chore(deps)`, `chore(deps-dev)`, `chore(deps-docs)`, `chore(ci)`.

Realistic outcome: **~3–4 PRs/week instead of one per package**.

## After merging this

- **Existing 7 open Dependabot PRs are not retroactively bundled** — they stay as-is until merged or closed. New runs use the new config.
- First run after merge will surface the bundled outstanding security/version updates as 1–4 PRs.
- If the dev/runtime split feels noisy, easy to switch to one bundle by removing `dependency-type` from the groups.