### PR TITLE
fix: keep base index authoritative when combining additional features

### DIFF
--- a/packages/openstef-meta/src/openstef_meta/models/forecast_combiners/learned_weights_combiner.py
+++ b/packages/openstef-meta/src/openstef_meta/models/forecast_combiners/learned_weights_combiner.py
@@ -279,9 +279,12 @@ class WeightsCombiner(ForecastCombiner):
         df = dataset.input_data(start=dataset.index[0])
         if additional_features is not None:
             df_a = additional_features.input_data(start=dataset.index[0])
-            df = pd.concat([df, df_a], axis=1, join="inner")
+            # Left-join keeps the full base-prediction index authoritative: rows without
+            # additional features are retained (as NaN) instead of dropped, so every base
+            # prediction still receives weights and is never zeroed out.
+            df = df.join(df_a, how="left")
         if df.empty:
-            msg = "No overlapping timestamps between base predictions and additional features after inner join."
+            msg = "No base predictions available to combine."
             raise InsufficientlyCompleteError(msg)
         return df
 
@@ -299,10 +302,10 @@ class WeightsCombiner(ForecastCombiner):
             is_max: pd.DataFrame = weights.eq(weights.max(axis=1), axis=0)
             weights = is_max.div(weights.sum(axis=1), axis=0)
 
-        # Reindex weights to predictions so that rows without additional_features
-        # (dropped by _prepare_input_data's inner join) get zero weight.
+        # Weights are already aligned to the full base-prediction index (left join in
+        # _prepare_input_data), so valid base forecasts are never zeroed out for rows
+        # lacking additional features.
         predictions = dataset.input_data()
-        weights = weights.reindex(predictions.index, fill_value=0.0)
         return nan_aware_weighted_mean(predictions, weights)
 
     @override

--- a/packages/openstef-meta/src/openstef_meta/models/forecast_combiners/learned_weights_combiner.py
+++ b/packages/openstef-meta/src/openstef_meta/models/forecast_combiners/learned_weights_combiner.py
@@ -276,13 +276,13 @@ class WeightsCombiner(ForecastCombiner):
     def _prepare_input_data(
         dataset: ForecastInputDataset, additional_features: ForecastInputDataset | None
     ) -> pd.DataFrame:
-        df = dataset.input_data(start=dataset.index[0])
-        if additional_features is not None:
-            df_a = additional_features.input_data(start=dataset.index[0])
-            # Left-join keeps the full base-prediction index authoritative: rows without
-            # additional features are retained (as NaN) instead of dropped, so every base
-            # prediction still receives weights and is never zeroed out.
-            df = df.join(df_a, how="left")
+        # Left join keeps the full base-prediction index authoritative: rows without additional
+        # features are retained (as NaN) instead of dropped, so every base prediction still
+        # receives weights and is never zeroed out.
+        combined = combine_forecast_input_datasets(
+            input_data=dataset, additional_features=additional_features, join="left"
+        )
+        df = combined.input_data()
         if df.empty:
             msg = "No base predictions available to combine."
             raise InsufficientlyCompleteError(msg)

--- a/packages/openstef-meta/src/openstef_meta/models/forecast_combiners/stacking_combiner.py
+++ b/packages/openstef-meta/src/openstef_meta/models/forecast_combiners/stacking_combiner.py
@@ -64,10 +64,14 @@ class StackingCombiner(ForecastCombiner):
         data: EnsembleForecastDataset,
         quantile: Quantile,
         additional_features: ForecastInputDataset | None = None,
+        *,
+        join: str = "inner",
     ) -> ForecastInputDataset:
         input_data = data.get_base_predictions_for_quantile(quantile=quantile)
         if additional_features is not None:
-            input_data = combine_forecast_input_datasets(input_data=input_data, additional_features=additional_features)
+            input_data = combine_forecast_input_datasets(
+                input_data=input_data, additional_features=additional_features, join=join
+            )
         return input_data
 
     @property
