### PR TITLE
chore: make outlier_strictness_n_std configurable

### DIFF
--- a/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
+++ b/packages/openstef-models/src/openstef_models/presets/forecasting_workflow.py
@@ -233,6 +233,14 @@ class ForecastingWorkflowConfig(BaseConfig):  # PredictionJob
         description="Feature selection for which features to replace out-of-range values with NaN. "
         "Defaults to no features (disabled).",
     )
+    outlier_strictness_n_std: float = Field(
+        default=2.0,
+        description=(
+            "Number of standard deviations for outlier detection (lower = stricter bounds). "
+            "Only used when nan_on_outlier_features is enabled."
+        ),
+        gt=0,
+    )
     max_day_lags: int = Field(
         default=14,
         description="Maximum number of days to look back for day-based lags. "
@@ -412,7 +420,14 @@ def create_forecasting_workflow(
     if config.model == "xgboost":
         nan_outlier_handlers = [
             *(
-                [OutlierHandler(mode="standard", selection=config.nan_on_outlier_features, outlier_action="nan")]
+                [
+                    OutlierHandler(
+                        mode="standard",
+                        selection=config.nan_on_outlier_features,
+                        outlier_action="nan",
+                        n_std=config.outlier_strictness_n_std,
+                    )
+                ]
                 if config.nan_on_outlier_features != FeatureSelection.NONE
                 else []
             ),


### PR DESCRIPTION
## What does this PR do?

Make `outlier_strictness_n_std` parameter in ForecastingWorkflowConfig to make it a configurable parameter for tuning outlier detection strictness.

## Type of change

- [x] Chore

## Breaking changes

- [x] No breaking changes

## AI disclosure

- [ ] No AI assistance was used (beyond grammar/spelling)
- [x] AI assistance was used — tool(s): GitHub Copilot (Claude Haiku 4.5)
  - [x] I have reviewed, understood, and can explain all AI-generated code in this PR
  - [x] This is disclosed in commit message (Assisted-by: GitHub Copilot)

## Checklist

- [x] Commits are signed off per DCO
- [x] PR title follows Conventional Commits
- [x] Documentation updated (docstrings)