### PR TITLE
chore(deps): set dependabot to lockfile-only versioning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@
 # Dependabot configuration for the OpenSTEF uv workspace.
 #
 #  - Patch/minor updates are grouped into daily PRs; majors stay individual.
+#  - lockfile-only: updates touch uv.lock only, never widen pyproject.toml
+#    constraints, so no "update X requirement from A to B" PRs.
 #  - Cooldown delays brand-new releases by a few days as supply-chain protection.
 #  - Security advisories are in their own group, exempt from cooldown.
 
@@ -24,6 +26,7 @@ updates:
       time: "06:00"
       timezone: Europe/Amsterdam
     open-pull-requests-limit: 10
+    versioning-strategy: lockfile-only
     commit-message:
       prefix: "chore(deps)"
       include: scope


### PR DESCRIPTION
## Summary

Adds `versioning-strategy: lockfile-only` to the uv block in `.github/dependabot.yml`.

This stops the **"update X requirement from A to B" PR spam** — the per-package, per-directory PRs (e.g. #915, #916, #925–#929) that widen the declared version ranges in `pyproject.toml`. With lockfile-only, Dependabot updates only `uv.lock`; declared constraints stay put and are widened deliberately by a maintainer when adopting a new major.

## Unaffected

- Security updates still fire (they bump the lockfile).
- Grouping, cooldown, and the daily schedule are unchanged.
- Major bumps still surface (as lockfile updates) where the range allows.

## Notes

The currently-open requirement-widening Dependabot PRs are superseded by the lock refresh in #934 and can be closed.