### PR TITLE
chore(deps): use uv ecosystem and add cooldown for supply-chain hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,12 @@
 #  - Reduce PR volume (was ~1 PR per package per advisory) by grouping
 #    patch+minor bumps into daily bundles.
 #  - Keep security visible and fast: separate `applies-to: security-updates`
-#    groups land within ~24h on the daily cadence rather than waiting
-#    up to a week.
+#    groups land within ~24h on the daily cadence. `cooldown` does NOT
+#    apply to security updates, so CVE fixes are never throttled.
+#  - Supply-chain hardening via `cooldown`: a brand-new release waits a
+#    few days before Dependabot proposes a bump, which gives the
+#    community time to surface malicious or broken releases (e.g.
+#    xz-utils 2024, tj-actions/changed-files 2025).
 #  - Major bumps stay individual — they often need code changes.
 #
 # Block layout:
@@ -26,7 +30,7 @@ updates:
   # ---------------------------------------------------------------------
   # Block 1 — Published packages (runtime + dev tooling at root)
   # ---------------------------------------------------------------------
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directories:
       - "/"
       - "/packages/openstef-beam"
@@ -45,6 +49,13 @@ updates:
     labels:
       - dependencies
       - python:uv
+    # Cooldown applies to version-updates only. Security-updates bypass
+    # it entirely so CVE patches are never delayed.
+    cooldown:
+      default-days: 3
+      semver-patch-days: 2
+      semver-minor-days: 5
+      semver-major-days: 7
     groups:
       python-security:
         applies-to: security-updates
@@ -67,7 +78,7 @@ updates:
   # ---------------------------------------------------------------------
   # Block 2 — Internal tooling: docs and examples
   # ---------------------------------------------------------------------
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directories:
       - "/docs"
       - "/examples"
@@ -83,6 +94,11 @@ updates:
       - dependencies
       - python:uv
       - documentation
+    cooldown:
+      default-days: 3
+      semver-patch-days: 2
+      semver-minor-days: 5
+      semver-major-days: 7
     groups:
       python-tooling-security:
         applies-to: security-updates
@@ -111,6 +127,14 @@ updates:
     labels:
       - dependencies
       - github-actions
+    # Actions are SHA-pinned but cooldown still helps catch incidents
+    # like tj-actions/changed-files (March 2025) where a compromised
+    # action was published and detected within days.
+    cooldown:
+      default-days: 3
+      semver-patch-days: 2
+      semver-minor-days: 5
+      semver-major-days: 7
     groups:
       actions-all:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,4 +62,5 @@ updates:
       semver-minor-days: 5
       semver-major-days: 7
     groups:
-      actions-all: {}
+      actions-all:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,9 +58,6 @@ updates:
       - github-actions
     cooldown:
       default-days: 3
-      semver-patch-days: 2
-      semver-minor-days: 5
-      semver-major-days: 7
     groups:
       actions-all:
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,36 +3,18 @@
 
 # Dependabot configuration for the OpenSTEF uv workspace.
 #
-# Goals:
-#  - Reduce PR volume (was ~1 PR per package per advisory) by grouping
-#    patch+minor bumps into daily bundles.
-#  - Keep security visible and fast: separate `applies-to: security-updates`
-#    groups land within ~24h on the daily cadence. `cooldown` does NOT
-#    apply to security updates, so CVE fixes are never throttled.
-#  - Supply-chain hardening via `cooldown`: a brand-new release waits a
-#    few days before Dependabot proposes a bump, which gives the
-#    community time to surface malicious or broken releases (e.g.
-#    xz-utils 2024, tj-actions/changed-files 2025).
-#  - Major bumps stay individual — they often need code changes.
-#
-# Block layout:
-#  - Block 1: published packages (root + packages/*). Splits runtime
-#    (`project.dependencies`) from dev (`dependency-groups.dev`).
-#  - Block 2: internal tooling (docs/, examples/). These workspace
-#    members put sphinx/jupyter under `dependencies`, so the
-#    production/development filter doesn't separate them usefully —
-#    everything in these roots is treated as docs/example tooling.
-#  - Block 3: GitHub Actions, single grouped daily PR.
+#  - Patch/minor updates are grouped into daily PRs; majors stay individual.
+#  - Cooldown delays brand-new releases by a few days as supply-chain protection.
+#  - Security advisories are in their own group, exempt from cooldown.
 
 version: 2
 
 updates:
