### PR TITLE
build: use uv_build backend for publishable packages and re-enable --require-hashes

### DIFF
--- a/packages/openstef-beam/pyproject.toml
+++ b/packages/openstef-beam/pyproject.toml
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 [build-system]
-build-backend = "hatchling.build"
-requires = [ "hatchling" ]
+build-backend = "uv_build"
+requires = [ "uv_build<0.12" ]
 
 [project]
 name = "openstef-beam"
@@ -42,9 +42,6 @@ urls.Documentation = "https://openstef.github.io/openstef/index.html"
 urls.Homepage = "https://lfenergy.org/projects/openstef/"
 urls.Issues = "https://github.com/OpenSTEF/openstef/issues"
 urls.Repository = "https://github.com/OpenSTEF/openstef"
-
-[tool.hatch]
-build.targets.wheel.packages = [ "src/openstef_beam" ]
 
 [tool.uv]
 sources.openstef-core = { workspace = true }

--- a/packages/openstef-core/pyproject.toml
+++ b/packages/openstef-core/pyproject.toml
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 [build-system]
-build-backend = "hatchling.build"
-requires = [ "hatchling" ]
+build-backend = "uv_build"
+requires = [ "uv_build<0.12" ]
 
 [project]
 name = "openstef-core"
@@ -40,6 +40,3 @@ urls.Documentation = "https://openstef.github.io/openstef/index.html"
 urls.Homepage = "https://lfenergy.org/projects/openstef/"
 urls.Issues = "https://github.com/OpenSTEF/openstef/issues"
 urls.Repository = "https://github.com/OpenSTEF/openstef"
-
-[tool.hatch]
-build.targets.wheel.packages = [ "src/openstef_core" ]

--- a/packages/openstef-foundation-models/pyproject.toml
+++ b/packages/openstef-foundation-models/pyproject.toml
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 [build-system]
-build-backend = "hatchling.build"
-requires = [ "hatchling" ]
+build-backend = "uv_build"
+requires = [ "uv_build<0.12" ]
 
 [project]
 name = "openstef-foundation-models"
@@ -59,9 +59,6 @@ urls.Documentation = "https://openstef.github.io/openstef/index.html"
 urls.Homepage = "https://lfenergy.org/projects/openstef/"
 urls.Issues = "https://github.com/OpenSTEF/openstef/issues"
 urls.Repository = "https://github.com/OpenSTEF/openstef"
-
-[tool.hatch]
-build.targets.wheel.packages = [ "src/openstef_foundation_models" ]
 
 [tool.uv]
 sources.openstef-beam = { workspace = true }

--- a/packages/openstef-meta/pyproject.toml
+++ b/packages/openstef-meta/pyproject.toml
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 [build-system]
-build-backend = "hatchling.build"
-requires = [ "hatchling" ]
+build-backend = "uv_build"
+requires = [ "uv_build<0.12" ]
 
 [project]
 name = "openstef-meta"
@@ -33,6 +33,3 @@ urls.Documentation = "https://openstef.github.io/openstef/index.html"
 urls.Homepage = "https://lfenergy.org/projects/openstef/"
 urls.Issues = "https://github.com/OpenSTEF/openstef/issues"
 urls.Repository = "https://github.com/OpenSTEF/openstef"
-
-[tool.hatch]
-build.targets.wheel.packages = [ "src/openstef_meta" ]

--- a/packages/openstef-models/pyproject.toml
+++ b/packages/openstef-models/pyproject.toml
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 [build-system]
-build-backend = "hatchling.build"
-requires = [ "hatchling" ]
+build-backend = "uv_build"
+requires = [ "uv_build<0.12" ]
 
 [project]
 name = "openstef-models"
@@ -47,9 +47,6 @@ urls.Documentation = "https://openstef.github.io/openstef/index.html"
 urls.Homepage = "https://lfenergy.org/projects/openstef/"
 urls.Issues = "https://github.com/OpenSTEF/openstef/issues"
 urls.Repository = "https://github.com/OpenSTEF/openstef"
-
-[tool.hatch]
-build.targets.wheel.packages = [ "src/openstef_models" ]
 
 [tool.uv]
 # xgb-cpu installs xgboost-cpu (Linux/Windows) and xgb-gpu installs the full

--- a/poe_tasks.toml
+++ b/poe_tasks.toml
@@ -160,13 +160,17 @@ args = [
 # Builds only the publishable distributions. `openstef-deployment-examples` is a workspace
 # member (so `uv run --package openstef-deployment-examples ...` works) but must NOT be
 # published to PyPI, so it is deliberately excluded here rather than using `--all-packages`.
+# The five real packages use the uv_build backend so they build under --require-hashes. The root
+# meta-package ships no module, so it stays on hatchling (uv_build requires a module); hatchling
+# can't build under --require-hashes (its isolated build deps aren't hash-pinned in uv.lock), so
+# the root is built without it — it contains only metadata, no code.
 help = "Build all publishable packages (excludes openstef-deployment-examples)"
 sequence = [
-  { cmd = "uv build --package openstef-core" },
-  { cmd = "uv build --package openstef-models" },
-  { cmd = "uv build --package openstef-beam" },
-  { cmd = "uv build --package openstef-foundation-models" },
-  { cmd = "uv build --package openstef-meta" },
+  { cmd = "uv build --package openstef-core --require-hashes" },
+  { cmd = "uv build --package openstef-models --require-hashes" },
+  { cmd = "uv build --package openstef-beam --require-hashes" },
+  { cmd = "uv build --package openstef-foundation-models --require-hashes" },
+  { cmd = "uv build --package openstef-meta --require-hashes" },
   { cmd = "uv build .", help = "Build root meta package separately (not a workspace member)" },
 ]
 


### PR DESCRIPTION
## What

- Switch the five publishable packages (`openstef-core`, `openstef-models`, `openstef-beam`, `openstef-foundation-models`, `openstef-meta`) from the `hatchling` build backend to uv's native `uv_build`.
- Re-enable `--require-hashes` on those package builds in the `build` poe task (reverted in #1009).

## Why

`uv build --require-hashes` was reverted in #1009 because it cannot be satisfied with `hatchling`: hatchling builds in an **isolated PEP 517 environment** whose build dependencies are not in `uv.lock` and cannot be hash-pinned, so uv has no hashes to verify.

`uv_build` is built into uv and performs an **in-process direct build** — no isolated environment and no third-party build backend to resolve/install/hash — so hashed builds pass. Verified locally: all five packages build under `uv build --package <pkg> --require-hashes`.

## Notes

- All five packages use a **src layout** (`src/<module>`) with the module name matching the normalized project name, which is exactly uv_build's default, so their `[tool.hatch]` `build.targets.wheel.packages` blocks are dropped with no replacement config needed.
- `requires = ["uv_build<0.12"]` is an upper bound only (no lower bound to maintain); uv recommends an upper bound so the published sdist stays buildable when a future breaking `uv_build` ships.
- The **root `openstef` meta-package stays on `hatchling`**: it ships no module (only dependencies), and uv_build requires a module. It is built without `--require-hashes` — it contains only metadata, no code. `openstef-deployment-examples` remains excluded from the publishable set.
- `uv.lock` is unchanged (build backends are not locked dependencies).
