### PR TITLE
fix(release): exclude openstef-deployment-examples from published packages

### DIFF
--- a/poe_tasks.toml
+++ b/poe_tasks.toml
@@ -153,10 +153,17 @@ args = [
 ]
 
 [tool.poe.tasks.build]
-help = "Build all packages"
+# Builds only the publishable distributions. `openstef-deployment-examples` is a workspace
+# member (so `uv run --package openstef-deployment-examples ...` works) but must NOT be
+# published to PyPI, so it is deliberately excluded here rather than using `--all-packages`.
+help = "Build all publishable packages (excludes openstef-deployment-examples)"
 sequence = [
-  { cmd = "uv build --all-packages" },
-  { cmd = "uv build .", help = "Build root meta package separately (not part of --all-packages)" },
+  { cmd = "uv build --package openstef-core" },
+  { cmd = "uv build --package openstef-models" },
+  { cmd = "uv build --package openstef-beam" },
+  { cmd = "uv build --package openstef-foundation-models" },
+  { cmd = "uv build --package openstef-meta" },
+  { cmd = "uv build .", help = "Build root meta package separately (not a workspace member)" },
 ]
 
 [tool.poe.tasks._docs_sync]


### PR DESCRIPTION
## What

The release build task previously ran \`uv build --all-packages\`, which also built the \`openstef-deployment-examples\` workspace member and dropped its sdist/wheel into \`dist/\`. The subsequent \`uv publish\` step would then attempt to publish it to PyPI.

This changes the \`build\` poe task to build **only the publishable distributions** explicitly:

- \`openstef-core\`
- \`openstef-models\`
- \`openstef-beam\`
- \`openstef-foundation-models\`
- \`openstef-meta\`
- \`openstef\` (root meta-package)

## Why this approach

- \`uv build\` has no exclude flag for \`--all-packages\`.
- \`examples/deployment\` must stay a real workspace package (the \`deploy-*\` tasks run \`uv run --package openstef-deployment-examples ...\`), so marking it \`tool.uv.package = false\` is not viable.
- Explicit enumeration matches the existing convention in the \`version\` task and makes adding a new publishable package a deliberate step.

## Trade-off

A newly added publishable package must also be added to this list.

## Verification

Ran \`uv run poe build\` — \`dist/\` contains exactly the six publishable distributions and **no** \`openstef_deployment_examples\` artifact.