### PR TITLE
fix: guard non-exhaustive model match and narrow CodeQL suite

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -35,7 +35,10 @@ jobs:
         with:
           languages: python
           build-mode: none # Python is interpreted; no build step required
-          queries: security-and-quality
+          # security-extended keeps CodeQL focused on vulnerability queries;
+          # the maintainability/reliability queries in security-and-quality
+          # overlap ruff and SonarCloud.
+          queries: security-extended
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3

--- a/packages/openstef-foundation-models/src/openstef_foundation_models/presets/forecasting_workflow.py
+++ b/packages/openstef-foundation-models/src/openstef_foundation_models/presets/forecasting_workflow.py
@@ -21,7 +21,7 @@ or pass a :class:`~openstef_foundation_models.models.checkpoint.LocalCheckpoint`
 to run a file already on disk.
 """
 
-from typing import Literal
+from typing import Literal, assert_never
 
 from pydantic import Field
 
@@ -181,6 +181,8 @@ def create_forecasting_workflow(config: ForecastingWorkflowConfig) -> CustomFore
                 horizons=config.horizons,
                 hyperparams=config.chronos2_hyperparams,
             )
+        case _:
+            assert_never(config.model)
 
     callbacks: list[ForecastingCallback] = []
     return CustomForecastingWorkflow(


### PR DESCRIPTION
## What

Two follow-ups from triaging the first CodeQL scan (PR #1027).

## Changes

- **`forecasting_workflow.py`** — add `case _: assert_never(config.model)` to the model `match`. Today `model` is `Literal["chronos2"]` so the single case is exhaustive, but there was no fallback; adding a second model family would silently leave `forecaster` unbound. The guard makes `ty` enforce exhaustiveness and fails loudly at runtime. Resolves the `py/uninitialized-local-variable` alert.
- **`codeql.yaml`** — narrow the query suite from `security-and-quality` to `security-extended`. The scan produced no vulnerability findings; all 51 alerts were maintainability/reliability queries that overlap ruff and SonarCloud (unused imports, ineffectual statements, PEP 695 `type`-alias false positives, etc.). `security-extended` keeps CodeQL focused on vulnerabilities.

## Not addressed (intentionally)

- `py/unsafe-cyclic-import` in `openstef_core.datasets` — a real but low-urgency import-ordering smell; restructuring is out of scope here.
- `py/undefined-export` (x11) — false positives from PEP 695 `type X = ...` aliases CodeQL does not recognize as definitions.
