### PR TITLE
docs: clarify BEAM acronym in API reference

### DIFF
--- a/docs/source/api/beam.rst
+++ b/docs/source/api/beam.rst
@@ -9,7 +9,9 @@ BEAM Package (:mod:`openstef_beam`)
 
 .. currentmodule:: openstef_beam
 
-Backtesting, evaluation, analysis and metrics for forecasting models.
+BEAM (Backtesting, Evaluation, Analysis, and Metrics) is a package for
+backtesting, evaluating, analysing, and measuring the performance of
+forecasting models.
 
 .. autosummary::
    :toctree: generated/

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -28,7 +28,7 @@ This is the complete API reference for OpenSTEF. The API is organized into sever
         :link: beam-api
         :link-type: ref
 
-        Backtesting, evaluation, analysis and metrics for forecasting models
+        BEAM (Backtesting, Evaluation, Analysis, and Metrics) for forecasting models
 
     .. grid-item-card:: :fa:`layer-group` Meta Package
         :link: meta-api


### PR DESCRIPTION
Closes #960 (partially)

## What
The BEAM package name was never explained anywhere in the API reference docs, 
leaving new users confused about what "BEAM" stands for.

## Changes
- `docs/source/api/beam.rst`: expanded description to explain BEAM stands for 
  Backtesting, Evaluation, Analysis, and Metrics
- `docs/source/api/index.rst`: updated the package card description to include 
  the acronym expansion

## Why
Found while browsing the docs as part of the documentation gaps tracking 
issue #960.