### PR TITLE
fix: use pull_request_target in PR labeler to support fork PRs

### DIFF
--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2017-2022 Contributors to the OpenSTEF project <openstef@lfenergy.org>
 #
 # SPDX-License-Identifier: MPL-2.0
-# Automatically label PRs, config in ../pr-labler.yml
+# Automatically label PRs, config in .github/pr-labeler.yml
 name: PR Labeler
 on:
   pull_request_target:

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -4,7 +4,7 @@
 # Automatically label PRs, config in ../pr-labler.yml
 name: PR Labeler
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
Closes #961

## Summary
The PR Labeler workflow fails on every fork PR with:
`Error: HttpError: Resource not accessible by integration`

## Root cause
The workflow triggers on `pull_request`, which gives fork PRs a read-only 
`GITHUB_TOKEN`. The labeler action needs write access to add labels.

## Fix
Changed trigger from `pull_request` to `pull_request_target`. This is safe 
because the workflow has no checkout step — it only reads the base repo's 
`.github/pr-labeler.yml` config and applies labels based on branch names, 
so no untrusted fork code is executed.

Credit to @Valyrian-Code for the detailed root cause analysis in #961.