### PR TITLE
chore: require hashes for uv build

### DIFF
--- a/poe_tasks.toml
+++ b/poe_tasks.toml
@@ -155,8 +155,8 @@ args = [
 [tool.poe.tasks.build]
 help = "Build all packages"
 sequence = [
-  { cmd = "uv build --all-packages" },
-  { cmd = "uv build .", help = "Build root meta package separately (not part of --all-packages)" },
+  { cmd = "uv build --all-packages --require-hashes" },
+  { cmd = "uv build . --require-hashes", help = "Build root meta package separately (not part of --all-packages)" },
 ]
 
 [tool.poe.tasks._docs_sync]


### PR DESCRIPTION
## Why

Best practice for reproducible builds and supply-chain protection: every dependency should be verified against locked hashes.

## What

Add `--require-hashes` to both `uv build` commands in the `build` poe task (`poe_tasks.toml`), so build-environment dependencies must match a hash from the lockfile.