### PR TITLE
ci: add SonarCloud CI scan with coverage

### DIFF
--- a/.github/workflows/_job_quality_check.yaml
+++ b/.github/workflows/_job_quality_check.yaml
@@ -22,6 +22,7 @@ jobs:
       - name: Checkout # Must be done before using composite actions
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          fetch-depth: 0 # full history gives Sonar accurate new-code / blame info
           show-progress: false # very verbose for not much
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
@@ -64,6 +65,15 @@ jobs:
       - name: notebooks-check
         if: ${{ ! inputs._SKIP_QUALITY && always() }}
         run: poe notebooks-check
+
+      # Upload analysis + coverage.xml (produced by the tests step) to SonarCloud.
+      # Skipped on fork PRs, which cannot access the SONAR_TOKEN secret.
+      - name: SonarCloud scan
+        if: ${{ ! inputs._SKIP_QUALITY && !cancelled() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
 
       - name: Stop if any quality step failed
         # All tests are run with always() not to stop on the first error. This step makes the workflow fail if any quality step failed.

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -19,3 +19,4 @@ jobs:
   quality:
     name: Quality Checks
     uses: ./.github/workflows/_job_quality_check.yaml
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Additional tutorials are available in the [online documentation](https://openste
 This project includes third-party libraries licensed under their respective Open-Source licenses. SPDX-License-Identifier headers show applicable licenses. License files are in the [LICENSES/](LICENSES/) directory.
 ## Contributing
 
-We welcome contributions to OpenSTEF 4.0!
+We welcome contributions to OpenSTEF 4.0! 
 
 **[Read our Contributing Guide](https://openstef.github.io/openstef/contribute/)** - documentation for contributors including:
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ SPDX-License-Identifier: MPL-2.0
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
 ![GitHub Release](https://img.shields.io/github/v/release/openstef/openstef)
 
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=OpenSTEF_openstef&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=OpenSTEF_openstef)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=OpenSTEF_openstef&metric=coverage)](https://sonarcloud.io/summary/new_code?id=OpenSTEF_openstef)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=OpenSTEF_openstef&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=OpenSTEF_openstef)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=OpenSTEF_openstef&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=OpenSTEF_openstef)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=OpenSTEF_openstef&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=OpenSTEF_openstef)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=OpenSTEF_openstef&metric=bugs)](https://sonarcloud.io/summary/new_code?id=OpenSTEF_openstef)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=OpenSTEF_openstef&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=OpenSTEF_openstef)
+[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=OpenSTEF_openstef&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=OpenSTEF_openstef)
+
 ## What is OpenSTEF
 
 **OpenSTEF** (Open Short-Term Energy Forecasting) is an open-source, model-agnostic Python framework for creating short-term forecasts in the energy sector. It provides complete machine learning pipelines for data preprocessing, feature engineering, model training, probabilistic forecasting, and evaluation. Version 4.0.0 introduces a complete architectural refactor with enhanced modularity, full type safety, and modern Python development practices.

--- a/README.md
+++ b/README.md
@@ -19,15 +19,6 @@ SPDX-License-Identifier: MPL-2.0
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
 ![GitHub Release](https://img.shields.io/github/v/release/openstef/openstef)
 
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=OpenSTEF_openstef&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=OpenSTEF_openstef)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=OpenSTEF_openstef&metric=coverage)](https://sonarcloud.io/summary/new_code?id=OpenSTEF_openstef)
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=OpenSTEF_openstef&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=OpenSTEF_openstef)
-[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=OpenSTEF_openstef&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=OpenSTEF_openstef)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=OpenSTEF_openstef&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=OpenSTEF_openstef)
-[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=OpenSTEF_openstef&metric=bugs)](https://sonarcloud.io/summary/new_code?id=OpenSTEF_openstef)
-[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=OpenSTEF_openstef&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=OpenSTEF_openstef)
-[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=OpenSTEF_openstef&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=OpenSTEF_openstef)
-
 ## What is OpenSTEF
 
 **OpenSTEF** (Open Short-Term Energy Forecasting) is an open-source, model-agnostic Python framework for creating short-term forecasts in the energy sector. It provides complete machine learning pipelines for data preprocessing, feature engineering, model training, probabilistic forecasting, and evaluation. Version 4.0.0 introduces a complete architectural refactor with enhanced modularity, full type safety, and modern Python development practices.
@@ -89,7 +80,7 @@ Additional tutorials are available in the [online documentation](https://openste
 This project includes third-party libraries licensed under their respective Open-Source licenses. SPDX-License-Identifier headers show applicable licenses. License files are in the [LICENSES/](LICENSES/) directory.
 ## Contributing
 
-We welcome contributions to OpenSTEF 4.0! 
+We welcome contributions to OpenSTEF 4.0!
 
 **[Read our Contributing Guide](https://openstef.github.io/openstef/contribute/)** - documentation for contributors including:
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -16,3 +16,16 @@ sonar.python.version=3.12
 
 # Exclude expected duplication in tests (fixtures, helpers, parametrized patterns).
 sonar.cpd.exclusions=**/tests/**/*.py
+
+# Project identity on SonarCloud.
+sonar.projectKey=OpenSTEF_openstef
+sonar.organization=openstef
+
+# Coverage report produced by `poe tests` (pytest-cov, --cov-report=xml:coverage.xml).
+# Required for the coverage metric/badge: Automatic Analysis cannot import coverage,
+# so this is only consumed by the CI-based scan (see .github/workflows/_job_quality_check.yaml).
+sonar.python.coverage.reportPaths=coverage.xml
+
+# Tests live in per-package tests/ dirs; tell Sonar where to find them.
+sonar.tests=packages
+sonar.test.inclusions=**/tests/**/*.py


### PR DESCRIPTION
Switch from Automatic Analysis to CI-based analysis so coverage.xml is uploaded. Scan runs as a step in the existing quality check after tests; secrets inherited from check.yaml. 