@@ -100,7 +104,8 @@ class StackingCombiner(ForecastCombiner):
             raise NotFittedError(self.__class__.__name__)
 
         predictions = [
-            self._models[q].predict(data=self._prepare_input(data, q, additional_features)).data for q in self.quantiles
+            self._models[q].predict(data=self._prepare_input(data, q, additional_features, join="left")).data
+            for q in self.quantiles
         ]
         return ForecastDataset(data=pd.concat(predictions, axis=1), sample_interval=data.sample_interval)
 
@@ -116,7 +121,11 @@ class StackingCombiner(ForecastCombiner):
             if not isinstance(model, ContributionsMixin):
                 msg = f"Model {type(model).__name__} does not support predict_contributions."
                 raise NotImplementedError(msg)
-            frames.append(model.predict_contributions(data=self._prepare_input(data, q, additional_features)).data)
+            frames.append(
+                model.predict_contributions(
+                    data=self._prepare_input(data, q, additional_features, join="left")
+                ).data
+            )
 
         contributions = pd.concat(frames, axis=1)
         target_series = data.target_series

--- a/packages/openstef-meta/src/openstef_meta/models/forecast_combiners/stacking_combiner.py
+++ b/packages/openstef-meta/src/openstef_meta/models/forecast_combiners/stacking_combiner.py
@@ -122,9 +122,7 @@ class StackingCombiner(ForecastCombiner):
                 msg = f"Model {type(model).__name__} does not support predict_contributions."
                 raise NotImplementedError(msg)
             frames.append(
-                model.predict_contributions(
-                    data=self._prepare_input(data, q, additional_features, join="left")
-                ).data
+                model.predict_contributions(data=self._prepare_input(data, q, additional_features, join="left")).data
             )
 
         contributions = pd.concat(frames, axis=1)

