### PR TITLE
ci: add CodeQL code scanning (security-and-quality)

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2026 Contributors to the OpenSTEF project <openstef@lfenergy.org>
+# SPDX-License-Identifier: MPL-2.0
+
+name: CodeQL
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    types: [opened, synchronize, reopened]
+  schedule:
+    # Weekly full scan so advisories that land after a merge still surface.
+    - cron: '30 4 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (Python)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Upload results to the Security tab
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
+        with:
+          languages: python
+          build-mode: none # Python is interpreted; no build step required
+          queries: security-and-quality
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
+        with:
+          category: '/language:python'


### PR DESCRIPTION
## What

Add GitHub CodeQL code scanning with the `security-and-quality` query suite for Python.

## Why

Closes the OpenSSF Silver criterion `static_analysis_common_vulnerabilities`: at least one static-analysis tool should carry rules for common vulnerabilities. CodeQL runs natively in Actions with no secrets, so unlike SonarCloud it also scans pull requests from forks. SonarCloud stays in place and continues to report hotspots.

## How

- New workflow `.github/workflows/codeql.yaml`, triggered on push to `main`, pull requests, and a weekly schedule.
- `build-mode: none` (Python is interpreted; no build step).
- Least-privilege permissions: job-scoped `security-events: write`, otherwise read-only.
- Actions SHA-pinned per repo convention (`actions/checkout` v7.0.0, `github/codeql-action` v3).

## Note for reviewer

If the repository currently uses code-scanning **Default** setup, it should be switched to **Advanced** so this workflow is the scanning source (the two can conflict). Requires repo admin.
