### PR TITLE
fix(#881): make forecasted timestamps consistent over forecasters

### DIFF
--- a/docs/source/user_guide/concepts/models.rst
+++ b/docs/source/user_guide/concepts/models.rst
@@ -39,6 +39,24 @@ a Forecaster - it is solely responsible for the mathematical prediction step.
 All forecasters implement the :class:`~openstef_models.models.forecasting.forecaster.Forecaster` interface with ``fit()`` and ``predict()``
 methods.
 
+.. rubric:: Output horizon guarantee
+
+Every forecaster obeys the following guarantee:
+
+  **A forecaster's** ``predict()`` **only returns timestamps in the interval**
+  ``[forecast_start, forecast_start + max_horizon]``.
+
+Rows in the input dataset that fall beyond ``max_horizon`` are silently discarded
+before the model runs. This is implemented by passing
+``horizon=self.max_horizon`` to
+:meth:`~openstef_core.datasets.validated_datasets.ForecastInputDataset.input_data`
+inside every ``predict()`` implementation.
+
+The consequence is that you can safely pass a :class:`~openstef_core.datasets.ForecastInputDataset` containing
+more data than the forecaster needs (e.g. a full day of context) without worrying
+that the forecaster will produce spurious predictions far into the future. Its
+output is always bounded by ``max_horizon``.
+
 Transforms
 ^^^^^^^^^^
 

--- a/docs/source/user_guide/concepts/models.rst
+++ b/docs/source/user_guide/concepts/models.rst
@@ -45,7 +45,7 @@ methods.
    in the interval ``[forecast_start, forecast_start + max_horizon]``. Input rows
    beyond ``max_horizon`` are silently discarded before the model runs. This is
    enforced by passing ``horizon=self.max_horizon`` to
-   :meth:`~openstef_core.datasets.validated_datasets.ForecastInputDataset.input_data`
+   :meth:`~openstef_core.datasets.ForecastInputDataset.input_data`
    inside every concrete ``predict()`` implementation. You can therefore safely pass
    a :class:`~openstef_core.datasets.ForecastInputDataset` containing more data than
    the forecaster needs without worrying about spurious predictions far into the future.

--- a/docs/source/user_guide/concepts/models.rst
+++ b/docs/source/user_guide/concepts/models.rst
@@ -39,23 +39,16 @@ a Forecaster - it is solely responsible for the mathematical prediction step.
 All forecasters implement the :class:`~openstef_models.models.forecasting.forecaster.Forecaster` interface with ``fit()`` and ``predict()``
 methods.
 
-.. rubric:: Output horizon guarantee
+.. note::
 
-Every forecaster obeys the following guarantee:
-
-  **A forecaster's** ``predict()`` **only returns timestamps in the interval**
-  ``[forecast_start, forecast_start + max_horizon]``.
-
-Rows in the input dataset that fall beyond ``max_horizon`` are silently discarded
-before the model runs. This is implemented by passing
-``horizon=self.max_horizon`` to
-:meth:`~openstef_core.datasets.validated_datasets.ForecastInputDataset.input_data`
-inside every ``predict()`` implementation.
-
-The consequence is that you can safely pass a :class:`~openstef_core.datasets.ForecastInputDataset` containing
-more data than the forecaster needs (e.g. a full day of context) without worrying
-that the forecaster will produce spurious predictions far into the future. Its
-output is always bounded by ``max_horizon``.
+   **Output horizon guarantee**: a forecaster's ``predict()`` only returns timestamps
+   in the interval ``[forecast_start, forecast_start + max_horizon]``. Input rows
+   beyond ``max_horizon`` are silently discarded before the model runs. This is
+   enforced by passing ``horizon=self.max_horizon`` to
+   :meth:`~openstef_core.datasets.validated_datasets.ForecastInputDataset.input_data`
+   inside every concrete ``predict()`` implementation. You can therefore safely pass
+   a :class:`~openstef_core.datasets.ForecastInputDataset` containing more data than
+   the forecaster needs without worrying about spurious predictions far into the future.
 
 Transforms
 ^^^^^^^^^^

--- a/packages/openstef-core/src/openstef_core/datasets/validated_datasets.py
+++ b/packages/openstef-core/src/openstef_core/datasets/validated_datasets.py
@@ -135,12 +135,14 @@ class ForecastInputDataset(TimeSeriesDataset):
 
         return pd.Series(1, index=self.index)
 
-    def input_data(self, start: datetime | None = None) -> pd.DataFrame:
+    def input_data(self, start: datetime | None = None, horizon: LeadTime | None = None) -> pd.DataFrame:
         """Extract the input features excluding the target column.
 
         Args:
             start: Optional datetime to filter data from. If provided, only includes
                 data points with timestamps at or after this date.
+            horizon: Optional maximum horizon to limit returned data. If provided, only
+                includes data points with timestamps at or before forecast_start + horizon.
 
         Returns:
             DataFrame containing input features with original datetime index.
@@ -152,6 +154,9 @@ class ForecastInputDataset(TimeSeriesDataset):
         input_data: pd.DataFrame = self.data.drop(columns=drop_columns, errors="ignore")
         if start is not None:
             input_data = input_data[input_data.index >= pd.Timestamp(start)]
+        if horizon is not None:
+            end = self.forecast_start + horizon.value
+            input_data = input_data[input_data.index <= pd.Timestamp(end)]
 
         return input_data
 

--- a/packages/openstef-core/tests/unit/datasets/test_validated_datasets.py
+++ b/packages/openstef-core/tests/unit/datasets/test_validated_datasets.py
@@ -4,7 +4,7 @@
 
 """Tests for validated dataset classes."""
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import numpy as np
 import pandas as pd
@@ -112,7 +112,7 @@ def test_input_data__expected_columns(basic_input_dataset: ForecastInputDataset)
 def test_input_data__start_filters_rows(basic_input_dataset: ForecastInputDataset):
     """Rows before start are excluded when start is provided."""
     # Arrange
-    start = datetime(2025, 1, 1, 3, 0)
+    start = datetime(2025, 1, 1, 3, 0, tzinfo=UTC)
 
     # Act
     result = basic_input_dataset.input_data(start=start)
@@ -170,7 +170,7 @@ def test_input_data__horizon_combined_with_start(basic_input_dataset: ForecastIn
     # Arrange
     # forecast_start = 2025-01-01T00:00, start = T+2h, horizon = 4h → end = T+4h
     # expected rows: T+2h, T+3h, T+4h → 3 rows
-    start = datetime(2025, 1, 1, 2, 0)
+    start = datetime(2025, 1, 1, 2, 0, tzinfo=UTC)
     horizon = LeadTime(timedelta(hours=4))
 
     # Act
@@ -262,7 +262,7 @@ def test_forecast_dataset__median_series_missing_raises(forecast_index: pd.Datet
 
     # Act & Assert
     with pytest.raises(MissingColumnsError):
-        ds.median_series
+        _ = ds.median_series
 
 
 def test_forecast_dataset__target_series_none_when_absent(forecast_dataset: ForecastDataset):
@@ -429,5 +429,5 @@ def test_ensemble_forecast_dataset__column_missing_separator_raises(forecast_ind
     )
 
     # Act & Assert
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Column missing separator"):
         EnsembleForecastDataset(data=data, sample_interval=timedelta(hours=1))

--- a/packages/openstef-core/tests/unit/datasets/test_validated_datasets.py
+++ b/packages/openstef-core/tests/unit/datasets/test_validated_datasets.py
@@ -1,0 +1,433 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the OpenSTEF project <openstef@lfenergy.org>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Tests for validated dataset classes."""
+
+from datetime import datetime, timedelta
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from openstef_core.datasets.validated_datasets import (
+    EnergyComponentDataset,
+    EnsembleForecastDataset,
+    ForecastDataset,
+    ForecastInputDataset,
+)
+from openstef_core.exceptions import MissingColumnsError
+from openstef_core.types import LeadTime, Quantile
+
+
+@pytest.fixture
+def forecast_index() -> pd.DatetimeIndex:
+    return pd.date_range("2025-01-01T00:00:00", periods=6, freq="h")
+
+
+# ---------------------------------------------------------------------------
+# ForecastInputDataset
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def basic_input_dataset(forecast_index: pd.DatetimeIndex) -> ForecastInputDataset:
+    data = pd.DataFrame(
+        {
+            "load": [100.0, 110.0, 120.0, 130.0, 140.0, 150.0],
+            "temperature": [10.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+            "wind_speed": [3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+        },
+        index=forecast_index,
+    )
+    return ForecastInputDataset(
+        data=data,
+        sample_interval=timedelta(hours=1),
+        target_column="load",
+    )
+
+
+@pytest.fixture
+def weighted_input_dataset(forecast_index: pd.DatetimeIndex) -> ForecastInputDataset:
+    data = pd.DataFrame(
+        {
+            "load": [100.0, 110.0, 120.0, 130.0, 140.0, 150.0],
+            "temperature": [10.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+            "sample_weight": [1.0, 0.5, 1.0, 0.5, 1.0, 0.5],
+        },
+        index=forecast_index,
+    )
+    return ForecastInputDataset(
+        data=data,
+        sample_interval=timedelta(hours=1),
+        target_column="load",
+        sample_weight_column="sample_weight",
+    )
+
+
+def test_forecast_input_dataset__missing_target_column_raises():
+    """Missing target column raises MissingColumnsError at construction."""
+    # Arrange
+    data = pd.DataFrame({"temperature": [10.0]}, index=pd.date_range("2025-01-01", periods=1, freq="h"))
+
+    # Act & Assert
+    with pytest.raises(MissingColumnsError):
+        ForecastInputDataset(data=data, sample_interval=timedelta(hours=1), target_column="load")
+
+
+def test_sample_weight_series__returns_ones_when_column_missing(basic_input_dataset: ForecastInputDataset):
+    """sample_weight_series returns all-ones Series when weight column is absent."""
+    # Act
+    weights = basic_input_dataset.sample_weight_series
+
+    # Assert
+    assert (weights == 1).all()
+    assert len(weights) == len(basic_input_dataset.index)
+
+
+def test_sample_weight_series__returns_column_values(weighted_input_dataset: ForecastInputDataset):
+    """sample_weight_series returns the actual weight column values."""
+    # Arrange
+    expected = pd.Series([1.0, 0.5, 1.0, 0.5, 1.0, 0.5], index=weighted_input_dataset.index, name="sample_weight")
+
+    # Act
+    weights = weighted_input_dataset.sample_weight_series
+
+    # Assert
+    pd.testing.assert_series_equal(weights, expected)
+
+
+def test_input_data__expected_columns(basic_input_dataset: ForecastInputDataset):
+    """input_data includes expected columns."""
+    # Act
+    result = basic_input_dataset.input_data()
+
+    # Assert
+    assert "load" not in result.columns
+    assert "sample_weight" not in result.columns
+    assert "temperature" in result.columns
+    assert "wind_speed" in result.columns
+
+
+def test_input_data__start_filters_rows(basic_input_dataset: ForecastInputDataset):
+    """Rows before start are excluded when start is provided."""
+    # Arrange
+    start = datetime(2025, 1, 1, 3, 0)
+
+    # Act
+    result = basic_input_dataset.input_data(start=start)
+
+    # Assert
+    assert result.index.min() >= pd.Timestamp(start)
+    assert len(result) == 3
+
+
+def test_input_data__no_start_returns_all_rows(basic_input_dataset: ForecastInputDataset):
+    """All rows returned when start is None."""
+    # Act
+    result = basic_input_dataset.input_data()
+
+    # Assert
+    assert len(result) == 6
+
+
+@pytest.mark.parametrize(
+    ("horizon_hours", "expected_len"),
+    [
+        pytest.param(2, 3, id="2h_horizon"),
+        pytest.param(5, 6, id="5h_horizon_full_range"),
+        pytest.param(0, 1, id="0h_horizon_only_start"),
+    ],
+)
+def test_input_data__horizon_limits_rows(
+    basic_input_dataset: ForecastInputDataset,
+    horizon_hours: int,
+    expected_len: int,
+):
+    """Rows after forecast_start + horizon are excluded when horizon is given."""
+    # Arrange
+    horizon = LeadTime(timedelta(hours=horizon_hours))
+
+    # Act
+    # forecast_start = 2025-01-01T00:00 (first index), so end = 00:00 + horizon
+    result = basic_input_dataset.input_data(start=basic_input_dataset.forecast_start, horizon=horizon)
+
+    # Assert
+    assert len(result) == expected_len
+
+
+def test_input_data__horizon_none_returns_all_rows(basic_input_dataset: ForecastInputDataset):
+    """No filtering by horizon when horizon=None."""
+    # Act
+    result = basic_input_dataset.input_data(start=basic_input_dataset.forecast_start, horizon=None)
+
+    # Assert
+    assert len(result) == 6
+
+
+def test_input_data__horizon_combined_with_start(basic_input_dataset: ForecastInputDataset):
+    """start and horizon together correctly bound the returned rows."""
+    # Arrange
+    # forecast_start = 2025-01-01T00:00, start = T+2h, horizon = 4h → end = T+4h
+    # expected rows: T+2h, T+3h, T+4h → 3 rows
+    start = datetime(2025, 1, 1, 2, 0)
+    horizon = LeadTime(timedelta(hours=4))
+
+    # Act
+    result = basic_input_dataset.input_data(start=start, horizon=horizon)
+
+    # Assert
+    assert len(result) == 3
+    assert result.index.min() == pd.Timestamp(start)
+    assert result.index.max() == pd.Timestamp(basic_input_dataset.forecast_start + timedelta(hours=4))
+
+
+def test_create_forecast_range__correct_range(basic_input_dataset: ForecastInputDataset):
+    """Forecast range ends at forecast_start + horizon."""
+    # Arrange
+    horizon = LeadTime(timedelta(hours=3))
+    expected_end = pd.Timestamp(basic_input_dataset.forecast_start + timedelta(hours=3))
+
+    # Act
+    index = basic_input_dataset.create_forecast_range(horizon=horizon)
+
+    # Assert
+    assert len(index) == 4  # 00:00, 01:00, 02:00, 03:00
+    assert index[0] == pd.Timestamp(basic_input_dataset.forecast_start)
+    assert index[-1] == expected_end
+
+
+def test_to_pandas_roundtrip(basic_input_dataset: ForecastInputDataset):
+    """to_pandas / reconstruction preserves target_column and forecast_start in attrs."""
+    # Act
+    df = basic_input_dataset.to_pandas()
+
+    # Assert
+    assert df.attrs["target_column"] == "load"
+    assert "forecast_start" in df.attrs
+
+    restored = ForecastInputDataset(data=df, sample_interval=timedelta(hours=1))
+    assert restored.target_column == basic_input_dataset.target_column
+    assert restored.forecast_start == basic_input_dataset.forecast_start
+
+
+# ---------------------------------------------------------------------------
+# ForecastDataset
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def forecast_dataset(forecast_index: pd.DatetimeIndex) -> ForecastDataset:
+    data = pd.DataFrame(
+        {
+            "quantile_P10": [90.0, 100.0, 110.0, 120.0, 130.0, 140.0],
+            "quantile_P50": [100.0, 110.0, 120.0, 130.0, 140.0, 150.0],
+            "quantile_P90": [110.0, 120.0, 130.0, 140.0, 150.0, 160.0],
+        },
+        index=forecast_index,
+    )
+    return ForecastDataset(data=data, sample_interval=timedelta(hours=1))
+
+
+def test_forecast_dataset__invalid_column_raises():
+    """ForecastDataset raises when a non-quantile column name is present."""
+    # Arrange
+    data = pd.DataFrame(
+        {"not_a_quantile": [1.0, 2.0]},
+        index=pd.date_range("2025-01-01", periods=2, freq="h"),
+    )
+
+    # Act & Assert
+    with pytest.raises(ValueError, match="valid quantile"):
+        ForecastDataset(data=data, sample_interval=timedelta(hours=1))
+
+
+def test_forecast_dataset__median_series(forecast_dataset: ForecastDataset):
+    """median_series returns the P50 column."""
+    # Arrange
+    expected = pd.Series([100.0, 110.0, 120.0, 130.0, 140.0, 150.0], index=forecast_dataset.index, name="quantile_P50")
+
+    # Act
+    median = forecast_dataset.median_series
+
+    # Assert
+    pd.testing.assert_series_equal(median, expected)
+
+
+def test_forecast_dataset__median_series_missing_raises(forecast_index: pd.DatetimeIndex):
+    """median_series raises MissingColumnsError when P50 is absent."""
+    # Arrange
+    data = pd.DataFrame({"quantile_P10": [1.0]}, index=pd.date_range("2025-01-01", periods=1, freq="h"))
+    ds = ForecastDataset(data=data, sample_interval=timedelta(hours=1))
+
+    # Act & Assert
+    with pytest.raises(MissingColumnsError):
+        ds.median_series
+
+
+def test_forecast_dataset__target_series_none_when_absent(forecast_dataset: ForecastDataset):
+    """target_series is None when target column is not in the data."""
+    # Act & Assert
+    assert forecast_dataset.target_series is None
+
+
+def test_forecast_dataset__target_series_returned_when_present(forecast_index: pd.DatetimeIndex):
+    """target_series returns the column when it exists."""
+    # Arrange
+    data = pd.DataFrame(
+        {
+            "quantile_P50": [100.0, 110.0],
+            "load": [95.0, 105.0],
+        },
+        index=pd.date_range("2025-01-01", periods=2, freq="h"),
+    )
+    ds = ForecastDataset(data=data, sample_interval=timedelta(hours=1), target_column="load")
+
+    # Act & Assert
+    assert ds.target_series is not None
+    assert list(ds.target_series) == [95.0, 105.0]
+
+
+def test_forecast_dataset__filter_quantiles(forecast_dataset: ForecastDataset):
+    """filter_quantiles keeps only the requested quantile columns."""
+    # Act
+    result = forecast_dataset.filter_quantiles([Quantile(0.1), Quantile(0.9)])
+
+    # Assert
+    assert [float(q) for q in result.quantiles] == pytest.approx([0.1, 0.9], abs=1e-9)
+    assert "quantile_P50" not in result.data.columns
+
+
+def test_forecast_dataset__filter_quantiles_missing_raises(forecast_dataset: ForecastDataset):
+    """filter_quantiles raises MissingColumnsError for a non-existent quantile."""
+    # Act & Assert
+    with pytest.raises(MissingColumnsError):
+        forecast_dataset.filter_quantiles([Quantile(0.05)])
+
+
+def test_forecast_dataset__from_quantile_predictions():
+    """from_quantile_predictions builds a ForecastDataset from a raw numpy array."""
+    # Arrange
+    quantiles = [Quantile(0.1), Quantile(0.5), Quantile(0.9)]
+    predictions = np.array([[90.0, 100.0, 110.0], [95.0, 105.0, 115.0]])
+    index = pd.date_range("2025-01-01", periods=2, freq="h")
+
+    # Act
+    ds = ForecastDataset.from_quantile_predictions(predictions, index, quantiles, timedelta(hours=1))
+
+    # Assert
+    assert sorted(float(q) for q in ds.quantiles) == [0.1, 0.5, 0.9]
+    assert len(ds.data) == 2
+
+
+# ---------------------------------------------------------------------------
+# EnergyComponentDataset
+# ---------------------------------------------------------------------------
+
+
+def test_energy_component_dataset__valid():
+    """EnergyComponentDataset accepts data with all required energy component columns."""
+    # Arrange
+    data = pd.DataFrame(
+        {"wind": [50.0], "solar": [30.0], "other": [20.0]},
+        index=pd.date_range("2025-01-01", periods=1, freq="h"),
+    )
+
+    # Act
+    ds = EnergyComponentDataset(data=data, sample_interval=timedelta(hours=1))
+
+    # Assert
+    assert set(ds.feature_names) == {"wind", "solar", "other"}
+
+
+def test_energy_component_dataset__missing_component_raises():
+    """EnergyComponentDataset raises when a required energy component column is absent."""
+    # Arrange
+    data = pd.DataFrame(
+        {"wind": [50.0], "solar": [30.0]},
+        index=pd.date_range("2025-01-01", periods=1, freq="h"),
+    )
+
+    # Act & Assert
+    with pytest.raises(MissingColumnsError):
+        EnergyComponentDataset(data=data, sample_interval=timedelta(hours=1))
+
+
+# ---------------------------------------------------------------------------
+# EnsembleForecastDataset
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ensemble_dataset(forecast_index: pd.DatetimeIndex) -> EnsembleForecastDataset:
+    data = pd.DataFrame(
+        {
+            "lgbm__quantile_P10": np.full(6, 90.0),
+            "lgbm__quantile_P50": np.full(6, 100.0),
+            "xgb__quantile_P10": np.full(6, 88.0),
+            "xgb__quantile_P50": np.full(6, 99.0),
+            "load": np.linspace(95.0, 105.0, 6),
+        },
+        index=forecast_index,
+    )
+    return EnsembleForecastDataset(
+        data=data,
+        sample_interval=timedelta(hours=1),
+        target_column="load",
+    )
+
+
+def test_ensemble_forecast_dataset__forecaster_names_parsed(ensemble_dataset: EnsembleForecastDataset):
+    """EnsembleForecastDataset parses forecaster names from column prefixes."""
+    # Act & Assert
+    assert set(ensemble_dataset.forecaster_names) == {"lgbm", "xgb"}
+
+
+def test_ensemble_forecast_dataset__quantiles_parsed(ensemble_dataset: EnsembleForecastDataset):
+    """EnsembleForecastDataset parses quantiles from column suffixes."""
+    # Act & Assert
+    assert sorted(float(q) for q in ensemble_dataset.quantiles) == [0.1, 0.5]
+
+
+def test_ensemble_forecast_dataset__get_base_predictions_for_quantile(ensemble_dataset: EnsembleForecastDataset):
+    """get_base_predictions_for_quantile returns ForecastInputDataset with correct columns."""
+    # Act
+    result = ensemble_dataset.get_base_predictions_for_quantile(Quantile(0.1))
+
+    # Assert
+    assert isinstance(result, ForecastInputDataset)
+    # feature_names includes all non-internal columns; the forecaster columns plus target_column
+    assert {"lgbm", "xgb"}.issubset(set(result.data.columns))
+
+
+def test_ensemble_forecast_dataset__from_forecast_datasets(forecast_index: pd.DatetimeIndex):
+    """from_forecast_datasets correctly merges multiple ForecastDatasets."""
+    # Arrange
+    ds_a = ForecastDataset(
+        data=pd.DataFrame({"quantile_P50": [100.0] * 3}, index=forecast_index[:3]),
+        sample_interval=timedelta(hours=1),
+    )
+    ds_b = ForecastDataset(
+        data=pd.DataFrame({"quantile_P50": [110.0] * 3}, index=forecast_index[:3]),
+        sample_interval=timedelta(hours=1),
+    )
+
+    # Act
+    ensemble = EnsembleForecastDataset.from_forecast_datasets({"a": ds_a, "b": ds_b})
+
+    # Assert
+    assert set(ensemble.forecaster_names) == {"a", "b"}
+    assert len(ensemble.data) == 3
+
+
+def test_ensemble_forecast_dataset__column_missing_separator_raises(forecast_index: pd.DatetimeIndex):
+    """EnsembleForecastDataset raises ValueError for columns lacking the separator."""
+    # Arrange
+    data = pd.DataFrame(
+        {"noseperator_quantile_P50": [1.0]},
+        index=pd.date_range("2025-01-01", periods=1, freq="h"),
+    )
+
+    # Act & Assert
+    with pytest.raises(ValueError):
+        EnsembleForecastDataset(data=data, sample_interval=timedelta(hours=1))

--- a/packages/openstef-core/tests/unit/datasets/test_validated_datasets.py
+++ b/packages/openstef-core/tests/unit/datasets/test_validated_datasets.py
@@ -22,7 +22,7 @@ from openstef_core.types import LeadTime, Quantile
 
 @pytest.fixture
 def forecast_index() -> pd.DatetimeIndex:
-    return pd.date_range("2025-01-01T00:00:00", periods=6, freq="h")
+    return pd.date_range("2025-01-01T00:00:00Z", periods=6, freq="h")
 
 
 # ---------------------------------------------------------------------------
@@ -178,7 +178,7 @@ def test_input_data__horizon_combined_with_start(basic_input_dataset: ForecastIn
 
     # Assert
     assert len(result) == 3
-    assert result.index.min() == pd.Timestamp(start)
+    assert result.index.min() == start
     assert result.index.max() == pd.Timestamp(basic_input_dataset.forecast_start + timedelta(hours=4))
 
 

--- a/packages/openstef-models/src/openstef_models/models/forecasting/forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/forecaster.py
@@ -54,7 +54,7 @@ class Forecaster(BaseConfig, BatchPredictor[ForecastInputDataset, ForecastDatase
           ``[forecast_start, forecast_start + max_horizon]``.  Any input rows
           beyond ``max_horizon`` are silently discarded.  This is enforced by
           passing ``horizon=self.max_horizon`` to
-          :meth:`~openstef_core.datasets.validated_datasets.ForecastInputDataset.input_data`
+          :meth:`~openstef_core.datasets.ForecastInputDataset.input_data`
           inside every concrete ``predict()`` implementation.
 
     Example:

--- a/packages/openstef-models/src/openstef_models/models/forecasting/forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/forecaster.py
@@ -48,8 +48,14 @@ class Forecaster(BaseConfig, BatchPredictor[ForecastInputDataset, ForecastDatase
     initialised in ``model_post_init``.
 
     Invariants:
-        - Predictions must include all quantiles specified in the configuration
-        - predict_batch() only called when supports_batching returns True
+        - Predictions must include all quantiles specified in the configuration.
+        - predict_batch() only called when supports_batching returns True.
+        - ``predict()`` only returns timestamps in the interval
+          ``[forecast_start, forecast_start + max_horizon]``.  Any input rows
+          beyond ``max_horizon`` are silently discarded.  This is enforced by
+          passing ``horizon=self.max_horizon`` to
+          :meth:`~openstef_core.datasets.validated_datasets.ForecastInputDataset.input_data`
+          inside every concrete ``predict()`` implementation.
 
     Example:
         Creating a forecaster with multiple horizons

--- a/packages/openstef-models/src/openstef_models/models/forecasting/gblinear_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/gblinear_forecaster.py
@@ -275,7 +275,7 @@ class GBLinearForecaster(Forecaster, ExplainableForecaster, ContributionsMixin):
             raise InputValidationError("There are nan values in the input data. Use imputation transform to fix them.")
 
         # Get input features for prediction
-        input_data: pd.DataFrame = data.input_data(start=data.forecast_start)
+        input_data: pd.DataFrame = data.input_data(start=data.forecast_start, horizon=self.max_horizon)
         # Generate predictions
         predictions_array: np.ndarray = self._gblinear_model.predict(input_data).reshape(-1, len(self.quantiles))
 

--- a/packages/openstef-models/src/openstef_models/models/forecasting/lgbm_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/lgbm_forecaster.py
@@ -282,7 +282,7 @@ class LGBMForecaster(Forecaster, ExplainableForecaster, ContributionsMixin):
         if not self.is_fitted:
             raise NotFittedError(self.__class__.__name__)
 
-        input_data: pd.DataFrame = data.input_data(start=data.forecast_start)
+        input_data: pd.DataFrame = data.input_data(start=data.forecast_start, horizon=self.max_horizon)
         prediction: npt.NDArray[np.floating] = self._lgbm_model.predict(X=input_data)
 
         return ForecastDataset(

--- a/packages/openstef-models/src/openstef_models/models/forecasting/lgbmlinear_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/lgbmlinear_forecaster.py
@@ -283,7 +283,7 @@ class LGBMLinearForecaster(Forecaster, ExplainableForecaster, ContributionsMixin
         if not self.is_fitted:
             raise NotFittedError(self.__class__.__name__)
 
-        input_data: pd.DataFrame = data.input_data(start=data.forecast_start)
+        input_data: pd.DataFrame = data.input_data(start=data.forecast_start, horizon=self.max_horizon)
         prediction: npt.NDArray[np.floating] = self._lgbmlinear_model.predict(X=input_data)
 
         return ForecastDataset(

--- a/packages/openstef-models/src/openstef_models/models/forecasting/median_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/median_forecaster.py
@@ -185,7 +185,7 @@ class MedianForecaster(Forecaster, ExplainableForecaster, ContributionsMixin):
             )
             raise ValueError(msg)
 
-        input_data: pd.DataFrame = data.input_data(start=data.forecast_start)
+        input_data: pd.DataFrame = data.input_data(start=data.forecast_start, horizon=self.max_horizon)
 
         # Check that the input data contains the required lag features
         missing_features = set(self._feature_names) - set(data.feature_names)

--- a/packages/openstef-models/src/openstef_models/models/forecasting/xgboost_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/xgboost_forecaster.py
@@ -349,7 +349,7 @@ class XGBoostForecaster(Forecaster, ExplainableForecaster, ContributionsMixin):
             raise NotFittedError(self.__class__.__name__)
 
         # Get input features for prediction
-        input_data: pd.DataFrame = data.input_data(start=data.forecast_start)
+        input_data: pd.DataFrame = data.input_data(start=data.forecast_start, horizon=self.max_horizon)
         # Generate predictions
         predictions_array: np.ndarray = self._xgboost_model.predict(input_data).reshape(-1, len(self.quantiles))
 

--- a/packages/openstef-models/tests/unit/models/forecasting/test_lgbmlinear_forecaster.py
+++ b/packages/openstef-models/tests/unit/models/forecasting/test_lgbmlinear_forecaster.py
@@ -21,7 +21,7 @@ def base_config() -> LGBMLinearForecaster:
 
     return LGBMLinearForecaster(
         quantiles=[Q(0.1), Q(0.5), Q(0.9)],
-        horizons=[LeadTime(timedelta(days=1))],
+        horizons=[LeadTime(timedelta(days=14))],
         hyperparams=LGBMLinearHyperParams(n_estimators=100, max_depth=3, min_data_in_leaf=1, min_data_in_bin=1),
         device="cpu",
         n_jobs=1,

--- a/packages/openstef-models/tests/unit/models/forecasting/test_median_forecaster.py
+++ b/packages/openstef-models/tests/unit/models/forecasting/test_median_forecaster.py
@@ -84,7 +84,7 @@ def test_median_handles_some_missing_data():
     )
     expected_result.index.freq = None  # ty: ignore[invalid-assignment]
 
-    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3M")])
+    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3H")])
     model = config
 
     # Act
@@ -124,7 +124,7 @@ def test_median_handles_missing_data_for_some_horizons():
     )
     expected_result.index.freq = None  # ty: ignore[invalid-assignment]
 
-    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3M")])
+    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3H")])
     model = config
 
     # Act
@@ -164,7 +164,7 @@ def test_median_handles_all_missing_data():
         forecast_start=training_input_data.forecast_start,
     )
 
-    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3M")])
+    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3H")])
     model = config
 
     # Act
@@ -204,7 +204,7 @@ def test_median_uses_lag_features_if_available():
     )
     expected_result.index.freq = None  # ty: ignore[invalid-assignment]
 
-    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3M")])
+    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3H")])
     model = config
 
     # Act
@@ -255,7 +255,7 @@ def test_median_handles_small_gap():
     )
     expected_result.index.freq = None  # ty: ignore[invalid-assignment]
 
-    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3M")])
+    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT5H")])
     model = config
 
     # Act
@@ -306,7 +306,7 @@ def test_median_handles_large_gap():
     )
     expected_result.index.freq = None  # ty: ignore[invalid-assignment]
 
-    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3M")])
+    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT48H")])
     model = config
 
     # Act

--- a/packages/openstef-models/tests/unit/models/forecasting/test_median_forecaster.py
+++ b/packages/openstef-models/tests/unit/models/forecasting/test_median_forecaster.py
@@ -15,7 +15,13 @@ from openstef_models.models.forecasting.forecaster import ForecastDataset
 from openstef_models.models.forecasting.median_forecaster import MedianForecaster
 
 
-def test_median_returns_median():
+@pytest.fixture
+def median_forecaster() -> MedianForecaster:
+    """Median forecaster fixture."""
+    return MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime(timedelta(days=2))])
+
+
+def test_median_returns_median(median_forecaster: MedianForecaster):
     # Arrange
     index = pd.date_range("2020-01-01T00:00", periods=3, freq="h")
     training_data = create_timeseries_dataset(
@@ -44,8 +50,7 @@ def test_median_returns_median():
     )
     expected_result.index.freq = None  # ty: ignore[invalid-assignment]
 
-    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT36H")])
-    model = config
+    model = median_forecaster
 
     # Act
     model.fit(training_input_data)
@@ -56,7 +61,7 @@ def test_median_returns_median():
     pd.testing.assert_frame_equal(result.data, expected_result.data)
 
 
-def test_median_handles_some_missing_data():
+def test_median_handles_some_missing_data(median_forecaster: MedianForecaster):
     # Arrange
     index = pd.date_range("2023-01-01", periods=3, freq="h")
     training_data = create_timeseries_dataset(
@@ -84,19 +89,16 @@ def test_median_handles_some_missing_data():
     )
     expected_result.index.freq = None  # ty: ignore[invalid-assignment]
 
-    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3H")])
-    model = config
-
     # Act
-    model.fit(training_input_data)
-    result = model.predict(training_input_data)
+    median_forecaster.fit(training_input_data)
+    result = median_forecaster.predict(training_input_data)
 
     # Assert
     assert result.sample_interval == expected_result.sample_interval
     pd.testing.assert_frame_equal(result.data, expected_result.data)
 
 
-def test_median_handles_missing_data_for_some_horizons():
+def test_median_handles_missing_data_for_some_horizons(median_forecaster: MedianForecaster):
     # Arrange
     index = pd.date_range("2023-01-01", periods=3, freq="h")
     training_data = create_timeseries_dataset(
@@ -124,19 +126,16 @@ def test_median_handles_missing_data_for_some_horizons():
     )
     expected_result.index.freq = None  # ty: ignore[invalid-assignment]
 
-    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3H")])
-    model = config
-
     # Act
-    model.fit(training_input_data)
-    result = model.predict(training_input_data)
+    median_forecaster.fit(training_input_data)
+    result = median_forecaster.predict(training_input_data)
 
     # Assert
     assert result.sample_interval == expected_result.sample_interval
     pd.testing.assert_frame_equal(result.data, expected_result.data)
 
 
-def test_median_handles_all_missing_data():
+def test_median_handles_all_missing_data(median_forecaster: MedianForecaster):
     # Arrange
     index = pd.date_range("2023-01-01", periods=3, freq="h")
     training_data = create_timeseries_dataset(
@@ -164,19 +163,16 @@ def test_median_handles_all_missing_data():
         forecast_start=training_input_data.forecast_start,
     )
 
-    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3H")])
-    model = config
-
     # Act
-    model.fit(training_input_data)
-    result = model.predict(training_input_data)
+    median_forecaster.fit(training_input_data)
+    result = median_forecaster.predict(training_input_data)
 
     # Assert
     assert result.sample_interval == expected_result.sample_interval
     pd.testing.assert_frame_equal(result.data, expected_result.data)
 
 
-def test_median_uses_lag_features_if_available():
+def test_median_uses_lag_features_if_available(median_forecaster: MedianForecaster):
     # Arrange
     index = pd.date_range("2023-01-01T00:00", periods=3, freq="h")
     training_data = create_timeseries_dataset(
@@ -204,19 +200,16 @@ def test_median_uses_lag_features_if_available():
     )
     expected_result.index.freq = None  # ty: ignore[invalid-assignment]
 
-    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3H")])
-    model = config
-
     # Act
-    model.fit(training_input_data)
-    result = model.predict(training_input_data)
+    median_forecaster.fit(training_input_data)
+    result = median_forecaster.predict(training_input_data)
 
     # Assert
     assert result.sample_interval == expected_result.sample_interval
     pd.testing.assert_frame_equal(result.data, expected_result.data)
 
 
-def test_median_handles_small_gap():
+def test_median_handles_small_gap(median_forecaster: MedianForecaster):
     # Arrange
     index = pd.date_range("2023-01-01T00:00", periods=5, freq="h")
     training_data = create_timeseries_dataset(
@@ -255,19 +248,16 @@ def test_median_handles_small_gap():
     )
     expected_result.index.freq = None  # ty: ignore[invalid-assignment]
 
-    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT5H")])
-    model = config
-
     # Act
-    model.fit(training_input_data)
-    result = model.predict(training_input_data)
+    median_forecaster.fit(training_input_data)
+    result = median_forecaster.predict(training_input_data)
 
     # Assert
     assert result.sample_interval == expected_result.sample_interval
     pd.testing.assert_frame_equal(result.data, expected_result.data)
 
 
-def test_median_handles_large_gap():
+def test_median_handles_large_gap(median_forecaster: MedianForecaster):
     # Arrange
     index_1 = pd.date_range("2023-01-01T00:00", periods=3, freq="h")
     training_data_1 = create_timeseries_dataset(
@@ -306,19 +296,16 @@ def test_median_handles_large_gap():
     )
     expected_result.index.freq = None  # ty: ignore[invalid-assignment]
 
-    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT48H")])
-    model = config
-
     # Act
-    model.fit(training_input_data)
-    result = model.predict(training_input_data)
+    median_forecaster.fit(training_input_data)
+    result = median_forecaster.predict(training_input_data)
 
     # Assert
     assert result.sample_interval == expected_result.sample_interval
     pd.testing.assert_frame_equal(result.data, expected_result.data)
 
 
-def test_median_fit_with_missing_features_raises():
+def test_median_fit_with_missing_features_raises(median_forecaster: MedianForecaster):
     # Arrange
     index = pd.date_range("2023-01-01", periods=3, freq="h")
     training_data = create_timeseries_dataset(
@@ -335,9 +322,7 @@ def test_median_fit_with_missing_features_raises():
         forecast_start=index[0],
     )
 
-    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3H")])
-    model = config
-    model.fit(training_input_data)
+    median_forecaster.fit(training_input_data)
 
     # Create prediction data missing one lag feature
     prediction_data = training_data.data.copy()
@@ -351,10 +336,10 @@ def test_median_fit_with_missing_features_raises():
 
     # Act & Assert
     with pytest.raises(ValueError, match="The input data is missing the following lag features"):
-        model.predict(prediction_input_data)
+        median_forecaster.predict(prediction_input_data)
 
 
-def test_median_fit_with_no_lag_features_raises():
+def test_median_fit_with_no_lag_features_raises(median_forecaster: MedianForecaster):
     # Arrange
     index = pd.date_range("2023-01-01", periods=3, freq="h")
     training_data = create_timeseries_dataset(
@@ -369,15 +354,12 @@ def test_median_fit_with_no_lag_features_raises():
         forecast_start=index[0],
     )
 
-    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3H")])
-    model = config
-
     # Act & Assert
     with pytest.raises(ValueError, match=r"No lag features found in the input data."):
-        model.fit(training_input_data)
+        median_forecaster.fit(training_input_data)
 
 
-def test_median_fit_with_inconsistent_lag_features_raises():
+def test_median_fit_with_inconsistent_lag_features_raises(median_forecaster: MedianForecaster):
     # Arrange
     index = pd.date_range("2023-01-01", periods=3, freq="h")
     training_data = create_timeseries_dataset(
@@ -396,14 +378,14 @@ def test_median_fit_with_inconsistent_lag_features_raises():
     )
 
     config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3H")])
-    model = config
+    median_forecaster = config
 
     # Act & Assert
     with pytest.raises(ValueError, match="Lag features are not evenly spaced"):
-        model.fit(training_input_data)
+        median_forecaster.fit(training_input_data)
 
 
-def test_median_fit_with_inconsistent_frequency_raises():
+def test_median_fit_with_inconsistent_frequency_raises(median_forecaster: MedianForecaster):
     # Arrange
     index = pd.date_range("2023-01-01", periods=3, freq="min")
     training_data = create_timeseries_dataset(
@@ -421,9 +403,6 @@ def test_median_fit_with_inconsistent_frequency_raises():
         forecast_start=index[0],
     )
 
-    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3H")])
-    model = config
-
     # Act & Assert
     with pytest.raises(
         ValueError,
@@ -431,10 +410,10 @@ def test_median_fit_with_inconsistent_frequency_raises():
             r"Lag feature interval (1:00:00) does not match data frequency (0:01:00). Please ensure lag features match the data frequency."
         ),
     ):
-        model.fit(training_input_data)
+        median_forecaster.fit(training_input_data)
 
 
-def test_predicting_without_fitting_raises():
+def test_predicting_without_fitting_raises(median_forecaster: MedianForecaster):
     # Arrange
     index = pd.date_range("2023-01-01", periods=3, freq="min")
     training_data = create_timeseries_dataset(
@@ -452,9 +431,6 @@ def test_predicting_without_fitting_raises():
         forecast_start=index[0],
     )
 
-    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3M")])
-    model = config
-
     # Act & Assert
     with pytest.raises(AttributeError, match="This MedianForecaster instance is not fitted yet"):
-        model.predict(training_input_data)
+        median_forecaster.predict(training_input_data)

--- a/packages/openstef-models/tests/unit/models/forecasting/test_median_forecaster.py
+++ b/packages/openstef-models/tests/unit/models/forecasting/test_median_forecaster.py
@@ -50,11 +50,9 @@ def test_median_returns_median(median_forecaster: MedianForecaster):
     )
     expected_result.index.freq = None  # ty: ignore[invalid-assignment]
 
-    model = median_forecaster
-
     # Act
-    model.fit(training_input_data)
-    result = model.predict(training_input_data)
+    median_forecaster.fit(training_input_data)
+    result = median_forecaster.predict(training_input_data)
 
     # Assert
     assert result.sample_interval == expected_result.sample_interval
@@ -376,9 +374,6 @@ def test_median_fit_with_inconsistent_lag_features_raises(median_forecaster: Med
         target_column="load",
         forecast_start=index[0],
     )
-
-    config = MedianForecaster(quantiles=[Q(0.5)], horizons=[LeadTime.from_string("PT3H")])
-    median_forecaster = config
 
     # Act & Assert
     with pytest.raises(ValueError, match="Lag features are not evenly spaced"):


### PR DESCRIPTION
This pull request updates the handling of input data for forecasting models to ensure that predictions are only made for the specified forecast horizon (fixes #881). It also adjusts the test configurations to use longer and more realistic forecast horizons. The main changes are as follows:

**Core logic improvements:**

* The `input_data` method in `ValidatedDatasets` now accepts an optional `horizon` parameter, which limits the returned data to timestamps up to `forecast_start + horizon`. [[1]](diffhunk://#diff-d6a52b438eacfa60132a47e31a0b1e96cec8a15dddf32d0dc3bf058eb63a6478L138-R145) [[2]](diffhunk://#diff-d6a52b438eacfa60132a47e31a0b1e96cec8a15dddf32d0dc3bf058eb63a6478R157-R159)
* All forecasting model classes (`GBLinearForecaster`, `LGBMForecaster`, `LGBMLinearForecaster`, `MedianForecaster`, `XGBoostForecaster`) now pass the `horizon` argument to `input_data`, ensuring predictions are restricted to the intended forecast window. [[1]](diffhunk://#diff-1725b6c0037fdfb4a0cffae2fcdfa37f98516045a969b09bf8f29b909f2fd9a5L278-R278) [[2]](diffhunk://#diff-237e7fc65148daa0569f27d1736adc21a52eee89dda40268392aa44a934f2a95L285-R285) [[3]](diffhunk://#diff-106fc52e42e012a02e624721227d247ee2438c8480ef6fb83ae7856dc067ece3L286-R286) [[4]](diffhunk://#diff-2d013a85bd35ce85a0bd39750e4a4dccd369bfd625bf6029322dc8ccd3ba0a1cL188-R188) [[5]](diffhunk://#diff-a933e569b6f94894ab18b8d097fdf9804d98dbfb372019d35ee3781624c165a3L352-R352)

**Test adjustments:**

* Unit tests for the `MedianForecaster` and `LGBMLinearForecaster` have been updated to use longer and more realistic forecast horizons. [[1]](diffhunk://#diff-665fc93b1e032b6e73af153ab17fb54afe55c97961cc05ca8b941a76d4df8128L24-R24) [[2]](diffhunk://#diff-33067e0379813d05696ae021a020be99bf245b675bc9cf4be43f4468b64a40f6L87-R87) [[3]](diffhunk://#diff-33067e0379813d05696ae021a020be99bf245b675bc9cf4be43f4468b64a40f6L127-R127) [[4]](diffhunk://#diff-33067e0379813d05696ae021a020be99bf245b675bc9cf4be43f4468b64a40f6L167-R167) [[5]](diffhunk://#diff-33067e0379813d05696ae021a020be99bf245b675bc9cf4be43f4468b64a40f6L207-R207) [[6]](diffhunk://#diff-33067e0379813d05696ae021a020be99bf245b675bc9cf4be43f4468b64a40f6L258-R258) [[7]](diffhunk://#diff-33067e0379813d05696ae021a020be99bf245b675bc9cf4be43f4468b64a40f6L309-R309)

**Documentation additions:**

* The newly added invariant is added to the documentation, both in code and in `docs/`. 