--- a/packages/openstef-meta/src/openstef_meta/utils/datasets.py
+++ b/packages/openstef-meta/src/openstef_meta/utils/datasets.py
@@ -16,9 +16,9 @@ def combine_forecast_input_datasets(
     Args:
         input_data: ForecastInputDataset containing base forecaster predictions.
         additional_features: Optional ForecastInputDataset containing additional features to combine.
-        join: Type of join to perform on the datasets. Defaults to "inner". Use "left" to keep the
-            full base-prediction index (``input_data``) authoritative, aligning additional features
-            onto it and leaving uncovered rows as NaN instead of dropping them.
+        join: How to combine the datasets. "inner" (default) keeps only shared timestamps. "left"
+            keeps the full ``input_data`` index authoritative, aligning additional features onto it
+            and leaving uncovered rows as NaN.
 
     Returns:
         Combined ForecastInputDataset containing both input data and additional features.

--- a/packages/openstef-meta/src/openstef_meta/utils/datasets.py
+++ b/packages/openstef-meta/src/openstef_meta/utils/datasets.py
@@ -16,25 +16,32 @@ def combine_forecast_input_datasets(
     Args:
         input_data: ForecastInputDataset containing base forecaster predictions.
         additional_features: Optional ForecastInputDataset containing additional features to combine.
-        join: Type of join to perform on the datasets. Defaults to "inner".
+        join: Type of join to perform on the datasets. Defaults to "inner". Use "left" to keep the
+            full base-prediction index (``input_data``) authoritative, aligning additional features
+            onto it and leaving uncovered rows as NaN instead of dropping them.
 
     Returns:
         Combined ForecastInputDataset containing both input data and additional features.
     """
     if not isinstance(additional_features, ForecastInputDataset):
         return input_data
-    if join != "inner":
-        raise NotImplementedError("Only 'inner' join is currently supported.")
+    if join not in ("inner", "left"):
+        raise NotImplementedError("Only 'inner' and 'left' joins are currently supported.")
     df_additional = additional_features.data
     if input_data.target_column in df_additional.columns:
         df_additional = df_additional.drop(columns=[input_data.target_column])
 
     df_input = input_data.data
-    df = pd.concat(
-        [df_input, df_additional],
-        axis=1,
-        join="inner",
-    )
+    if join == "left":
+        # Base predictions stay authoritative: additional features are aligned onto the base
+        # index, so rows lacking features are kept (as NaN) rather than dropped.
+        df = df_input.join(df_additional, how="left")
+    else:
+        df = pd.concat(
+            [df_input, df_additional],
+            axis=1,
+            join="inner",
+        )
 
     return ForecastInputDataset(
         data=df,

--- a/packages/openstef-meta/tests/unit/models/forecast_combiners/test_learned_weights_combiner.py
+++ b/packages/openstef-meta/tests/unit/models/forecast_combiners/test_learned_weights_combiner.py
@@ -116,6 +116,55 @@ def test_quantile_weights_combiner__fit_with_additional_features_shorter_index(
     assert combiner.is_fitted
 
 
+def test_predict_keeps_full_index_when_base_timestamp_missing_from_additional(
+    ensemble_dataset: EnsembleForecastDataset,
+) -> None:
+    """Predict must forecast every base timestamp even when additional_features misses some.
+
+    Regression test for the real scenario: additional_features extends further into the future
+    than the base predictions but its index grid does not perfectly cover the base index, so a
+    base timestamp is absent and its extra feature is NaN there (future data). The previous inner
+    join + reindex(fill_value=0.0) zeroed the weights for that uncovered row, collapsing its
+    forecast to 0 despite valid base predictions. A left join keeps the base index authoritative
+    and lets the classifier tolerate the NaN feature instead.
+    """
+    # Arrange — additional_features is longer (future rows) but omits the last base timestamp,
+    # and carries an extra feature that is NaN for the future rows.
+    base_index = ensemble_dataset.data.index
+    future_index = pd.date_range(
+        base_index[-1] + ensemble_dataset.sample_interval, periods=3, freq=ensemble_dataset.sample_interval
+    )
+    additional_index = base_index[:-1].append(future_index)
+    additional_features = ForecastInputDataset(
+        data=pd.DataFrame(
+            {
+                "load": [1.0, 2.0, 0.0, 0.0, 0.0],
+                "extra_feature": [10.0, 20.0, np.nan, np.nan, np.nan],
+            },
+            index=additional_index,
+        ),
+        sample_interval=ensemble_dataset.sample_interval,
+        target_column="load",
+    )
+    combiner = WeightsCombiner(
+        hyperparams=LGBMCombinerHyperParams(n_leaves=5, n_estimators=10),
+        quantiles=[Q(0.5)],
+        horizons=[LeadTime(timedelta(days=1))],
+    )
+    combiner.fit(ensemble_dataset, additional_features=additional_features)
+
+    # Act
+    result = combiner.predict(ensemble_dataset, additional_features=additional_features)
+    contributions = combiner.predict_contributions(ensemble_dataset, additional_features=additional_features)
+
+    # Assert — full base index forecast, no NaN, and the uncovered row keeps non-zero weights
+    weight_cols = [c for c in contributions.data.columns if c != "load"]
+    assert result.data.index.equals(base_index)
+    assert not result.data.isna().any().any()
+    assert contributions.data.loc[base_index[-1], weight_cols].sum() > 0
+    assert result.data.loc[base_index[-1], Q(0.5).format()] != 0
+
+
 def test_predict_renormalizes_weights_when_base_model_predictions_are_nan() -> None:
     """Predict should renormalize weights when a base model has NaN predictions.
 

--- a/packages/openstef-meta/tests/unit/models/forecast_combiners/test_stacking_combiner.py
+++ b/packages/openstef-meta/tests/unit/models/forecast_combiners/test_stacking_combiner.py
@@ -4,10 +4,12 @@
 
 from datetime import timedelta
 
+import numpy as np
+import pandas as pd
 import pytest
 
 from openstef_core.datasets import TimeSeriesDataset
-from openstef_core.datasets.validated_datasets import EnsembleForecastDataset
+from openstef_core.datasets.validated_datasets import EnsembleForecastDataset, ForecastInputDataset
 from openstef_core.exceptions import NotFittedError
 from openstef_core.types import LeadTime, Q
 from openstef_meta.models.forecast_combiners.stacking_combiner import StackingCombiner
@@ -80,6 +82,54 @@ def test_stacking_combiner_not_fitted_error(
     """Test that NotFittedError is raised when predicting before fitting."""
     with pytest.raises(NotFittedError):
         combiner.predict(ensemble_dataset)
+
+
+def test_stacking_predict_keeps_full_index_when_base_timestamp_missing_from_additional(
+    ensemble_dataset: EnsembleForecastDataset,
+) -> None:
+    """Predict must forecast every base timestamp even when additional_features misses some.
+
+    Regression test for the real scenario: additional_features extends further into the future
+    than the base predictions but its index grid does not perfectly cover the base index, so a
+    base timestamp is absent and its extra feature is NaN there (future data). The previous inner
+    join silently truncated the forecast to the overlap; a left join keeps the base index
+    authoritative and lets the meta-forecaster tolerate the NaN feature instead.
+    """
+    # Arrange — additional_features is longer (future rows) but omits the last base timestamp,
+    # and carries an extra feature that is NaN for the future rows.
+    base_index = ensemble_dataset.data.index
+    future_index = pd.date_range(
+        base_index[-1] + ensemble_dataset.sample_interval, periods=3, freq=ensemble_dataset.sample_interval
+    )
+    additional_index = base_index[:-1].append(future_index)
+    additional_features = ForecastInputDataset(
+        data=pd.DataFrame(
+            {
+                "load": [1.0, 2.0, 0.0, 0.0, 0.0],
+                "extra_feature": [10.0, 20.0, np.nan, np.nan, np.nan],
+            },
+            index=additional_index,
+        ),
+        sample_interval=ensemble_dataset.sample_interval,
+        target_column="load",
+    )
+    combiner = StackingCombiner(
+        meta_forecaster=_make_template("lgbm"),
+        quantiles=[Q(0.5)],
+        horizons=[LeadTime(timedelta(days=1))],
+    )
+    combiner.fit(ensemble_dataset, additional_features=additional_features)
+
+    # Act
+    result = combiner.predict(ensemble_dataset, additional_features=additional_features)
+    contributions = combiner.predict_contributions(ensemble_dataset, additional_features=additional_features)
+
+    # Assert — forecast spans the full base index (not just the overlap) with no NaN
+    weight_cols = [c for c in contributions.data.columns if c != "load"]
+    assert result.data.index.equals(base_index)
+    assert not result.data.isna().any().any()
+    assert contributions.data.loc[base_index[-1], weight_cols].sum() > 0
+    assert result.data.loc[base_index[-1], Q(0.5).format()] != 0
 
 
 def test_stacking_combiner_predict_contributions(

--- a/packages/openstef-meta/tests/unit/utils/test_datasets.py
+++ b/packages/openstef-meta/tests/unit/utils/test_datasets.py
@@ -122,4 +122,3 @@ def test_combine_forecast_input_datasets_left_join_keeps_base_index(ensemble_dat
     # Assert — base index is authoritative; uncovered row keeps the feature as NaN
     assert combined.data.index.equals(base_index)
     assert bool(combined.data.loc[base_index[-1], "extra"] != combined.data.loc[base_index[-1], "extra"])
-

--- a/packages/openstef-meta/tests/unit/utils/test_datasets.py
+++ b/packages/openstef-meta/tests/unit/utils/test_datasets.py
@@ -11,6 +11,7 @@ import pytest
 
 from openstef_core.datasets.validated_datasets import EnsembleForecastDataset, ForecastDataset, ForecastInputDataset
 from openstef_core.types import Quantile
+from openstef_meta.utils.datasets import combine_forecast_input_datasets
 
 
 @pytest.fixture
@@ -81,3 +82,44 @@ def test_get_base_predictions_for_quantile(ensemble_dataset: EnsembleForecastDat
     # Assert
     assert isinstance(dataset, ForecastInputDataset)
     assert dataset.data.shape == (3, 3)  # 3 timestamps, 2 learners * 1 quantiles + target
+
+
+def test_combine_forecast_input_datasets_none_returns_input(ensemble_dataset: EnsembleForecastDataset):
+    # Arrange
+    base = ensemble_dataset.get_base_predictions_for_quantile(Quantile(0.5))
+
+    # Act / Assert — no additional features leaves the input untouched
+    assert combine_forecast_input_datasets(base, None) is base
+
+
+def test_combine_forecast_input_datasets_invalid_join_raises(ensemble_dataset: EnsembleForecastDataset):
+    # Arrange
+    base = ensemble_dataset.get_base_predictions_for_quantile(Quantile(0.5))
+    additional = ForecastInputDataset(
+        data=pd.DataFrame({"load": [1.0, 2.0, 3.0]}, index=base.data.index),
+        sample_interval=base.sample_interval,
+        target_column="load",
+    )
+
+    # Act / Assert
+    with pytest.raises(NotImplementedError):
+        combine_forecast_input_datasets(base, additional, join="outer")
+
+
+def test_combine_forecast_input_datasets_left_join_keeps_base_index(ensemble_dataset: EnsembleForecastDataset):
+    # Arrange — additional features cover only a subset of the base index
+    base = ensemble_dataset.get_base_predictions_for_quantile(Quantile(0.5))
+    base_index = base.data.index
+    additional = ForecastInputDataset(
+        data=pd.DataFrame({"load": [1.0, 2.0], "extra": [10.0, 20.0]}, index=base_index[:-1]),
+        sample_interval=base.sample_interval,
+        target_column="load",
+    )
+
+    # Act
+    combined = combine_forecast_input_datasets(base, additional, join="left")
+
+    # Assert — base index is authoritative; uncovered row keeps the feature as NaN
+    assert combined.data.index.equals(base_index)
+    assert bool(combined.data.loc[base_index[-1], "extra"] != combined.data.loc[base_index[-1], "extra"])
+

--- a/packages/openstef-models/src/openstef_models/models/forecasting/median_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/median_forecaster.py
@@ -200,9 +200,7 @@ class MedianForecaster(Forecaster, ExplainableForecaster, ContributionsMixin):
         lag_df = input_data.reindex(new_index, fill_value=np.nan)[self._feature_names]
 
         # Convert the lag DataFrame to NumPy arrays for faster processing.
-        # copy=True ensures a writable array under pandas Copy-on-Write (pandas >= 3),
-        # since the autoregressive step fills the diagonal in place.
-        lag_array = lag_df.to_numpy(copy=True)
+        lag_array = lag_df.to_numpy()
         # Initialize the prediction array with NaNs.
         prediction = np.full(lag_array.shape[0], np.nan)
 

--- a/packages/openstef-models/src/openstef_models/models/forecasting/median_forecaster.py
+++ b/packages/openstef-models/src/openstef_models/models/forecasting/median_forecaster.py
@@ -200,7 +200,9 @@ class MedianForecaster(Forecaster, ExplainableForecaster, ContributionsMixin):
         lag_df = input_data.reindex(new_index, fill_value=np.nan)[self._feature_names]
 
         # Convert the lag DataFrame to NumPy arrays for faster processing.
-        lag_array = lag_df.to_numpy()
+        # copy=True ensures a writable array under pandas Copy-on-Write (pandas >= 3),
+        # since the autoregressive step fills the diagonal in place.
+        lag_array = lag_df.to_numpy(copy=True)
         # Initialize the prediction array with NaNs.
         prediction = np.full(lag_array.shape[0], np.nan)
 


### PR DESCRIPTION
## What does this PR do?

Fixes forecast combiners zeroing/truncating forecasts when `additional_features` does not fully cover the base-prediction index (e.g. future rows with NaN features). Base predictions are now authoritative: additional features are left-joined at predict time, and the zero-fill reindex is removed. `WeightsCombiner` reuses `combine_forecast_input_datasets` to match `StackingCombiner`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (see checklist below)
- [ ] Documentation
- [ ] Refactor / chore / CI

## AI disclosure

- [ ] No AI assistance was used (beyond grammar/spelling)
- [x] AI assistance was used — tool(s): GitHub Copilot
  - [x] I have reviewed, understand, and can explain all AI-generated code in this PR
  - [x] This is disclosed in a commit message (e.g. `Assisted-by: <tool name>`)

## Checklist

- [x] `poe all --check` passes locally
- [x] Tests added/updated for the change
- [ ] Documentation updated (docstrings, user guide, examples) if needed
- [x] Commits are signed off per our DCO (`git commit -s`)
- [x] PR title follows Conventional Commits
