### PR TITLE
fix: Updated mlflow storage to support databricks and other mlflow internal connections.

### DIFF
--- a/packages/openstef-models/src/openstef_models/integrations/mlflow/mlflow_storage.py
+++ b/packages/openstef-models/src/openstef_models/integrations/mlflow/mlflow_storage.py
@@ -66,6 +66,23 @@ class MLFlowStorage(BaseConfig):
     Handles creation, storage, and retrieval of MLflow runs including models,
     training data, metrics, and hyperparameters. Organizes artifacts locally
     before uploading to MLflow tracking server.
+
+    ``tracking_uri`` configures the Tracking backend that stores experiments and
+    runs. ``registry_uri`` optionally configures a separate Model Registry
+    backend; if it is omitted, MLflow uses the registry associated with the
+    tracking backend. ``artifact_location`` configures the artifact root for
+    experiments created by this instance.
+
+    Typical configurations:
+
+    tracking_uri="sqlite:///mlflow.db", # Local SQLite tracking backend with separate local artifacts
+    tracking_uri="https://mlflow.example.com", # Remote MLflow Tracking Server with S3 artifacts
+    tracking_uri="databricks", # Databricks MLflow Tracking Server with DBFS artifacts
+
+    A caller may provide ``client`` to use an already configured
+    :class:`mlflow.MlflowClient`. When supplied, it takes precedence over
+    ``tracking_uri`` and ``registry_uri`` and is excluded from serialized model
+    configuration.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/packages/openstef-models/src/openstef_models/integrations/mlflow/mlflow_storage.py
+++ b/packages/openstef-models/src/openstef_models/integrations/mlflow/mlflow_storage.py
@@ -22,7 +22,7 @@ from urllib.parse import urlparse
 from mlflow import MlflowClient
 from mlflow.entities import Metric, Param, Run
 from mlflow.exceptions import MlflowException
-from pydantic import Field, PrivateAttr
+from pydantic import ConfigDict, Field, PrivateAttr
 
 from openstef_core.base_model import BaseConfig
 from openstef_core.exceptions import ModelNotFoundError
@@ -31,7 +31,7 @@ from openstef_models.integrations.joblib import JoblibModelSerializer
 from openstef_models.mixins import ModelIdentifier, ModelSerializer
 
 
-def normalize_tracking_uri(uri: str) -> str:
+def normalize_tracking_uri(uri: str, exceptions: Sequence[str] = []) -> str:
     r"""Normalize a tracking URI to a file:/// URI when it refers to a local path.
 
     MLflow's model registry rejects bare Windows paths (e.g. ``D:\mlflow``) because
@@ -44,10 +44,13 @@ def normalize_tracking_uri(uri: str) -> str:
 
     Args:
         uri: Raw tracking URI string, may be a path or a proper URI.
+        exceptions: List of URI to treat as urls even if they have no scheme
 
     Returns:
         A ``file:///`` URI for local paths, or the original URI for remote schemes.
     """
+    if uri in exceptions:
+        return uri
     scheme = urlparse(uri).scheme
     # Empty scheme → relative/absolute POSIX path.
     # Single-letter scheme → Windows drive letter (e.g. "D" from "D:\\...").
