### PR TITLE
docs: auto-update documentation for v4.3.1

### DIFF
--- a/docs/source/user_guide/concepts/models.rst
+++ b/docs/source/user_guide/concepts/models.rst
@@ -205,3 +205,4 @@ Most users start with Presets and only drop down to lower levels when they need
 custom behavior. The component boundaries are designed so you can replace one piece
 (e.g., swap a Forecaster or add a Transform) without rewriting the rest of the
 pipeline.
+```

--- a/docs/source/user_guide/guides/probabilistic_forecasting.rst
+++ b/docs/source/user_guide/guides/probabilistic_forecasting.rst
@@ -134,6 +134,8 @@ maintain consistency between levels.
      - ``reg:quantileerror`` objective
      - Fast iteration on linear-tractable problems, or as a robust baseline.
      - Uses XGBoost's built-in quantile regression for linear boosters.
+       Quantile levels are sorted internally before training, so input order
+       does not matter.
    * - **LightGBM**
      - ``MultiQuantileRegressor``
      - Large feature sets where LightGBM's training speed pays off.
@@ -264,3 +266,4 @@ See :doc:`/user_guide/guides/backtesting_tutorial` for how to evaluate forecast 
    - :doc:`/user_guide/concepts/models` for understanding how different model types compare.
    - :doc:`/user_guide/guides/backtesting_tutorial` for evaluating forecast performance systematically.
    - :doc:`/user_guide/guides/reliability_fallback` for operational concerns like fallback behavior when data is missing.
+```


### PR DESCRIPTION
## Automated documentation update for `v4.3.1`

This PR was opened automatically by the **openstef-doc-pipeline**.

| Field | Value |
|-------|-------|
| Release | [v4.3.1](https://github.com/OpenSTEF/openstef/releases/tag/v4.3.1) |
| Tag | `v4.3.1` |
| Branch | `docs/auto-update-v4.3.1` |
| Pages Generated | 2 |
| Changed Python Files | 5 |

### Generated artefacts

| File | Description |
|------|-------------|
| `docs/source/user_guide/concepts/models.rst` | Auto-generated docs artefact |
| `docs/source/user_guide/guides/probabilistic_forecasting.rst` | Auto-generated docs artefact |

### Diagrams

This PR includes **0 generated Mermaid diagram(s)** integrated into the documentation.

### Release notes

## What's Changed
* chore(deps)(deps): bump the python-versions group across 1 directory with 28 updates by @dependabot[bot] in https://github.com/OpenSTEF/openstef/pull/1057


**Full Changelog**: https://github.com/OpenSTEF/openstef/compare/v4.3.0...v4.3.1

---

> **Human review required.**
> Please review all generated files carefully before merging.
> The pipeline does **not** auto-merge this PR.
