### PR TITLE
docs: auto-update documentation for v4.3.0

### DIFF
--- a/docs/source/user_guide/concepts/beam.rst
+++ b/docs/source/user_guide/concepts/beam.rst
@@ -233,3 +233,4 @@ benchmarks (hundreds of targets, multiple models) remain tractable.
    - :ref:`concept_metalearning` for how BEAM results inform model selection decisions.
    - :doc:`/user_guide/guides/backtesting_tutorial` for a hands-on walkthrough of setting up and running a backtest.
    - :doc:`/api/beam` for the full openstef-beam API reference.
+```

--- a/docs/source/user_guide/guides/forecasting.rst
+++ b/docs/source/user_guide/guides/forecasting.rst
@@ -113,7 +113,7 @@ The ``fit()`` method returns a :class:`~openstef_models.models.forecasting_model
 
 1. **Preprocessing**: New data passes through the same preprocessing pipeline used during training, ensuring feature consistency.
 2. **Forecaster.predict()**: The model generates raw predictions.
-3. **Postprocessing**: A separate :class:`~openstef_core.mixins.transform.TransformPipeline` applies quantile sorting (via :class:`~openstef_models.transforms.postprocessing.quantile_sorter.QuantileSorter`) and confidence interval construction (via :class:`~openstef_models.transforms.postprocessing.confidence_interval_applicator.ConfidenceIntervalApplicator`).
+3. **Postprocessing**: A separate :class:`~openstef_core.mixins.transform.TransformPipeline` applies quantile sorting (via :class:`~openstef_models.transforms.postprocessing.quantile_sorter.QuantileSorter`) and confidence interval construction (via :class:`~openstef_models.transforms.postprocessing.confidence_interval_applicator.ConfidenceIntervalApplicator`). Optional calibration transforms such as :class:`~openstef_models.transforms.postprocessing.IsotonicQuantileCalibrator` or :class:`~openstef_models.transforms.postprocessing.ConformalizedQuantileCalibrator` can be appended to this pipeline for improved quantile reliability; see :doc:`/user_guide/guides/probabilistic_forecasting` for details.
 4. **Callbacks**: The final :class:`~openstef_core.datasets.validated_datasets.ForecastDataset` is passed to callbacks for logging or downstream delivery.
 
 Model Reuse
@@ -154,3 +154,4 @@ For a complete walkthrough with real data, see :doc:`/tutorials/forecasting_quic
    - :doc:`/user_guide/guides/probabilistic_forecasting` for quantile forecasts and calibration.
    - :doc:`/user_guide/guides/deployment` for integrating forecasting into production systems.
    - :doc:`/user_guide/guides/backtesting_tutorial` for a hands-on backtest walkthrough; see also :ref:`concept_beam` for the broader framework.
+```

--- a/docs/source/user_guide/guides/probabilistic_forecasting.rst
+++ b/docs/source/user_guide/guides/probabilistic_forecasting.rst
@@ -211,7 +211,7 @@ calibration before and after, including diagnostic plots, see
 :doc:`/tutorials/quantile_calibration`.
 
 Conformalized Quantile Calibration
-----------------------------------
+-----------------------------------
 
 OpenSTEF also provides a dependency-free
 :class:`~openstef_models.transforms.postprocessing.ConformalizedQuantileCalibrator`
@@ -264,3 +264,4 @@ See :doc:`/user_guide/guides/backtesting_tutorial` for how to evaluate forecast 
    - :doc:`/user_guide/concepts/models` for understanding how different model types compare.
    - :doc:`/user_guide/guides/backtesting_tutorial` for evaluating forecast performance systematically.
    - :doc:`/user_guide/guides/reliability_fallback` for operational concerns like fallback behavior when data is missing.
+```

--- a/docs/source/user_guide/guides/reliability_fallback.rst
+++ b/docs/source/user_guide/guides/reliability_fallback.rst
@@ -268,3 +268,4 @@ problems that need fixing at the source.
    - :doc:`/user_guide/guides/probabilistic_forecasting` for how quantile
      forecasts are structured in normal operation.
    - :doc:`/user_guide/logging` for monitoring fallback activations in production.
+```


### PR DESCRIPTION
## Automated documentation update for `v4.3.0`

This PR was opened automatically by the **openstef-doc-pipeline**.

| Field | Value |
|-------|-------|
| Release | [v4.3.0](https://github.com/OpenSTEF/openstef/releases/tag/v4.3.0) |
| Tag | `v4.3.0` |
| Branch | `docs/auto-update-v4.3.0` |
| Pages Generated | 4 |
| Changed Python Files | 7 |

### Generated artefacts

| File | Description |
|------|-------------|
| `docs/source/user_guide/concepts/beam.rst` | Auto-generated docs artefact |
| `docs/source/user_guide/guides/forecasting.rst` | Auto-generated docs artefact |
| `docs/source/user_guide/guides/probabilistic_forecasting.rst` | Auto-generated docs artefact |
| `docs/source/user_guide/guides/reliability_fallback.rst` | Auto-generated docs artefact |

### Diagrams

This PR includes **0 generated Mermaid diagram(s)** integrated into the documentation.

### Release notes

## What's Changed
* feat: add conformalized quantile calibration transform by @rikveenboer in https://github.com/OpenSTEF/openstef/pull/1060
* fix: import scikit-learn lazily in openstef-beam r2 metric by @Valyrian-Code in https://github.com/OpenSTEF/openstef/pull/981
* chore: make outlier_strictness_n_std configurable by @MvLieshout in https://github.com/OpenSTEF/openstef/pull/1065

## New Contributors
* @rikveenboer made their first contribution in https://github.com/OpenSTEF/openstef/pull/1060

**Full Changelog**: https://github.com/OpenSTEF/openstef/compare/v4.2.3...v4.3.0

---

> **Human review required.**
> Please review all generated files carefully before merging.
> The pipeline does **not** auto-merge this PR.
