### PR TITLE
fix: use validation data and support N-forecaster ensembles in WeightsCombiner

### DIFF
--- a/packages/openstef-meta/src/openstef_meta/models/forecast_combiners/learned_weights_combiner.py
+++ b/packages/openstef-meta/src/openstef_meta/models/forecast_combiners/learned_weights_combiner.py
@@ -160,6 +160,12 @@ class WeightsCombiner(ForecastCombiner):
     A classifier predicts per-timestep model weights.  Depending on ``hard_selection``,
     the combiner either picks the best forecaster (hard) or blends using predicted
     probabilities (soft).
+
+    When ``data_val`` is supplied to :meth:`fit`, the classifier is trained on those
+    held-out predictions instead of the in-sample training predictions. In-sample
+    predictions from boosted/tree forecasters are systematically over-optimistic, which
+    would otherwise bias the combiner towards whichever forecaster overfits the training
+    data hardest, regardless of true out-of-sample skill.
     """
 
     hyperparams: HyperParams = Field(
@@ -181,6 +187,7 @@ class WeightsCombiner(ForecastCombiner):
     _is_fitted: bool = PrivateAttr(default=False)
     _feature_names: list[str] = PrivateAttr(default_factory=list[str])
     _models: dict[Quantile, ClassifierMixin] = PrivateAttr(default_factory=dict[Quantile, ClassifierMixin])
+    _dummy_fallback_label: dict[Quantile, str] = PrivateAttr(default_factory=dict[Quantile, str])
 
     @override
     def model_post_init(self, _context: object, /) -> None:
@@ -211,11 +218,16 @@ class WeightsCombiner(ForecastCombiner):
         data_val: EnsembleForecastDataset | None = None,
         additional_features: ForecastInputDataset | None = None,
     ) -> None:
-        self._label_encoder.fit(data.forecaster_names)
+        # Prefer genuine held-out predictions when available: in-sample predictions from
+        # boosted/tree forecasters are systematically over-optimistic, which biases the
+        # "who wins" classifier towards whichever forecaster overfits training data hardest.
+        effective_data = data_val if data_val is not None else data
+
+        self._label_encoder.fit(effective_data.forecaster_names)
 
         feature_names: list[str] = []
         for q in self.quantiles:
-            base_data = data.get_base_predictions_for_quantile(quantile=q)
+            base_data = effective_data.get_base_predictions_for_quantile(quantile=q)
             labels = self._classify_best_forecaster(base_data, quantile=q)
             combined_data = combine_forecast_input_datasets(
                 input_data=base_data,
@@ -256,17 +268,32 @@ class WeightsCombiner(ForecastCombiner):
         return losses.idxmin(axis=1)
 
     def _validate_labels(self, labels: pd.Series, quantile: Quantile) -> None:
-        # Fall back to DummyClassifier when one forecaster dominates — sklearn classifiers need ≥2 classes
-        if len(labels.unique()) == 1:
-            logger.warning("Quantile %s has only 1 class — switching to DummyClassifier.", quantile.format())
+        # Fall back to DummyClassifier whenever fewer forecasters ever win than are registered —
+        # sklearn classifiers need to see every class at least once. With only 2 forecasters this
+        # only happens when one wins every sample, but with 3+ it's common for a subset (not
+        # necessarily just one) to never win, so the guard must generalize beyond "exactly 1 label".
+        n_seen = len(labels.unique())
+        n_registered = len(self._label_encoder.classes_)
+        if n_seen < n_registered:
+            majority_label = str(labels.value_counts().idxmax())
+            logger.warning(
+                "Quantile %s: only %d/%d forecasters ever win — switching to DummyClassifier (majority winner: '%s').",
+                quantile.format(),
+                n_seen,
+                n_registered,
+                majority_label,
+            )
             self._models[quantile] = DummyClassifier(strategy="most_frequent")
+            self._dummy_fallback_label[quantile] = majority_label
 
     def _predict_weights(self, base_predictions: pd.DataFrame, quantile: Quantile) -> pd.DataFrame:
         model = self._models[quantile]
         if isinstance(model, DummyClassifier):
-            # DummyClassifier has no predict_proba — construct one-hot weights manually
-            weights_array = pd.DataFrame(0, index=base_predictions.index, columns=self._label_encoder.classes_)
-            weights_array[self._label_encoder.classes_[0]] = 1.0
+            # DummyClassifier has no predict_proba — use the recorded majority winner rather than
+            # assuming the alphabetically-first registered forecaster name is the actual winner.
+            fallback_label = self._dummy_fallback_label.get(quantile, self._label_encoder.classes_[0])
+            weights_array = pd.DataFrame(0.0, index=base_predictions.index, columns=self._label_encoder.classes_)
+            weights_array[fallback_label] = 1.0
         else:
             weights_array = model.predict_proba(base_predictions)  # ty: ignore[unresolved-attribute]
 

--- a/packages/openstef-meta/src/openstef_meta/models/forecast_combiners/stacking_combiner.py
+++ b/packages/openstef-meta/src/openstef_meta/models/forecast_combiners/stacking_combiner.py
@@ -88,11 +88,18 @@ class StackingCombiner(ForecastCombiner):
     ) -> None:
         for q in self.quantiles:
             input_data = self._prepare_input(data, q, additional_features)
+            input_data = input_data.pipe_pandas(partial(pd.DataFrame.dropna, subset=[input_data.target_column]))
 
-            target_dropna = partial(pd.DataFrame.dropna, subset=[input_data.target_column])
-            input_data = input_data.pipe_pandas(target_dropna)
+            # Pass validation predictions through so meta-forecasters that support early
+            # stopping (e.g. LGBM/XGBoost) can use them, instead of always discarding data_val.
+            input_data_val = None
+            if data_val is not None:
+                input_data_val = self._prepare_input(data_val, q)
+                input_data_val = input_data_val.pipe_pandas(
+                    partial(pd.DataFrame.dropna, subset=[input_data_val.target_column])
+                )
 
-            self._models[q].fit(data=input_data, data_val=None)
+            self._models[q].fit(data=input_data, data_val=input_data_val)
 
     @override
     def predict(

--- a/packages/openstef-meta/tests/unit/models/forecast_combiners/test_learned_weights_combiner.py
+++ b/packages/openstef-meta/tests/unit/models/forecast_combiners/test_learned_weights_combiner.py
@@ -215,3 +215,107 @@ def test_predict_renormalizes_weights_when_base_model_predictions_are_nan() -> N
     assert nan_rows["quantile_P50"].mean() > 500, (
         "Predictions in the NaN region should not be systematically scaled down"
     )
+
+
+def _make_three_forecaster_dataset(winners: list[str], index: pd.DatetimeIndex) -> EnsembleForecastDataset:
+    """Build a 3-forecaster ensemble dataset where `winners[i]` has the lowest error at row i.
+
+    Each forecaster predicts a constant offset from the target; the named winner at each
+    row gets a near-zero offset (best pinball loss), the others get a large offset.
+    """
+    target = pd.Series(1000.0, index=index)
+    data: dict[str, pd.Series] = {"load": target}
+    for name in ("Alpha", "Bravo", "Charlie"):
+        is_winner = pd.Series([w == name for w in winners], index=index)
+        offset = is_winner.map({True: 0.0, False: 500.0})
+        data[f"{name}__quantile_P50"] = target + offset
+
+    return EnsembleForecastDataset(data=pd.DataFrame(data), sample_interval=timedelta(minutes=15))
+
+
+def test_validate_labels_handles_subset_of_forecasters_never_winning() -> None:
+    """With 3+ forecasters, only some (not necessarily just one) may ever win.
+
+    Regression test: the degenerate-label guard used to only trigger when exactly one
+    unique label was observed, which crashed `predict_proba` when the fitted classifier
+    only ever saw 2 of 3 registered classes (a `ValueError` on shape mismatch). It must
+    generalize to "fewer distinct winners than registered forecasters".
+    """
+    index = pd.date_range("2023-01-01", periods=20, freq="15min")
+    # Charlie never wins; Alpha and Bravo alternate — 2 unique labels out of 3 registered.
+    winners = ["Alpha" if i % 2 == 0 else "Bravo" for i in range(20)]
+    dataset = _make_three_forecaster_dataset(winners, index)
+
+    combiner = WeightsCombiner(
+        hyperparams=LGBMCombinerHyperParams(n_leaves=5, n_estimators=10),
+        quantiles=[Q(0.5)],
+        horizons=[LeadTime(timedelta(days=1))],
+    )
+
+    # Act — should not raise even though Charlie is never a label
+    combiner.fit(dataset)
+    result = combiner.predict(dataset)
+
+    # Assert
+    assert combiner.is_fitted
+    assert not result.data.isna().any().any()
+
+
+def test_dummy_fallback_uses_actual_majority_winner_not_alphabetical_first() -> None:
+    """The DummyClassifier fallback must weight the real majority winner, not `classes_[0]`.
+
+    Regression test: when every sample is won by the same forecaster, `_predict_weights`
+    used to hardcode weight 1.0 on `self._label_encoder.classes_[0]` — the alphabetically
+    first registered forecaster name — regardless of which forecaster actually won. Use a
+    winner ("Charlie") that does not sort first alphabetically among the 3 names.
+    """
+    index = pd.date_range("2023-01-01", periods=20, freq="15min")
+    winners = ["Charlie"] * 20  # Alpha sorts first alphabetically, but never wins
+    dataset = _make_three_forecaster_dataset(winners, index)
+
+    combiner = WeightsCombiner(
+        hyperparams=LGBMCombinerHyperParams(n_leaves=5, n_estimators=10),
+        quantiles=[Q(0.5)],
+        horizons=[LeadTime(timedelta(days=1))],
+    )
+
+    combiner.fit(dataset)
+    result = combiner.predict(dataset)
+
+    # Assert — predictions should match Charlie's (the real winner), not Alpha's
+    charlie_predictions = dataset.data["Charlie__quantile_P50"]
+    alpha_predictions = dataset.data["Alpha__quantile_P50"]
+    pd.testing.assert_series_equal(
+        result.data["quantile_P50"], charlie_predictions, check_names=False, check_exact=False
+    )
+    assert not result.data["quantile_P50"].equals(alpha_predictions)
+
+
+def test_fit_trains_on_data_val_when_provided() -> None:
+    """`fit()` should learn weights from held-out `data_val`, not in-sample `data`.
+
+    Regression test: `data_val` used to be accepted but never referenced in `fit()`'s
+    body, so the combiner always trained on in-sample training predictions — which are
+    systematically over-optimistic for boosted/tree forecasters and bias the combiner
+    towards whichever forecaster overfits training data hardest. Here, "Alpha" wins
+    every training row but "Bravo" wins every validation row; a combiner trained on
+    `data_val` should learn to weight "Bravo", not "Alpha".
+    """
+    train_index = pd.date_range("2023-01-01", periods=20, freq="15min")
+    val_index = pd.date_range("2023-01-02", periods=20, freq="15min")
+    train_dataset = _make_three_forecaster_dataset(["Alpha"] * 20, train_index)
+    val_dataset = _make_three_forecaster_dataset(["Bravo"] * 20, val_index)
+
+    combiner = WeightsCombiner(
+        hyperparams=LGBMCombinerHyperParams(n_leaves=5, n_estimators=10),
+        quantiles=[Q(0.5)],
+        horizons=[LeadTime(timedelta(days=1))],
+    )
+
+    # Act
+    combiner.fit(train_dataset, data_val=val_dataset)
+    result = combiner.predict(val_dataset)
+
+    # Assert — combiner should have learned "Bravo" wins, matching the validation labels
+    bravo_predictions = val_dataset.data["Bravo__quantile_P50"]
+    pd.testing.assert_series_equal(result.data["quantile_P50"], bravo_predictions, check_names=False, check_exact=False)


### PR DESCRIPTION
## What does this PR do?

Fixes three bugs in `WeightsCombiner` (learned-weights ensemble combiner) and one in
`StackingCombiner` that limit the ensemble machinery to small (2-model), always-trainable
ensembles, even though `EnsembleForecastingModel.forecasters` is already a generic
`dict[str, Forecaster]` intended to support any number of base forecasters:

1. **`WeightsCombiner.fit()` ignored `data_val`.** The method accepted a `data_val`
   parameter but never referenced it, so the per-quantile "who wins" classifier was always
   trained on in-sample training predictions. In-sample predictions from boosted/tree
   forecasters are systematically over-optimistic, biasing the combiner toward whichever
   forecaster overfits the training window hardest. `fit()` now trains on `data_val` when
   supplied, falling back to `data` otherwise.

2. **The degenerate-label guard didn't generalize past 2 forecasters.**
   `_validate_labels()` only fell back to a `DummyClassifier` when exactly one forecaster
   ever won (the only degenerate case possible with 2 base models). With 3+ forecasters
   it's common for a *subset* to never win, which crashed `predict_proba` with a
   `ValueError` (column count mismatch) instead of falling back gracefully. The guard now
   triggers whenever fewer forecasters win than are registered, so ensembles of arbitrary
   size no longer crash.

3. **The `DummyClassifier` fallback silently discarded its own answer.**
   `_predict_weights()` hardcoded weight 1.0 on `self._label_encoder.classes_[0]` — the
   alphabetically-*first* registered forecaster name — instead of asking the fitted
   `DummyClassifier(strategy="most_frequent")` which forecaster actually wins most often.
   This is easy to miss with 2 models (right about half the time by chance) but becomes a
   frequent, silent mis-attribution with 3+ models. The fallback now uses the recorded
   majority winner.

4. **`StackingCombiner.fit()` also discarded `data_val`.** It accepted `data_val` but
   always passed `data_val=None` to the underlying meta-forecaster's `fit()`. It now passes
   validation data through so meta-forecasters that support early stopping (e.g. LGBM,
   XGBoost) can use it.

Together these make the ensemble machinery robust for ensembles of arbitrary size (not
just the built-in 2-model `lgbm`/`gblinear` preset default) and make the learned-weights
combiner actually use held-out validation data as its name/docstring already implied.

No public API changes — all fixes are internal to `fit()`/`_validate_labels()`/
`_predict_weights()` behavior.

Closes #

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (see checklist below)
- [ ] Documentation
- [ ] Refactor / chore / CI

## Breaking changes checklist

N/A — internal fitting behavior only; no public API, config schema, or serialized object
changes.

## AI disclosure

- [ ] No AI assistance was used (beyond grammar/spelling)
- [x] AI assistance was used — tool(s): GitHub Copilot (Claude Sonnet 4.5)
  - [x] I have reviewed, understand, and can explain all AI-generated code in this PR
  - [x] This is disclosed in a commit message (`Assisted-by: GitHub Copilot (Claude Sonnet 4.5)`)

## Checklist

- [x] `poe all --check` passes locally
- [x] Tests added/updated for the change
- [ ] Documentation updated (docstrings, user guide, examples) if needed
- [x] Commits are signed off per our DCO (`git commit -s`)
- [x] PR title follows Conventional Commits
