### PR TITLE
docs: auto-update documentation for v4.2.3

### DIFF
--- a/docs/source/user_guide/concepts/models.rst
+++ b/docs/source/user_guide/concepts/models.rst
@@ -205,3 +205,4 @@ Most users start with Presets and only drop down to lower levels when they need
 custom behavior. The component boundaries are designed so you can replace one piece
 (e.g., swap a Forecaster or add a Transform) without rewriting the rest of the
 pipeline.
+```

--- a/docs/source/user_guide/getting_started/installation.rst
+++ b/docs/source/user_guide/getting_started/installation.rst
@@ -250,6 +250,20 @@ Feature extras are additive — combine as many as you need:
    * - ``openstef-beam[all]``
      - All BEAM baselines plus S3 storage
 
+Pandas Compatibility
+--------------------
+
+OpenSTEF supports pandas 2.x and pandas 3.x (the dependency is pinned to
+``pandas >=2.3.1, <4``). A fresh install may resolve to pandas 3.0+, which enables
+Copy-on-Write semantics by default.
+
+.. warning::
+   If your existing code relies on pandas 2.x mutable-view behaviour (e.g. modifying a
+   slice of a DataFrame in place and expecting the parent to change), pandas 3.0 will
+   silently produce different results. Pin ``pandas<3`` in your own project constraints
+   until you have verified compatibility, or update your code to avoid in-place mutation
+   of views.
+
 Development Installation
 ========================
 

--- a/docs/source/user_guide/getting_started/migration.rst
+++ b/docs/source/user_guide/getting_started/migration.rst
@@ -318,3 +318,4 @@ If your v3 code relied on ``openstef-dbc``:
 3. **Configuration storage** -- serialize
    :class:`~openstef_models.presets.ForecastingWorkflowConfig` to/from your config
    store (JSON, YAML, database row).
+```

--- a/docs/source/user_guide/guides/deployment.rst
+++ b/docs/source/user_guide/guides/deployment.rst
@@ -122,11 +122,32 @@ Any source that returns a time series compatible with your sample interval works
 Model Storage with MLflow
 -------------------------
 
-OpenSTEF supports MLflow as a model registry backend through :class:`~openstef_models.integrations.mlflow.mlflow_storage_callback.MLFlowStorageCallback`. This callback hooks into the workflow lifecycle to automatically store trained models, log metrics, and retrieve previously trained models for reuse.
+OpenSTEF supports MLflow as a model registry backend through :class:`~openstef_models.integrations.mlflow.MLFlowStorageCallback`. This callback hooks into the workflow lifecycle to automatically store trained models, log metrics, and retrieve previously trained models for reuse.
+
+The underlying :class:`~openstef_models.integrations.mlflow.MLFlowStorage` class
+manages the connection to the MLflow tracking server. It can be configured with a
+``tracking_uri`` string for standard deployments, or constructed with an existing
+:class:`mlflow.MlflowClient` instance for environments that manage their own MLflow
+connections (such as Databricks-managed MLflow):
 
 .. code-block:: python
 
-   from openstef_models.integrations.mlflow.mlflow_storage_callback import MLFlowStorageCallback
+   from openstef_models.integrations.mlflow import MLFlowStorage
+
+   # Standard: provide a tracking URI
+   storage = MLFlowStorage(tracking_uri="https://mlflow.example.com")
+
+   # Databricks or custom: provide a pre-configured client
+   storage = MLFlowStorage(client=my_existing_mlflow_client)
+
+When a ``client`` is supplied, it takes precedence over ``tracking_uri`` and
+``registry_uri``.
+
+The callback is then wired into the workflow:
+
+.. code-block:: python
+
+   from openstef_models.integrations.mlflow import MLFlowStorageCallback
 
    callback = MLFlowStorageCallback(
        storage=my_mlflow_storage,
@@ -191,3 +212,4 @@ OpenSTEF is designed to be composed. If your deployment needs something the libr
 - Add custom preprocessing transforms to the model pipeline (see :doc:`/user_guide/concepts/models`).
 
 For how the forecasting workflow itself is structured (model creation, training, prediction), see :doc:`/user_guide/guides/forecasting`.
+```


### PR DESCRIPTION
## Automated documentation update for `v4.2.3`

This PR was opened automatically by the **openstef-doc-pipeline**.

| Field | Value |
|-------|-------|
| Release | [v4.2.3](https://github.com/OpenSTEF/openstef/releases/tag/v4.2.3) |
| Tag | `v4.2.3` |
| Branch | `docs/auto-update-v4.2.3` |
| Pages Generated | 4 |
| Changed Python Files | 10 |

### Generated artefacts

| File | Description |
|------|-------------|
| `docs/source/user_guide/getting_started/migration.rst` | Auto-generated docs artefact |
| `docs/source/user_guide/getting_started/installation.rst` | Auto-generated docs artefact |
| `docs/source/user_guide/concepts/models.rst` | Auto-generated docs artefact |
| `docs/source/user_guide/guides/deployment.rst` | Auto-generated docs artefact |

### Diagrams

This PR includes **0 generated Mermaid diagram(s)** integrated into the documentation.

### Release notes

## What's Changed
* chore: migrate to pandas 3.0 (Copy-on-Write) (#935) by @oaksprout in https://github.com/OpenSTEF/openstef/pull/1049
* fix: Updated mlflow storage to support databricks and other mlflow internal connections. by @egordm in https://github.com/OpenSTEF/openstef/pull/1059

## New Contributors
* @oaksprout made their first contribution in https://github.com/OpenSTEF/openstef/pull/1049

**Full Changelog**: https://github.com/OpenSTEF/openstef/compare/v4.2.2...v4.2.3

---

> **Human review required.**
> Please review all generated files carefully before merging.
> The pipeline does **not** auto-merge this PR.
