### PR TITLE
security: Added a known vulnerability to test codeql.

### DIFF
--- a/packages/openstef-core/src/openstef_core/vulnerability_do_not_commit_to_main.py
+++ b/packages/openstef-core/src/openstef_core/vulnerability_do_not_commit_to_main.py
@@ -1,13 +1,19 @@
 """Temporary CodeQL integration probe. Do not merge."""
 
+from django.conf.urls import url
 from django.db import connection
 
 
-def find_user(request: object) -> object:
-    username = request.GET["username"]
+def show_user(request, username):
+    del request
 
     with connection.cursor() as cursor:
         cursor.execute(
             "SELECT * FROM users WHERE username = '%s'" % username
         )
         return cursor.fetchone()
+
+
+urlpatterns = [
+    url(r"^users/(?P<username>[^/]+)$", show_user),
+]

--- a/packages/openstef-core/src/openstef_core/vulnerability_do_not_commit_to_main.py
+++ b/packages/openstef-core/src/openstef_core/vulnerability_do_not_commit_to_main.py
@@ -1,0 +1,13 @@
+"""Temporary CodeQL integration probe. Do not merge."""
+
+from django.db import connection
+
+
+def find_user(request: object) -> object:
+    username = request.GET["username"]
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT * FROM users WHERE username = '%s'" % username
+        )
+        return cursor.fetchone()


### PR DESCRIPTION
Signed-off-by: Egor Dmitriev <egor.dmitriev@alliander.com>
Signed-off-by: Egor Dmitriev <egor.dmitriev@alliander.com>

<!--
Thanks for contributing to OpenSTEF! Please fill out this template to help us
review your PR efficiently. See the contributing guide for more details:
https://openstef.github.io/openstef/contribute/index.html
-->

## What does this PR do?

<!-- Describe the change and the motivation behind it. -->

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (see checklist below)
- [ ] Documentation
- [ ] Refactor / chore / CI

## Breaking changes checklist

<!-- Only relevant if you checked "Breaking change" above, or are unsure. -->

- [ ] Public API, config schema, or serialized/pickled objects changed in a way that affects existing users
- [ ] If yes: see the [breaking changes guide](https://openstef.github.io/openstef/contribute/development_workflow.html#breaking-changes) for the pickle/`_migrate_state` migration pattern

Migration path for existing users (e.g. "old pickled `XScaler` objects auto-migrate on load", "users must now pass `X` explicitly"):

<!-- describe here -->

## AI disclosure

<!--
See our AI-assisted contributions guidelines:
https://openstef.github.io/openstef/contribute/contributing_guide.html#ai-assisted-contributions
-->

- [ ] No AI assistance was used (beyond grammar/spelling)
- [ ] AI assistance was used — tool(s): <!-- e.g. GitHub Copilot, Claude, ChatGPT -->
  - [ ] I have reviewed, understand, and can explain all AI-generated code in this PR
  - [ ] This is disclosed in a commit message (e.g. `Assisted-by: <tool name>`)

## Checklist

- [ ] `poe all --check` passes locally
- [ ] Tests added/updated for the change
- [ ] Documentation updated (docstrings, user guide, examples) if needed
- [ ] Commits are signed off per our [DCO](https://openstef.github.io/openstef/contribute/contributing_guide.html#signing-the-developer-certificate-of-origin-dco) (`git commit -s`)
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `feat!: ...` for breaking changes)