@@ -65,7 +68,14 @@ class MLFlowStorage(BaseConfig):
     before uploading to MLflow tracking server.
     """
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     tracking_uri: str = Field(default="./mlflow", description="MLflow tracking server URI.")
+    registry_uri: str | None = Field(default=None, description="MLflow tracking server URI.")
+
+    # Excluded from model_dump(), JSON serialization, and config persistence.
+    client: MlflowClient | None = Field(default=None, exclude=True, repr=False)
+
     local_artifacts_path: Path = Field(
         default=Path("./mlflow_artifacts_local"), description="Local path for storing MLflow artifacts before upload."
     )
@@ -86,6 +96,11 @@ class MLFlowStorage(BaseConfig):
 
     model_serializer: ModelSerializer = Field(default_factory=JoblibModelSerializer)
 
+    uri_exceptions: Sequence[str] = Field(
+        default=["databricks"],
+        description="List of URI treat as urls even if they have no scheme",
+    )
+
     _client: MlflowClient = PrivateAttr()
     _logger: logging.Logger = PrivateAttr(default=logging.getLogger(__name__))
 
@@ -95,8 +110,17 @@ class MLFlowStorage(BaseConfig):
             # Suppress MLflow's stdout messages (emoji URLs)
             os.environ.setdefault("MLFLOW_SUPPRESS_PRINTING_URL_TO_STDOUT", "true")
             os.environ.setdefault("MLFLOW_ENABLE_ARTIFACTS_PROGRESS_BAR", "false")
+
+        if self.client is not None:
+            self._client = self.client
+            return
+
         self.tracking_uri = normalize_tracking_uri(self.tracking_uri)
-        self._client = MlflowClient(tracking_uri=self.tracking_uri)
+        self.registry_uri = normalize_tracking_uri(self.registry_uri) if self.registry_uri else None
+        self._client = MlflowClient(
+            tracking_uri=self.tracking_uri,
+            registry_uri=self.registry_uri,
+        )
 
     def create_run(
         self,

--- a/packages/openstef-models/tests/unit/integrations/mlflow/test_mlflow_storage.py
+++ b/packages/openstef-models/tests/unit/integrations/mlflow/test_mlflow_storage.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
+from mlflow import MlflowClient
 import pytest
 
 from openstef_core.mixins import HyperParams, Stateful
@@ -47,6 +48,20 @@ def storage(tmp_path: Path) -> MLFlowStorage:
 def model_id() -> str:
     """Return consistent model identifier for tests."""
     return "test_model_123"
+
+def test_construct_from_mlflow(tmp_path: Path, model_id: str):
+    """Test that experiment_name_prefix is prepended to experiment names."""
+    # Arrange
+    mlflow_client = MlflowClient(tracking_uri=f"sqlite:///{tmp_path / 'mlflow.db'}")
+
+    # Act
+    storage = MLFlowStorage(
+        tracking_uri=f"sqlite:///{tmp_path / 'mlflow.db'}",
+        client=mlflow_client,
+    )
+
+    # Assert
+    assert storage._client is mlflow_client
 
 
 def test_create_run(storage: MLFlowStorage, model_id: str):
@@ -194,12 +209,15 @@ def test_search_run__returns_matching_run(storage: MLFlowStorage, model_id: str)
         pytest.param("https://mlflow.example.com:5000", "https://mlflow.example.com:5000", id="https-port"),
         pytest.param("sqlite:///mlflow.db", "sqlite:///mlflow.db", id="sqlite"),
         pytest.param("postgresql://user:pass@host/db", "postgresql://user:pass@host/db", id="postgresql"),
+        pytest.param("databricks", "databricks", id="databricks"),
     ],
 )
 def test_normalize_tracking_uri(uri: str, expected: str):
     """Local paths become file:/// URIs; remote/database URIs pass through unchanged."""
     # Act
-    result = normalize_tracking_uri(uri)
+    result = normalize_tracking_uri(
+        uri, exceptions=["databricks"]
+    )  # databricks is a special case that should not be normalized
 
     # Assert
     if expected == "file:///":

--- a/packages/openstef-models/tests/unit/integrations/mlflow/test_mlflow_storage.py
+++ b/packages/openstef-models/tests/unit/integrations/mlflow/test_mlflow_storage.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
-from mlflow import MlflowClient
 import pytest
+from mlflow import MlflowClient
 
 from openstef_core.mixins import HyperParams, Stateful
 from openstef_models.integrations.mlflow import MLFlowStorage
@@ -48,6 +48,7 @@ def storage(tmp_path: Path) -> MLFlowStorage:
 def model_id() -> str:
     """Return consistent model identifier for tests."""
     return "test_model_123"
+
 
 def test_construct_from_mlflow(tmp_path: Path, model_id: str):
     """Test that experiment_name_prefix is prepended to experiment names."""


### PR DESCRIPTION
## What does this PR do?

Updated mlflow storage to have an escape hatch if the tracking uri is a single text and is not a relative path. For example for databricks it's 'databricks'. This supports it for other providers if needed.

Also this adds support for setting model registry.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change (see checklist below)
- [ ] Documentation
- [ ] Refactor / chore / CI

## Breaking changes checklist

Config did change, but this is the part that is not serialized in any checkpoints. And it has defaults, so no interface or behaviour changes. 


## AI disclosure

- [X] No AI assistance was used (beyond grammar/spelling)
- [ ] AI assistance was used — tool(s): <!-- e.g. GitHub Copilot, Claude, ChatGPT -->
  - [ ] I have reviewed, understand, and can explain all AI-generated code in this PR
  - [ ] This is disclosed in a commit message (e.g. `Assisted-by: <tool name>`)

## Checklist

- [x] `poe all --check` passes locally
- [x] Tests added/updated for the change
- [x] Documentation updated (docstrings, user guide, examples) if needed
- [x] Commits are signed off per our [DCO](https://openstef.github.io/openstef/contribute/contributing_guide.html#signing-the-developer-certificate-of-origin-dco) (`git commit -s`)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `feat!: ...` for breaking changes)