-  # ---------------------------------------------------------------------
-  # Block 1 — Published packages (runtime + dev tooling at root)
-  # ---------------------------------------------------------------------
   - package-ecosystem: uv
     directories:
       - "/"
+      - "/docs"
+      - "/examples"
       - "/packages/openstef-beam"
       - "/packages/openstef-core"
       - "/packages/openstef-meta"
@@ -44,13 +26,10 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps)"
-      prefix-development: "chore(deps-dev)"
       include: scope
     labels:
       - dependencies
       - python:uv
-    # Cooldown applies to version-updates only. Security-updates bypass
-    # it entirely so CVE patches are never delayed.
     cooldown:
       default-days: 3
       semver-patch-days: 2
@@ -59,61 +38,11 @@ updates:
     groups:
       python-security:
         applies-to: security-updates
-        update-types:
-          - patch
-          - minor
-      python-runtime:
+        update-types: [patch, minor]
+      python-versions:
         applies-to: version-updates
-        dependency-type: production
-        update-types:
-          - patch
-          - minor
-      python-dev:
-        applies-to: version-updates
-        dependency-type: development
-        update-types:
-          - patch
-          - minor
+        update-types: [patch, minor]
 
-  # ---------------------------------------------------------------------
-  # Block 2 — Internal tooling: docs and examples
-  # ---------------------------------------------------------------------
-  - package-ecosystem: uv
-    directories:
-      - "/docs"
-      - "/examples"
-    schedule:
-      interval: daily
-      time: "06:00"
-      timezone: Europe/Amsterdam
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: "chore(deps-docs)"
-      include: scope
-    labels:
-      - dependencies
-      - python:uv
-      - documentation
-    cooldown:
-      default-days: 3
-      semver-patch-days: 2
-      semver-minor-days: 5
-      semver-major-days: 7
-    groups:
-      python-tooling-security:
-        applies-to: security-updates
-        update-types:
-          - patch
-          - minor
-      python-tooling:
-        applies-to: version-updates
-        update-types:
-          - patch
-          - minor
-
-  # ---------------------------------------------------------------------
-  # Block 3 — GitHub Actions
-  # ---------------------------------------------------------------------
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -127,15 +56,10 @@ updates:
     labels:
       - dependencies
       - github-actions
-    # Actions are SHA-pinned but cooldown still helps catch incidents
-    # like tj-actions/changed-files (March 2025) where a compromised
-    # action was published and detected within days.
     cooldown:
       default-days: 3
       semver-patch-days: 2
       semver-minor-days: 5
       semver-major-days: 7
     groups:
-      actions-all:
-        patterns:
-          - "*"
+      actions-all: {}


### PR DESCRIPTION
## Summary

Follow-up to #913. Two related changes to the Dependabot config:

### 1. Switch `package-ecosystem` from `pip` to `uv`

Dependabot has a dedicated `uv` ecosystem for projects with `uv.lock` files. The previous config used `pip` (the umbrella Python ecosystem), which worked as a fallback but isn't the canonical value.

Per Astral's docs: <https://docs.astral.sh/uv/guides/integration/dependabot/>

### 2. Add `cooldown` blocks for supply-chain hardening

Brand-new releases now wait a few days before Dependabot proposes a bump, giving the community time to surface malicious or broken releases.

This is the main defence against supply-chain attacks like:
- **xz-utils** (March 2024) — malicious release caught within days of publication
- **tj-actions/changed-files** (March 2025) — compromised action detected fast by the community

Cooldown values applied to all three ecosystems (uv published, uv tooling, github-actions):

| Update type | Days delayed |
|---|---|
| patch | 2 |
| minor | 5 |
| major | 7 |
| default (e.g. pre-releases) | 3 |

### Important: security updates bypass cooldown

Per [GitHub docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference): "The `cooldown` option is only available for *version* updates, not *security* updates."

So CVE patches still land within ~24h on the daily cadence. Cooldown only delays routine version bumps.

## Test plan

- [ ] Dependabot accepts the new config (check Insights → Dependency Graph → Dependabot tab; any config errors surface there).
- [ ] First daily run after merge: confirm PRs are still being created (cooldown of 2 days could mean the first bundle is smaller than usual if recent bumps are still within the window).
- [ ] Spot check: a security PR fires immediately when an alert is published, not delayed by cooldown.