### PR TITLE
ci: add docs build check on PRs (no deploy)

### DIFF
--- a/.github/workflows/docs-check.yaml
+++ b/.github/workflows/docs-check.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: 2026 Contributors to the OpenSTEF project <openstef@lfenergy.org>
+# SPDX-License-Identifier: MPL-2.0
+
+# Builds the documentation on PRs WITHOUT deploying it, so that changes which
+# break the docs build (e.g. a dependency bump that breaks notebook execution
+# or static figure export) are caught before they reach main, where the
+# Deploy Documentation workflow would otherwise fail.
+#
+# The build executes the tutorials, so it is slow. It therefore only runs when
+# a PR touches inputs that can affect the build (dependencies, docs sources,
+# example notebooks), and can also be triggered manually from the Actions tab.
+
+name: Docs Build Check
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths:
+      - "uv.lock"
+      - "**/pyproject.toml"
+      - "docs/**"
+      - "examples/**"
+      - ".github/workflows/docs-check.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-docs:
+    name: Build Documentation (no deploy)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          show-progress: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          activate-environment: true
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen --no-install-project --all-groups --all-extras
+
+      - name: Build Sphinx documentation
+        run: poe docs
+
+      - name: Upload built docs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: docs-html
+          path: docs/build/html
+          retention-days: 7
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Adds `.github/workflows/docs-check.yaml` — builds the docs on PRs **without deploying**, to catch build breakages before they reach `main` (where `Deploy Documentation` would fail, as just happened with the kaleido 1.3 regression in #939).

This is the prevention for that class of bug: the test/lint suite never builds the docs, so a dependency bump that only breaks notebook execution or static figure export is invisible until the post-merge deploy.

## Design

- **Path-filtered PR trigger**: runs only when a PR touches `uv.lock`, `**/pyproject.toml`, `docs/**`, or `examples/**` — the inputs that can affect the build. Most PRs skip the slow build. (#934 touched `uv.lock`, so this *would* have caught the kaleido break pre-merge.)
- **`workflow_dispatch`**: a manual "run it now" button in the Actions tab.
- **Build-only, no deploy**: `docs.yaml` still owns deployment on `main`. Uploads the HTML as an artifact for preview.
- Runs as its own job, in parallel with Quality Checks (no added wall-clock).

## Not a required check (yet)

Left non-blocking on purpose: executed-notebook builds can be network-flaky (HF dataset download, etc.), and a path-filtered *required* check also blocks merges on PRs that don't trigger it (GitHub treats a skipped required check as pending). Promote to required via branch protection once it's proven stable.

## Note

The build is inherently slow because it must **execute** the tutorials — that's exactly what catches export-time errors like the kaleido one. Path-filtering is what keeps that cost off unrelated PRs.